### PR TITLE
Use containerd/cio

### DIFF
--- a/pkg/server/container_execsync.go
+++ b/pkg/server/container_execsync.go
@@ -148,7 +148,7 @@ func (c *criContainerdService) execInContainer(ctx context.Context, id string, o
 		}
 	})
 
-	attachDone := execIO.Attach(cio.AttachOptions{
+	execIO.Attach(cio.AttachOptions{
 		Stdin:     opts.stdin,
 		Stdout:    opts.stdout,
 		Stderr:    opts.stderr,
@@ -177,7 +177,7 @@ func (c *criContainerdService) execInContainer(ctx context.Context, id string, o
 		exitRes := <-exitCh
 		logrus.Infof("Timeout received while waiting for exec process kill %q code %d and error %v",
 			execID, exitRes.ExitCode(), exitRes.Error())
-		<-attachDone
+		execIO.Wait()
 		logrus.Debugf("Stream pipe for exec process %q done", execID)
 		return nil, fmt.Errorf("timeout %v exceeded", opts.timeout)
 	case exitRes := <-exitCh:
@@ -186,7 +186,7 @@ func (c *criContainerdService) execInContainer(ctx context.Context, id string, o
 		if err != nil {
 			return nil, fmt.Errorf("failed while waiting for exec %q: %v", execID, err)
 		}
-		<-attachDone
+		execIO.Wait()
 		logrus.Debugf("Stream pipe for exec process %q done", execID)
 		return &code, nil
 	}

--- a/pkg/server/io/exec_io.go
+++ b/pkg/server/io/exec_io.go
@@ -55,7 +55,7 @@ func NewExecIO(id, root string, tty, stdin bool) (*ExecIO, error) {
 }
 
 // Attach attaches exec stdio. The logic is similar with container io attach.
-func (e *ExecIO) Attach(opts AttachOptions) <-chan struct{} {
+func (e *ExecIO) Attach(opts AttachOptions) {
 	var wg sync.WaitGroup
 	var stdinStreamRC io.ReadCloser
 	if e.Stdin != nil && opts.Stdin != nil {
@@ -110,13 +110,6 @@ func (e *ExecIO) Attach(opts AttachOptions) <-chan struct{} {
 		e.wg.Add(1)
 		go attachOutput(Stderr, opts.Stderr, e.Stderr)
 	}
-
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
-	return done
 }
 
 // Wait for IO streams to end

--- a/pkg/server/io/helpers.go
+++ b/pkg/server/io/helpers.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 package io
 
-
 import (
 	"io"
 	"path/filepath"

--- a/pkg/server/io/helpers.go
+++ b/pkg/server/io/helpers.go
@@ -16,16 +16,12 @@ limitations under the License.
 
 package io
 
+
 import (
 	"io"
-	"os"
 	"path/filepath"
-	"sync"
-	"syscall"
 
 	"github.com/containerd/containerd/cio"
-	"github.com/containerd/fifo"
-	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
 )
 
@@ -47,38 +43,14 @@ const (
 	// Stdin stream type.
 	Stdin StreamType = "stdin"
 	// Stdout stream type.
-	Stdout StreamType = StreamType(runtime.Stdout)
+	Stdout = StreamType(runtime.Stdout)
 	// Stderr stream type.
-	Stderr StreamType = StreamType(runtime.Stderr)
+	Stderr = StreamType(runtime.Stderr)
 )
-
-type wgCloser struct {
-	ctx    context.Context
-	wg     *sync.WaitGroup
-	set    []io.Closer
-	cancel context.CancelFunc
-}
-
-func (g *wgCloser) Wait() {
-	g.wg.Wait()
-}
-
-func (g *wgCloser) Close() {
-	for _, f := range g.set {
-		f.Close()
-	}
-}
-
-func (g *wgCloser) Cancel() {
-	g.cancel()
-}
 
 // newFifos creates fifos directory for a container.
 func newFifos(root, id string, tty, stdin bool) (*cio.FIFOSet, error) {
 	root = filepath.Join(root, "io")
-	if err := os.MkdirAll(root, 0700); err != nil {
-		return nil, err
-	}
 	fifos, err := cio.NewFIFOSetInDir(root, id, tty)
 	if err != nil {
 		return nil, err
@@ -87,55 +59,4 @@ func newFifos(root, id string, tty, stdin bool) (*cio.FIFOSet, error) {
 		fifos.Stdin = ""
 	}
 	return fifos, nil
-}
-
-type stdioPipes struct {
-	stdin  io.WriteCloser
-	stdout io.ReadCloser
-	stderr io.ReadCloser
-}
-
-// newStdioPipes creates actual fifos for stdio.
-func newStdioPipes(fifos *cio.FIFOSet) (_ *stdioPipes, _ *wgCloser, err error) {
-	var (
-		f           io.ReadWriteCloser
-		set         []io.Closer
-		ctx, cancel = context.WithCancel(context.Background())
-		p           = &stdioPipes{}
-	)
-	defer func() {
-		if err != nil {
-			for _, f := range set {
-				f.Close()
-			}
-			cancel()
-		}
-	}()
-
-	if fifos.Stdin != "" {
-		if f, err = fifo.OpenFifo(ctx, fifos.Stdin, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
-			return nil, nil, err
-		}
-		p.stdin = f
-		set = append(set, f)
-	}
-
-	if f, err = fifo.OpenFifo(ctx, fifos.Stdout, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
-		return nil, nil, err
-	}
-	p.stdout = f
-	set = append(set, f)
-
-	if f, err = fifo.OpenFifo(ctx, fifos.Stderr, syscall.O_RDONLY|syscall.O_CREAT|syscall.O_NONBLOCK, 0700); err != nil {
-		return nil, nil, err
-	}
-	p.stderr = f
-	set = append(set, f)
-
-	return p, &wgCloser{
-		wg:     &sync.WaitGroup{},
-		set:    set,
-		ctx:    ctx,
-		cancel: cancel,
-	}, nil
 }


### PR DESCRIPTION
Closes #483
Blocked on https://github.com/containerd/containerd/pull/1895

With the refactor of `cio.DirectIO` it can be used here.
I also updated vendor to match the changes made in containerd/containerd