### PR TITLE
[WIP]config: Allow to define trusted runtime

### DIFF
--- a/hack/test-utils.sh
+++ b/hack/test-utils.sh
@@ -18,6 +18,13 @@ source $(dirname "${BASH_SOURCE[0]}")/utils.sh
 
 # RESTART_WAIT_PERIOD is the period to wait before restarting containerd.
 RESTART_WAIT_PERIOD=${RESTART_WAIT_PERIOD:-10}
+CONTAINERD_CONFIG="--log-level=debug "
+
+# Use a configuration file for containerd.
+CONTAINERD_CONFIG_FILE=${CONTAINERD_CONFIG_FILE:-""}
+if [ -f "${CONTAINERD_CONFIG_FILE}" ]; then
+	CONTAINERD_CONFIG+="--config $CONTAINERD_CONFIG_FILE"
+fi
 
 CONTAINERD_SOCK=/run/containerd/containerd.sock
 
@@ -32,7 +39,7 @@ test_setup() {
     exit 1
   fi
   sudo pkill -x containerd
-  keepalive "sudo ${ROOT}/_output/containerd --log-level=debug" \
+  keepalive "sudo ${ROOT}/_output/containerd ${CONTAINERD_CONFIG}" \
     ${RESTART_WAIT_PERIOD} &> ${report_dir}/containerd.log &
   containerd_pid=$!
   # Wait for containerd to be running by using the containerd client ctr to check the version

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -31,4 +31,7 @@ const (
 
 	// SandboxID is the sandbox ID annotation
 	SandboxID = "io.kubernetes.cri.sandbox-id"
+
+	// PrivilegedSandbox is the privileged annotation
+	PrivilegedSandbox = "io.kubernetes.cri.privileged-sandbox"
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,20 +18,24 @@ package config
 
 import "github.com/containerd/containerd"
 
+// Runtime  struct to contain the type(ID), engine, and root variables for a default and a privileged runtime
+type Runtime struct {
+	//Type is the runtime type to use in containerd e.g. io.containerd.runtime.v1.linux
+	Type string `toml:"runtime_type" json:"runtimeType,omitempty"`
+	// Engine is the name of the runtime engine used by containerd.
+	Engine string `toml:"runtime_engine" json:"runtimeEngine,omitempty"`
+	// Root is the directory used by containerd for runtime state.
+	Root string `toml:"runtime_root" json:"runtimeRoot,omitempty"`
+}
+
 // ContainerdConfig contains toml config related to containerd
 type ContainerdConfig struct {
 	// Snapshotter is the snapshotter used by containerd.
 	Snapshotter string `toml:"snapshotter" json:"snapshotter,omitempty"`
-	// Runtime is the runtime to use in containerd. We may support
-	// other runtimes in the future.
-	Runtime string `toml:"runtime" json:"runtime,omitempty"`
-	// RuntimeEngine is the name of the runtime engine used by containerd.
-	// Containerd default should be "runc"
-	// We may support other runtime engines in the future.
-	RuntimeEngine string `toml:"runtime_engine" json:"runtimeEngine,omitempty"`
-	// RuntimeRoot is the directory used by containerd for runtime state.
-	// Containerd default should be "/run/containerd/runc"
-	RuntimeRoot string `toml:"runtime_root" json:"runtimeRoot,omitempty"`
+	// DefaultRuntime is the runtime to use in containerd.
+	DefaultRuntime Runtime `toml:"default_runtime" json:"defaultRuntime,omitempty"`
+	// PrivilegedRuntime is a non-secure runtime used only to run trusted workloads on it
+	PrivilegedRuntime Runtime `toml:"privileged_runtime" json:"privilegedRuntime,omitempty"`
 }
 
 // CniConfig contains toml config related to cni
@@ -101,10 +105,17 @@ func DefaultConfig() PluginConfig {
 			NetworkPluginConfDir: "/etc/cni/net.d",
 		},
 		ContainerdConfig: ContainerdConfig{
-			Snapshotter:   containerd.DefaultSnapshotter,
-			Runtime:       "io.containerd.runtime.v1.linux",
-			RuntimeEngine: "",
-			RuntimeRoot:   "",
+			Snapshotter: containerd.DefaultSnapshotter,
+			DefaultRuntime: Runtime{
+				Type:   "io.containerd.runtime.v1.linux",
+				Engine: "",
+				Root:   "",
+			},
+			PrivilegedRuntime: Runtime{
+				Type:   "io.containerd.runtime.v1.linux",
+				Engine: "",
+				Root:   "",
+			},
 		},
 		StreamServerAddress: "",
 		StreamServerPort:    "10010",

--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -87,6 +87,9 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	}
 	sandboxPid := s.Pid()
 
+	trusted := sandbox.Config.Annotations[annotations.PrivilegedSandbox] == "true"
+	containerRuntime := c.getRuntime(trusted)
+
 	// Generate unique id and name for the container and reserve the name.
 	// Reserve the container name to avoid concurrent `CreateContainer` request creating
 	// the same container.
@@ -227,10 +230,10 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	opts = append(opts,
 		containerd.WithSpec(spec, specOpts...),
 		containerd.WithRuntime(
-			c.config.ContainerdConfig.Runtime,
+			containerRuntime.Type,
 			&runctypes.RuncOptions{
-				Runtime:       c.config.ContainerdConfig.RuntimeEngine,
-				RuntimeRoot:   c.config.ContainerdConfig.RuntimeRoot,
+				Runtime:       containerRuntime.Engine,
+				RuntimeRoot:   containerRuntime.Root,
 				SystemdCgroup: c.config.SystemdCgroup}), // TODO (mikebrow): add CriuPath when we add support for pause
 		containerd.WithContainerLabels(containerLabels),
 		containerd.WithContainerExtension(containerMetadataExtension, &meta))


### PR DESCRIPTION
This PR adds:
- Trusted runtime configuration option.
- Allow to change contaienrd configuration for testing.

Some CRI compatible runtimes may not support privileged operations.
Specifically hypervisor based runtimes (like kata-containers, cc-runtime
and runv) do not support privileged operations like:

- Provide access to the host namespaces
- Create fully privileged containers with access to host devices

Hypervisor based runtimes create container workloads within virtual machines.
When a running host privileged containers using them,
they wont provide support to requested the privileged opertations.

This commits add the new options to define two runtimes:

Trusted runtime : Used when a privileged container is requested.
Default runtime : for non-privileged workloads.

A container that belongs to a privileged pod will inherent this property
an will be created with the trusted runtime.

- Add options to define trusted runtime
- Add logic to decide if a sanbox is trusted
- Export annotation containers below to a trusted sandbox

## Note 
This feature is implemented solution to address gaps described in #574. For long term solution will be defined as part of CRI API for `secure containers `



Fixes: #574 

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>