### PR TITLE
Cleanup cri stats integration test

### DIFF
--- a/integration/container_update_resources_test.go
+++ b/integration/container_update_resources_test.go
@@ -37,14 +37,8 @@ func checkMemoryLimit(t *testing.T, spec *runtimespec.Spec, memLimit int64) {
 }
 
 func TestUpdateContainerResources(t *testing.T) {
-	t.Logf("Create a sandbox")
-	sbConfig := PodSandboxConfig("sandbox", "update-container-resources")
-	sb, err := runtimeService.RunPodSandbox(sbConfig)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
+	sbConfig, sb := runPod(t, "sandbox", "update-container-resources")
+	defer cleanPod(t, sb)
 
 	t.Logf("Create a container with memory limit")
 	cnConfig := ContainerConfig(

--- a/integration/duplicate_name_test.go
+++ b/integration/duplicate_name_test.go
@@ -19,22 +19,15 @@ package integration
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDuplicateName(t *testing.T) {
-	t.Logf("Create a sandbox")
-	sbConfig := PodSandboxConfig("sandbox", "duplicate-name")
-	sb, err := runtimeService.RunPodSandbox(sbConfig)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
+	sbConfig, sb := runPod(t, "sandbox", "duplicate-name")
+	defer cleanPod(t, sb)
 
 	t.Logf("Create the sandbox again should fail")
-	_, err = runtimeService.RunPodSandbox(sbConfig)
+	_, err := runtimeService.RunPodSandbox(sbConfig)
 	require.Error(t, err)
 
 	t.Logf("Create a container")

--- a/integration/image_load_test.go
+++ b/integration/image_load_test.go
@@ -68,14 +68,10 @@ func TestImageLoad(t *testing.T) {
 	require.NotNil(t, img)
 	require.Equal(t, []string{loadedImage}, img.RepoTags)
 
+	sbConfig, sb := runPod(t, "sandbox", "image-load")
+	defer cleanPod(t, sb)
+
 	t.Logf("create a container with the loaded image")
-	sbConfig := PodSandboxConfig("sandbox", Randomize("image-load"))
-	sb, err := runtimeService.RunPodSandbox(sbConfig)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
 	containerConfig := ContainerConfig(
 		"container",
 		testImage,

--- a/integration/imagefs_info_test.go
+++ b/integration/imagefs_info_test.go
@@ -36,14 +36,8 @@ func TestImageFSInfo(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 	t.Logf("Create a sandbox to make sure there is an active snapshot")
-	config := PodSandboxConfig("running-pod", "imagefs")
-	sb, err := runtimeService.RunPodSandbox(config)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
-
+	_, sb := runPod(t, "sandbox", "imagefs")
+	defer cleanPod(t, sb)
 	// It takes time to populate imagefs stats. Use eventually
 	// to check for a period of time.
 	t.Logf("Check imagefs info")

--- a/integration/sandbox_clean_remove_test.go
+++ b/integration/sandbox_clean_remove_test.go
@@ -28,10 +28,7 @@ import (
 
 func TestSandboxCleanRemove(t *testing.T) {
 	ctx := context.Background()
-	t.Logf("Create a sandbox")
-	sbConfig := PodSandboxConfig("sandbox", "clean-remove")
-	sb, err := runtimeService.RunPodSandbox(sbConfig)
-	require.NoError(t, err)
+	_, sb := runPod(t, "sandbox", "clean-remove")
 	defer func() {
 		// Make sure the sandbox is cleaned up in any case.
 		runtimeService.StopPodSandbox(sb)
@@ -58,6 +55,5 @@ func TestSandboxCleanRemove(t *testing.T) {
 	assert.Error(t, runtimeService.RemovePodSandbox(sb))
 
 	t.Logf("Should be able to remove the sandbox after properly stopped")
-	assert.NoError(t, runtimeService.StopPodSandbox(sb))
-	assert.NoError(t, runtimeService.RemovePodSandbox(sb))
+	cleanPod(t, sb)
 }


### PR DESCRIPTION
Fixes #400

- Clean duplicate codes in cri stats integration test
- Convert the filter tests into table driven tests

@kubernetes-incubator/reviewers-cri-containerd 

Signed-off-by: Yanqiang Miao miao.yanqiang@zte.com.cn
