### PR TITLE
renames cri-containerd to cri

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,12 @@ GO := go
 GOOS := $(shell $(GO) env GOOS)
 GOARCH := $(shell $(GO) env GOARCH)
 EPOCH_TEST_COMMIT := f9e02affccd51702191e5312665a16045ffef8ab
-PROJECT := github.com/containerd/cri-containerd
+PROJECT := github.com/containerd/cri
 BINDIR := ${DESTDIR}/usr/local/bin
 BUILD_DIR := _output
 # VERSION is derived from the current tag for HEAD plus amends. Version is used
 # to set/overide the CRIContainerdVersion variable in the verison package for
-# cri-containerd.
+# cri plugin.
 VERSION := $(shell git describe --tags --dirty --always)
 # strip the first char of the tag if it's a `v`
 VERSION := $(VERSION:v%=%)
@@ -50,17 +50,17 @@ help:
 	@echo " * 'install-containerd'	- Install customized containerd to system location"
 	@echo " * 'release'          	- Build release tarball"
 	@echo " * 'push'             	- Push release tarball to GCS"
-	@echo " * 'test'             	- Test cri-containerd with unit test"
-	@echo " * 'test-integration' 	- Test cri-containerd with integration test"
-	@echo " * 'test-cri'         	- Test cri-containerd with cri validation test"
-	@echo " * 'test-e2e-node'    	- Test cri-containerd with Kubernetes node e2e test"
+	@echo " * 'test'             	- Test cri with unit test"
+	@echo " * 'test-integration' 	- Test cri with integration test"
+	@echo " * 'test-cri'         	- Test cri with cri validation test"
+	@echo " * 'test-e2e-node'    	- Test cri with Kubernetes node e2e test"
 	@echo " * 'clean'            	- Clean artifacts"
 	@echo " * 'verify'           	- Execute the source code verification tools"
-	@echo " * 'proto'            	- Update protobuf of cri-containerd api"
+	@echo " * 'proto'            	- Update protobuf of the cri plugin api"
 	@echo " * 'install.tools'    	- Install tools used by verify"
-	@echo " * 'install.deps'     	- Install dependencies of cri-containerd (containerd, runc, cni) Note: BUILDTAGS defaults to 'seccomp apparmor' for runc build"
+	@echo " * 'install.deps'     	- Install dependencies of cri (Note: BUILDTAGS defaults to 'seccomp apparmor' for runc build")
 	@echo " * 'uninstall'        	- Remove installed binaries from system locations"
-	@echo " * 'version'          	- Print current cri-containerd release version"
+	@echo " * 'version'          	- Print current cri plugin release version"
 	@echo " * 'update-vendor'    	- Syncs containerd/vendor.conf -> vendor.conf and sorts vendor.conf"
 
 verify: lint gofmt boiler

--- a/cmd/containerd/containerd.go
+++ b/cmd/containerd/containerd.go
@@ -37,7 +37,7 @@ import (
 	_ "github.com/containerd/containerd/services/tasks"
 	_ "github.com/containerd/containerd/services/version"
 	_ "github.com/containerd/containerd/snapshots/overlay"
-	_ "github.com/containerd/cri-containerd"
+	_ "github.com/containerd/cri"
 
 	"github.com/containerd/containerd/cmd/containerd/command"
 	"github.com/sirupsen/logrus"

--- a/cmd/ctrcri/ctrcri.go
+++ b/cmd/ctrcri/ctrcri.go
@@ -24,16 +24,16 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"github.com/containerd/cri-containerd/pkg/version"
+	"github.com/containerd/cri/pkg/version"
 )
 
 const (
 	// Add \u200B to avoid the space trimming.
-	desc = "\u200B" + `        __                 _ 
+	desc = "\u200B" + `        __                 _
   _____/ /________________(_)
- / ___/ __/ ___/ ___/ ___/ / 
-/ /__/ /_/ /  / /__/ /  / /  
-\___/\__/_/   \___/_/  /_/   
+ / ___/ __/ ___/ ___/ ___/ /
+/ /__/ /_/ /  / /__/ /  / /
+\___/\__/_/   \___/_/  /_/
 
 containerd CRI plugin CLI
 `

--- a/cmd/ctrcri/load.go
+++ b/cmd/ctrcri/load.go
@@ -25,8 +25,8 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
 
-	api "github.com/containerd/cri-containerd/pkg/api/v1"
-	"github.com/containerd/cri-containerd/pkg/client"
+	api "github.com/containerd/cri/pkg/api/v1"
+	"github.com/containerd/cri/pkg/client"
 )
 
 func dedent(s string) string {

--- a/cri.go
+++ b/cri.go
@@ -37,9 +37,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	criconfig "github.com/containerd/cri-containerd/pkg/config"
-	"github.com/containerd/cri-containerd/pkg/constants"
-	"github.com/containerd/cri-containerd/pkg/server"
+	criconfig "github.com/containerd/cri/pkg/config"
+	"github.com/containerd/cri/pkg/constants"
+	"github.com/containerd/cri/pkg/server"
 )
 
 // TODO(random-liu): Use github.com/pkg/errors for our errors.

--- a/hack/install-deps.sh
+++ b/hack/install-deps.sh
@@ -62,7 +62,7 @@ RUNC_PKG=github.com/opencontainers/runc
 CNI_PKG=github.com/containernetworking/plugins
 CONTAINERD_PKG=github.com/containerd/containerd
 CRITOOL_PKG=github.com/kubernetes-incubator/cri-tools
-CRI_CONTAINERD_PKG=github.com/containerd/cri-containerd
+CRI_CONTAINERD_PKG=github.com/containerd/cri
 
 # Create a temporary GOPATH for make install.deps.
 TMPGOPATH=$(mktemp -d /tmp/cri-containerd-install-deps.XXXX)

--- a/integration/image_load_test.go
+++ b/integration/image_load_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	api "github.com/containerd/cri-containerd/pkg/api/v1"
+	api "github.com/containerd/cri/pkg/api/v1"
 )
 
 // Test to load an image from tarball.
@@ -50,14 +50,14 @@ func TestImageLoad(t *testing.T) {
 	output, err = exec.Command("docker", "save", testImage, "-o", tar).CombinedOutput()
 	require.NoError(t, err, "output: %q", output)
 
-	t.Logf("make sure no such image in cri-containerd")
+	t.Logf("make sure no such image in cri")
 	img, err := imageService.ImageStatus(&runtime.ImageSpec{Image: testImage})
 	require.NoError(t, err)
 	if img != nil {
 		require.NoError(t, imageService.RemoveImage(&runtime.ImageSpec{Image: testImage}))
 	}
 
-	t.Logf("load image in cri-containerd")
+	t.Logf("load image in cri")
 	res, err := criContainerdClient.LoadImage(context.Background(), &api.LoadImageRequest{FilePath: tar})
 	require.NoError(t, err)
 	require.Equal(t, []string{loadedImage}, res.GetImages())

--- a/integration/test_utils.go
+++ b/integration/test_utils.go
@@ -31,10 +31,10 @@ import (
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/kubelet/remote"
 
-	api "github.com/containerd/cri-containerd/pkg/api/v1"
-	"github.com/containerd/cri-containerd/pkg/client"
-	"github.com/containerd/cri-containerd/pkg/constants"
-	"github.com/containerd/cri-containerd/pkg/util"
+	api "github.com/containerd/cri/pkg/api/v1"
+	"github.com/containerd/cri/pkg/client"
+	"github.com/containerd/cri/pkg/constants"
+	"github.com/containerd/cri/pkg/util"
 )
 
 const (

--- a/integration/truncindex_test.go
+++ b/integration/truncindex_test.go
@@ -48,7 +48,7 @@ func TestTruncIndex(t *testing.T) {
 	// if you add n images at least two will share the same leading digit.
 	// "sha256:n" where n is the a number from 0-9 where two images have the same trunc,
 	// for example sha256:9
-	// https://github.com/containerd/cri-containerd/pull/352
+	// https://github.com/containerd/cri/pull/352
 	// I am thinking how I get the two image which have same trunc.
 
 	// TODO(yanxuean): add test case for ListImages

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -23,7 +23,7 @@ import (
 	"google.golang.org/grpc"
 	"k8s.io/kubernetes/pkg/kubelet/util"
 
-	api "github.com/containerd/cri-containerd/pkg/api/v1"
+	api "github.com/containerd/cri/pkg/api/v1"
 )
 
 // NewCRIContainerdClient creates grpc client of cri-containerd

--- a/pkg/containerd/importer/importer.go
+++ b/pkg/containerd/importer/importer.go
@@ -36,8 +36,8 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 
-	ctrdutil "github.com/containerd/cri-containerd/pkg/containerd/util"
-	"github.com/containerd/cri-containerd/pkg/util"
+	ctrdutil "github.com/containerd/cri/pkg/containerd/util"
+	"github.com/containerd/cri/pkg/util"
 )
 
 // This code reuses the docker import code from containerd/containerd#1602.

--- a/pkg/containerd/util/util.go
+++ b/pkg/containerd/util/util.go
@@ -22,7 +22,7 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	"golang.org/x/net/context"
 
-	"github.com/containerd/cri-containerd/pkg/constants"
+	"github.com/containerd/cri/pkg/constants"
 )
 
 // deferCleanupTimeout is the default timeout for containerd cleanup operations

--- a/pkg/os/testing/fake_os.go
+++ b/pkg/os/testing/fake_os.go
@@ -24,7 +24,7 @@ import (
 	containerdmount "github.com/containerd/containerd/mount"
 	"golang.org/x/net/context"
 
-	osInterface "github.com/containerd/cri-containerd/pkg/os"
+	osInterface "github.com/containerd/cri/pkg/os"
 )
 
 // CalledDetail is the struct contains called function name and arguments.

--- a/pkg/server/container_attach.go
+++ b/pkg/server/container_attach.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	cio "github.com/containerd/cri-containerd/pkg/server/io"
+	cio "github.com/containerd/cri/pkg/server/io"
 )
 
 // Attach prepares a streaming endpoint to attach to a running container, and returns the address.

--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -44,12 +44,12 @@ import (
 	"golang.org/x/sys/unix"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	"github.com/containerd/cri-containerd/pkg/annotations"
-	customopts "github.com/containerd/cri-containerd/pkg/containerd/opts"
-	ctrdutil "github.com/containerd/cri-containerd/pkg/containerd/util"
-	cio "github.com/containerd/cri-containerd/pkg/server/io"
-	containerstore "github.com/containerd/cri-containerd/pkg/store/container"
-	"github.com/containerd/cri-containerd/pkg/util"
+	"github.com/containerd/cri/pkg/annotations"
+	customopts "github.com/containerd/cri/pkg/containerd/opts"
+	ctrdutil "github.com/containerd/cri/pkg/containerd/util"
+	cio "github.com/containerd/cri/pkg/server/io"
+	containerstore "github.com/containerd/cri/pkg/store/container"
+	"github.com/containerd/cri/pkg/util"
 )
 
 const (
@@ -69,7 +69,7 @@ const (
 
 func init() {
 	typeurl.Register(&containerstore.Metadata{},
-		"github.com/containerd/cri-containerd/pkg/store/container", "Metadata")
+		"github.com/containerd/cri/pkg/store/container", "Metadata")
 }
 
 // CreateContainer creates a new container in the given PodSandbox.

--- a/pkg/server/container_create_test.go
+++ b/pkg/server/container_create_test.go
@@ -32,9 +32,9 @@ import (
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	"github.com/containerd/cri-containerd/pkg/annotations"
-	ostesting "github.com/containerd/cri-containerd/pkg/os/testing"
-	"github.com/containerd/cri-containerd/pkg/util"
+	"github.com/containerd/cri/pkg/annotations"
+	ostesting "github.com/containerd/cri/pkg/os/testing"
+	"github.com/containerd/cri/pkg/util"
 )
 
 func checkMount(t *testing.T, mounts []runtimespec.Mount, src, dest, typ string,

--- a/pkg/server/container_execsync.go
+++ b/pkg/server/container_execsync.go
@@ -31,10 +31,10 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	ctrdutil "github.com/containerd/cri-containerd/pkg/containerd/util"
-	cioutil "github.com/containerd/cri-containerd/pkg/ioutil"
-	cio "github.com/containerd/cri-containerd/pkg/server/io"
-	"github.com/containerd/cri-containerd/pkg/util"
+	ctrdutil "github.com/containerd/cri/pkg/containerd/util"
+	cioutil "github.com/containerd/cri/pkg/ioutil"
+	cio "github.com/containerd/cri/pkg/server/io"
+	"github.com/containerd/cri/pkg/util"
 )
 
 // ExecSync executes a command in the container, and returns the stdout output.

--- a/pkg/server/container_list.go
+++ b/pkg/server/container_list.go
@@ -21,7 +21,7 @@ import (
 
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	containerstore "github.com/containerd/cri-containerd/pkg/store/container"
+	containerstore "github.com/containerd/cri/pkg/store/container"
 )
 
 // ListContainers lists all containers matching the filter.

--- a/pkg/server/container_list_test.go
+++ b/pkg/server/container_list_test.go
@@ -25,8 +25,8 @@ import (
 	"golang.org/x/net/context"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	containerstore "github.com/containerd/cri-containerd/pkg/store/container"
-	sandboxstore "github.com/containerd/cri-containerd/pkg/store/sandbox"
+	containerstore "github.com/containerd/cri/pkg/store/container"
+	sandboxstore "github.com/containerd/cri/pkg/store/sandbox"
 )
 
 func TestToCRIContainer(t *testing.T) {

--- a/pkg/server/container_log_reopen.go
+++ b/pkg/server/container_log_reopen.go
@@ -23,7 +23,7 @@ import (
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 )
 
-// ReopenContainerLog asks cri-containerd to reopen the stdout/stderr log file for the container.
+// ReopenContainerLog asks the cri plugin to reopen the stdout/stderr log file for the container.
 // This is often called after the log file has been rotated.
 func (c *criContainerdService) ReopenContainerLog(ctx context.Context, r *runtime.ReopenContainerLogRequest) (*runtime.ReopenContainerLogResponse, error) {
 	container, err := c.containerStore.Get(r.GetContainerId())

--- a/pkg/server/container_remove.go
+++ b/pkg/server/container_remove.go
@@ -26,9 +26,9 @@ import (
 	"golang.org/x/net/context"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	"github.com/containerd/cri-containerd/pkg/log"
-	"github.com/containerd/cri-containerd/pkg/store"
-	containerstore "github.com/containerd/cri-containerd/pkg/store/container"
+	"github.com/containerd/cri/pkg/log"
+	"github.com/containerd/cri/pkg/store"
+	containerstore "github.com/containerd/cri/pkg/store/container"
 )
 
 // RemoveContainer removes the container.

--- a/pkg/server/container_remove_test.go
+++ b/pkg/server/container_remove_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	containerstore "github.com/containerd/cri-containerd/pkg/store/container"
+	containerstore "github.com/containerd/cri/pkg/store/container"
 )
 
 // TestSetContainerRemoving tests setContainerRemoving sets removing

--- a/pkg/server/container_start.go
+++ b/pkg/server/container_start.go
@@ -28,10 +28,10 @@ import (
 	"golang.org/x/net/context"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	ctrdutil "github.com/containerd/cri-containerd/pkg/containerd/util"
-	cio "github.com/containerd/cri-containerd/pkg/server/io"
-	containerstore "github.com/containerd/cri-containerd/pkg/store/container"
-	sandboxstore "github.com/containerd/cri-containerd/pkg/store/sandbox"
+	ctrdutil "github.com/containerd/cri/pkg/containerd/util"
+	cio "github.com/containerd/cri/pkg/server/io"
+	containerstore "github.com/containerd/cri/pkg/store/container"
+	sandboxstore "github.com/containerd/cri/pkg/store/sandbox"
 )
 
 // StartContainer starts the container.

--- a/pkg/server/container_stats_list.go
+++ b/pkg/server/container_stats_list.go
@@ -26,7 +26,7 @@ import (
 	"golang.org/x/net/context"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	containerstore "github.com/containerd/cri-containerd/pkg/store/container"
+	containerstore "github.com/containerd/cri/pkg/store/container"
 )
 
 // ListContainerStats returns stats of all running containers.

--- a/pkg/server/container_status.go
+++ b/pkg/server/container_status.go
@@ -25,7 +25,7 @@ import (
 	"golang.org/x/net/context"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	containerstore "github.com/containerd/cri-containerd/pkg/store/container"
+	containerstore "github.com/containerd/cri/pkg/store/container"
 )
 
 // ContainerStatus inspects the container and returns the status.

--- a/pkg/server/container_status_test.go
+++ b/pkg/server/container_status_test.go
@@ -24,8 +24,8 @@ import (
 	"golang.org/x/net/context"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	containerstore "github.com/containerd/cri-containerd/pkg/store/container"
-	imagestore "github.com/containerd/cri-containerd/pkg/store/image"
+	containerstore "github.com/containerd/cri/pkg/store/container"
+	imagestore "github.com/containerd/cri/pkg/store/image"
 )
 
 func getContainerStatusTestData() (*containerstore.Metadata, *containerstore.Status,

--- a/pkg/server/container_stop.go
+++ b/pkg/server/container_stop.go
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/sys/unix"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	containerstore "github.com/containerd/cri-containerd/pkg/store/container"
+	containerstore "github.com/containerd/cri/pkg/store/container"
 )
 
 // killContainerTimeout is the timeout that we wait for the container to

--- a/pkg/server/container_stop_test.go
+++ b/pkg/server/container_stop_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 
-	containerstore "github.com/containerd/cri-containerd/pkg/store/container"
+	containerstore "github.com/containerd/cri/pkg/store/container"
 )
 
 func TestWaitContainerStop(t *testing.T) {

--- a/pkg/server/container_update_resources.go
+++ b/pkg/server/container_update_resources.go
@@ -29,9 +29,9 @@ import (
 	"golang.org/x/net/context"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	ctrdutil "github.com/containerd/cri-containerd/pkg/containerd/util"
-	containerstore "github.com/containerd/cri-containerd/pkg/store/container"
-	"github.com/containerd/cri-containerd/pkg/util"
+	ctrdutil "github.com/containerd/cri/pkg/containerd/util"
+	containerstore "github.com/containerd/cri/pkg/store/container"
+	"github.com/containerd/cri/pkg/util"
 )
 
 // UpdateContainerResources updates ContainerConfig of the container.

--- a/pkg/server/events.go
+++ b/pkg/server/events.go
@@ -27,10 +27,10 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 
-	ctrdutil "github.com/containerd/cri-containerd/pkg/containerd/util"
-	"github.com/containerd/cri-containerd/pkg/store"
-	containerstore "github.com/containerd/cri-containerd/pkg/store/container"
-	sandboxstore "github.com/containerd/cri-containerd/pkg/store/sandbox"
+	ctrdutil "github.com/containerd/cri/pkg/containerd/util"
+	"github.com/containerd/cri/pkg/store"
+	containerstore "github.com/containerd/cri/pkg/store/container"
+	sandboxstore "github.com/containerd/cri/pkg/store/sandbox"
 )
 
 // eventMonitor monitors containerd event and updates internal state correspondingly.

--- a/pkg/server/helpers.go
+++ b/pkg/server/helpers.go
@@ -39,9 +39,9 @@ import (
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/util/sysctl"
 
-	"github.com/containerd/cri-containerd/pkg/store"
-	imagestore "github.com/containerd/cri-containerd/pkg/store/image"
-	"github.com/containerd/cri-containerd/pkg/util"
+	"github.com/containerd/cri/pkg/store"
+	imagestore "github.com/containerd/cri/pkg/store/image"
+	"github.com/containerd/cri/pkg/util"
 )
 
 const (

--- a/pkg/server/helpers_test.go
+++ b/pkg/server/helpers_test.go
@@ -22,7 +22,7 @@ import (
 	imagedigest "github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/containerd/cri-containerd/pkg/util"
+	"github.com/containerd/cri/pkg/util"
 )
 
 // TestGetUserFromImage tests the logic of getting image uid or user name of image user.

--- a/pkg/server/image_list.go
+++ b/pkg/server/image_list.go
@@ -20,7 +20,7 @@ import (
 	"golang.org/x/net/context"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	imagestore "github.com/containerd/cri-containerd/pkg/store/image"
+	imagestore "github.com/containerd/cri/pkg/store/image"
 )
 
 // ListImages lists existing images.

--- a/pkg/server/image_list_test.go
+++ b/pkg/server/image_list_test.go
@@ -25,7 +25,7 @@ import (
 	"golang.org/x/net/context"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	imagestore "github.com/containerd/cri-containerd/pkg/store/image"
+	imagestore "github.com/containerd/cri/pkg/store/image"
 )
 
 func TestListImages(t *testing.T) {

--- a/pkg/server/image_load.go
+++ b/pkg/server/image_load.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	api "github.com/containerd/cri-containerd/pkg/api/v1"
-	"github.com/containerd/cri-containerd/pkg/containerd/importer"
-	imagestore "github.com/containerd/cri-containerd/pkg/store/image"
+	api "github.com/containerd/cri/pkg/api/v1"
+	"github.com/containerd/cri/pkg/containerd/importer"
+	imagestore "github.com/containerd/cri/pkg/store/image"
 )
 
 // LoadImage loads a image into containerd.

--- a/pkg/server/image_pull.go
+++ b/pkg/server/image_pull.go
@@ -30,9 +30,9 @@ import (
 	"golang.org/x/net/context"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	containerdresolver "github.com/containerd/cri-containerd/pkg/containerd/resolver"
-	imagestore "github.com/containerd/cri-containerd/pkg/store/image"
-	"github.com/containerd/cri-containerd/pkg/util"
+	containerdresolver "github.com/containerd/cri/pkg/containerd/resolver"
+	imagestore "github.com/containerd/cri/pkg/store/image"
+	"github.com/containerd/cri/pkg/util"
 )
 
 // For image management:
@@ -66,9 +66,9 @@ import (
 // an error occurrs during the pulling, should we remove the entry from metadata
 // store? Or should we leave it there until next startup (resource leakage)?
 //
-// 3) CRI-containerd only exposes "READY" (successfully pulled and unpacked) images
+// 3) The cri plugin only exposes "READY" (successfully pulled and unpacked) images
 // to the user, which are maintained in the in-memory metadata index. However, it's
-// still possible that someone else removes the content or snapshot by-pass cri-containerd,
+// still possible that someone else removes the content or snapshot by-pass the cri plugin,
 // how do we detect that and update the in-memory metadata correspondingly? Always
 // check whether corresponding snapshot is ready when reporting image status?
 //

--- a/pkg/server/image_remove.go
+++ b/pkg/server/image_remove.go
@@ -56,7 +56,7 @@ func (c *criContainerdService) RemoveImage(ctx context.Context, r *runtime.Remov
 			// We can only get image id by reading Config from content.
 			// If the config is missing, we will fail to get image id,
 			// So we won't be able to remove the image forever,
-			// and cri-containerd always report the image is ok.
+			// and the cri plugin always reports the image is ok.
 			// But we also don't check it by manifest,
 			// It's possible that two manifest digests have the same image ID in theory.
 			// In theory it's possible that an image is compressed with different algorithms,

--- a/pkg/server/image_status.go
+++ b/pkg/server/image_status.go
@@ -24,7 +24,7 @@ import (
 	"golang.org/x/net/context"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	imagestore "github.com/containerd/cri-containerd/pkg/store/image"
+	imagestore "github.com/containerd/cri/pkg/store/image"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 

--- a/pkg/server/image_status_test.go
+++ b/pkg/server/image_status_test.go
@@ -25,7 +25,7 @@ import (
 	"golang.org/x/net/context"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	imagestore "github.com/containerd/cri-containerd/pkg/store/image"
+	imagestore "github.com/containerd/cri/pkg/store/image"
 )
 
 func TestImageStatus(t *testing.T) {

--- a/pkg/server/imagefs_info_test.go
+++ b/pkg/server/imagefs_info_test.go
@@ -25,7 +25,7 @@ import (
 	"golang.org/x/net/context"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	snapshotstore "github.com/containerd/cri-containerd/pkg/store/snapshot"
+	snapshotstore "github.com/containerd/cri/pkg/store/snapshot"
 )
 
 func TestImageFsInfo(t *testing.T) {

--- a/pkg/server/instrumented_service.go
+++ b/pkg/server/instrumented_service.go
@@ -23,9 +23,9 @@ import (
 	"golang.org/x/net/context"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	api "github.com/containerd/cri-containerd/pkg/api/v1"
-	ctrdutil "github.com/containerd/cri-containerd/pkg/containerd/util"
-	"github.com/containerd/cri-containerd/pkg/log"
+	api "github.com/containerd/cri/pkg/api/v1"
+	ctrdutil "github.com/containerd/cri/pkg/containerd/util"
+	"github.com/containerd/cri/pkg/log"
 )
 
 // instrumentedService wraps service with containerd namespace and logs.

--- a/pkg/server/io/container_io.go
+++ b/pkg/server/io/container_io.go
@@ -25,8 +25,8 @@ import (
 	"github.com/containerd/containerd/cio"
 	"github.com/sirupsen/logrus"
 
-	cioutil "github.com/containerd/cri-containerd/pkg/ioutil"
-	"github.com/containerd/cri-containerd/pkg/util"
+	cioutil "github.com/containerd/cri/pkg/ioutil"
+	"github.com/containerd/cri/pkg/util"
 )
 
 // streamKey generates a key for the stream.

--- a/pkg/server/io/exec_io.go
+++ b/pkg/server/io/exec_io.go
@@ -23,7 +23,7 @@ import (
 	"github.com/containerd/containerd/cio"
 	"github.com/sirupsen/logrus"
 
-	cioutil "github.com/containerd/cri-containerd/pkg/ioutil"
+	cioutil "github.com/containerd/cri/pkg/ioutil"
 )
 
 // ExecIO holds the exec io.

--- a/pkg/server/io/logger.go
+++ b/pkg/server/io/logger.go
@@ -28,7 +28,7 @@ import (
 	"github.com/sirupsen/logrus"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	cioutil "github.com/containerd/cri-containerd/pkg/ioutil"
+	cioutil "github.com/containerd/cri/pkg/ioutil"
 )
 
 const (

--- a/pkg/server/io/logger_test.go
+++ b/pkg/server/io/logger_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	cioutil "github.com/containerd/cri-containerd/pkg/ioutil"
+	cioutil "github.com/containerd/cri/pkg/ioutil"
 )
 
 func TestRedirectLogs(t *testing.T) {

--- a/pkg/server/sandbox_list.go
+++ b/pkg/server/sandbox_list.go
@@ -20,7 +20,7 @@ import (
 	"golang.org/x/net/context"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	sandboxstore "github.com/containerd/cri-containerd/pkg/store/sandbox"
+	sandboxstore "github.com/containerd/cri/pkg/store/sandbox"
 )
 
 // ListPodSandbox returns a list of Sandbox.

--- a/pkg/server/sandbox_list_test.go
+++ b/pkg/server/sandbox_list_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	sandboxstore "github.com/containerd/cri-containerd/pkg/store/sandbox"
+	sandboxstore "github.com/containerd/cri/pkg/store/sandbox"
 )
 
 func TestToCRISandbox(t *testing.T) {

--- a/pkg/server/sandbox_portforward.go
+++ b/pkg/server/sandbox_portforward.go
@@ -28,8 +28,8 @@ import (
 	"golang.org/x/net/context"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	ctrdutil "github.com/containerd/cri-containerd/pkg/containerd/util"
-	sandboxstore "github.com/containerd/cri-containerd/pkg/store/sandbox"
+	ctrdutil "github.com/containerd/cri/pkg/containerd/util"
+	sandboxstore "github.com/containerd/cri/pkg/store/sandbox"
 )
 
 // PortForward prepares a streaming endpoint to forward ports from a PodSandbox, and returns the address.

--- a/pkg/server/sandbox_remove.go
+++ b/pkg/server/sandbox_remove.go
@@ -25,9 +25,9 @@ import (
 	"golang.org/x/net/context"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	"github.com/containerd/cri-containerd/pkg/log"
-	"github.com/containerd/cri-containerd/pkg/store"
-	sandboxstore "github.com/containerd/cri-containerd/pkg/store/sandbox"
+	"github.com/containerd/cri/pkg/log"
+	"github.com/containerd/cri/pkg/store"
+	sandboxstore "github.com/containerd/cri/pkg/store/sandbox"
 )
 
 // RemovePodSandbox removes the sandbox. If there are running containers in the

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -35,17 +35,17 @@ import (
 	"golang.org/x/sys/unix"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	"github.com/containerd/cri-containerd/pkg/annotations"
-	customopts "github.com/containerd/cri-containerd/pkg/containerd/opts"
-	ctrdutil "github.com/containerd/cri-containerd/pkg/containerd/util"
-	"github.com/containerd/cri-containerd/pkg/log"
-	sandboxstore "github.com/containerd/cri-containerd/pkg/store/sandbox"
-	"github.com/containerd/cri-containerd/pkg/util"
+	"github.com/containerd/cri/pkg/annotations"
+	customopts "github.com/containerd/cri/pkg/containerd/opts"
+	ctrdutil "github.com/containerd/cri/pkg/containerd/util"
+	"github.com/containerd/cri/pkg/log"
+	sandboxstore "github.com/containerd/cri/pkg/store/sandbox"
+	"github.com/containerd/cri/pkg/util"
 )
 
 func init() {
 	typeurl.Register(&sandboxstore.Metadata{},
-		"github.com/containerd/cri-containerd/pkg/store/sandbox", "Metadata")
+		"github.com/containerd/cri/pkg/store/sandbox", "Metadata")
 }
 
 // RunPodSandbox creates and starts a pod-level sandbox. Runtimes should ensure
@@ -140,7 +140,7 @@ func (c *criContainerdService) RunPodSandbox(ctx context.Context, r *runtime.Run
 		if err != nil {
 			return nil, fmt.Errorf("failed to get network status for sandbox %q: %v", id, err)
 		}
-		// Certain VM based solutions like clear containers (Issue containerd/cri-containerd#524)
+		// Certain VM based solutions like clear containers (Issue containerd/cri#524)
 		//  rely on the assumption that CRI shim will not be querying the network namespace to check the
 		// network states such as IP.
 		// In furture runtime implementation should avoid relying on CRI shim implementation details.
@@ -258,7 +258,7 @@ func (c *criContainerdService) RunPodSandbox(ctx context.Context, r *runtime.Run
 	// and before the end of this function.
 	// * If `Update` succeeds, sandbox state will become READY in one transaction.
 	// * If `Update` fails, sandbox will be removed from the store in the defer above.
-	// * If cri-containerd stops at any point before `Update` finishes, because sandbox
+	// * If containerd stops at any point before `Update` finishes, because sandbox
 	// state is not checkpointed, it will be recovered from corresponding containerd task
 	// status during restart:
 	//   * If the task is running, sandbox state will be READY,

--- a/pkg/server/sandbox_run_test.go
+++ b/pkg/server/sandbox_run_test.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/containerd/cri-containerd/pkg/annotations"
+	"github.com/containerd/cri/pkg/annotations"
 	"github.com/containerd/typeurl"
 	"github.com/cri-o/ocicni/pkg/ocicni"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -29,8 +29,8 @@ import (
 	"github.com/stretchr/testify/require"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	ostesting "github.com/containerd/cri-containerd/pkg/os/testing"
-	sandboxstore "github.com/containerd/cri-containerd/pkg/store/sandbox"
+	ostesting "github.com/containerd/cri/pkg/os/testing"
+	sandboxstore "github.com/containerd/cri/pkg/store/sandbox"
 )
 
 func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConfig, func(*testing.T, string, *runtimespec.Spec)) {

--- a/pkg/server/sandbox_status.go
+++ b/pkg/server/sandbox_status.go
@@ -26,7 +26,7 @@ import (
 	"golang.org/x/net/context"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	sandboxstore "github.com/containerd/cri-containerd/pkg/store/sandbox"
+	sandboxstore "github.com/containerd/cri/pkg/store/sandbox"
 )
 
 // PodSandboxStatus returns the status of the PodSandbox.

--- a/pkg/server/sandbox_status_test.go
+++ b/pkg/server/sandbox_status_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	sandboxstore "github.com/containerd/cri-containerd/pkg/store/sandbox"
+	sandboxstore "github.com/containerd/cri/pkg/store/sandbox"
 )
 
 func TestPodSandboxStatus(t *testing.T) {

--- a/pkg/server/sandbox_stop.go
+++ b/pkg/server/sandbox_stop.go
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/net/context"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	sandboxstore "github.com/containerd/cri-containerd/pkg/store/sandbox"
+	sandboxstore "github.com/containerd/cri/pkg/store/sandbox"
 )
 
 // StopPodSandbox stops the sandbox. If there are any running containers in the
@@ -75,7 +75,7 @@ func (c *criContainerdService) StopPodSandbox(ctx context.Context, r *runtime.St
 				return nil, fmt.Errorf("failed to destroy network for sandbox %q: %v", id, teardownErr)
 			}
 		}
-		/*TODO:It is still possible that cri-containerd crashes after we teardown the network, but before we remove the network namespace.
+		/*TODO:It is still possible that containerd crashes after we teardown the network, but before we remove the network namespace.
 		In that case, we'll not be able to remove the sandbox anymore. The chance is slim, but we should be aware of that.
 		In the future, once TearDownPod is idempotent, this will be fixed.*/
 

--- a/pkg/server/sandbox_stop_test.go
+++ b/pkg/server/sandbox_stop_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 
-	sandboxstore "github.com/containerd/cri-containerd/pkg/store/sandbox"
+	sandboxstore "github.com/containerd/cri/pkg/store/sandbox"
 )
 
 func TestWaitSandboxStop(t *testing.T) {

--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -33,16 +33,16 @@ import (
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 	"k8s.io/kubernetes/pkg/kubelet/server/streaming"
 
-	api "github.com/containerd/cri-containerd/pkg/api/v1"
-	"github.com/containerd/cri-containerd/pkg/atomic"
-	criconfig "github.com/containerd/cri-containerd/pkg/config"
-	ctrdutil "github.com/containerd/cri-containerd/pkg/containerd/util"
-	osinterface "github.com/containerd/cri-containerd/pkg/os"
-	"github.com/containerd/cri-containerd/pkg/registrar"
-	containerstore "github.com/containerd/cri-containerd/pkg/store/container"
-	imagestore "github.com/containerd/cri-containerd/pkg/store/image"
-	sandboxstore "github.com/containerd/cri-containerd/pkg/store/sandbox"
-	snapshotstore "github.com/containerd/cri-containerd/pkg/store/snapshot"
+	api "github.com/containerd/cri/pkg/api/v1"
+	"github.com/containerd/cri/pkg/atomic"
+	criconfig "github.com/containerd/cri/pkg/config"
+	ctrdutil "github.com/containerd/cri/pkg/containerd/util"
+	osinterface "github.com/containerd/cri/pkg/os"
+	"github.com/containerd/cri/pkg/registrar"
+	containerstore "github.com/containerd/cri/pkg/store/container"
+	imagestore "github.com/containerd/cri/pkg/store/image"
+	sandboxstore "github.com/containerd/cri/pkg/store/sandbox"
+	snapshotstore "github.com/containerd/cri/pkg/store/snapshot"
 )
 
 // grpcServices are all the grpc services provided by cri containerd.

--- a/pkg/server/service_test.go
+++ b/pkg/server/service_test.go
@@ -17,14 +17,14 @@ limitations under the License.
 package server
 
 import (
-	criconfig "github.com/containerd/cri-containerd/pkg/config"
-	ostesting "github.com/containerd/cri-containerd/pkg/os/testing"
-	"github.com/containerd/cri-containerd/pkg/registrar"
-	servertesting "github.com/containerd/cri-containerd/pkg/server/testing"
-	containerstore "github.com/containerd/cri-containerd/pkg/store/container"
-	imagestore "github.com/containerd/cri-containerd/pkg/store/image"
-	sandboxstore "github.com/containerd/cri-containerd/pkg/store/sandbox"
-	snapshotstore "github.com/containerd/cri-containerd/pkg/store/snapshot"
+	criconfig "github.com/containerd/cri/pkg/config"
+	ostesting "github.com/containerd/cri/pkg/os/testing"
+	"github.com/containerd/cri/pkg/registrar"
+	servertesting "github.com/containerd/cri/pkg/server/testing"
+	containerstore "github.com/containerd/cri/pkg/store/container"
+	imagestore "github.com/containerd/cri/pkg/store/image"
+	sandboxstore "github.com/containerd/cri/pkg/store/sandbox"
+	snapshotstore "github.com/containerd/cri/pkg/store/snapshot"
 )
 
 const (

--- a/pkg/server/snapshots.go
+++ b/pkg/server/snapshots.go
@@ -25,8 +25,8 @@ import (
 	snapshot "github.com/containerd/containerd/snapshots"
 	"github.com/sirupsen/logrus"
 
-	ctrdutil "github.com/containerd/cri-containerd/pkg/containerd/util"
-	snapshotstore "github.com/containerd/cri-containerd/pkg/store/snapshot"
+	ctrdutil "github.com/containerd/cri/pkg/containerd/util"
+	snapshotstore "github.com/containerd/cri/pkg/store/snapshot"
 )
 
 // snapshotsSyncer syncs snapshot stats periodically. imagefs info and container stats

--- a/pkg/server/streaming.go
+++ b/pkg/server/streaming.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/server/streaming"
 	"k8s.io/utils/exec"
 
-	ctrdutil "github.com/containerd/cri-containerd/pkg/containerd/util"
+	ctrdutil "github.com/containerd/cri/pkg/containerd/util"
 )
 
 func newStreamServer(c *criContainerdService, addr, port string) (streaming.Server, error) {

--- a/pkg/server/update_runtime_config.go
+++ b/pkg/server/update_runtime_config.go
@@ -23,7 +23,7 @@ import (
 )
 
 // UpdateRuntimeConfig updates the runtime config. Currently only handles podCIDR updates.
-// TODO(random-liu): Figure out how to handle pod cidr in cri-containerd.
+// TODO(random-liu): Figure out how to handle pod cidr in the cri plugin.
 func (c *criContainerdService) UpdateRuntimeConfig(ctx context.Context, r *runtime.UpdateRuntimeConfigRequest) (*runtime.UpdateRuntimeConfigResponse, error) {
 	return &runtime.UpdateRuntimeConfigResponse{}, nil
 }

--- a/pkg/server/version.go
+++ b/pkg/server/version.go
@@ -21,7 +21,7 @@ import (
 	"golang.org/x/net/context"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	"github.com/containerd/cri-containerd/pkg/constants"
+	"github.com/containerd/cri/pkg/constants"
 )
 
 const (

--- a/pkg/store/container/container.go
+++ b/pkg/store/container/container.go
@@ -23,8 +23,8 @@ import (
 	"github.com/docker/docker/pkg/truncindex"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	cio "github.com/containerd/cri-containerd/pkg/server/io"
-	"github.com/containerd/cri-containerd/pkg/store"
+	cio "github.com/containerd/cri/pkg/server/io"
+	"github.com/containerd/cri/pkg/store"
 )
 
 // Container contains all resources associated with the container. All methods to

--- a/pkg/store/container/container_test.go
+++ b/pkg/store/container/container_test.go
@@ -23,8 +23,8 @@ import (
 	assertlib "github.com/stretchr/testify/assert"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	cio "github.com/containerd/cri-containerd/pkg/server/io"
-	"github.com/containerd/cri-containerd/pkg/store"
+	cio "github.com/containerd/cri/pkg/server/io"
+	"github.com/containerd/cri/pkg/store"
 )
 
 func TestContainerStore(t *testing.T) {

--- a/pkg/store/image/image.go
+++ b/pkg/store/image/image.go
@@ -24,7 +24,7 @@ import (
 	godigest "github.com/opencontainers/go-digest"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 
-	"github.com/containerd/cri-containerd/pkg/store"
+	"github.com/containerd/cri/pkg/store"
 )
 
 // Image contains all resources associated with the image. All fields

--- a/pkg/store/image/image_test.go
+++ b/pkg/store/image/image_test.go
@@ -23,7 +23,7 @@ import (
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	assertlib "github.com/stretchr/testify/assert"
 
-	"github.com/containerd/cri-containerd/pkg/store"
+	"github.com/containerd/cri/pkg/store"
 )
 
 func TestImageStore(t *testing.T) {

--- a/pkg/store/sandbox/sandbox.go
+++ b/pkg/store/sandbox/sandbox.go
@@ -22,7 +22,7 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/docker/docker/pkg/truncindex"
 
-	"github.com/containerd/cri-containerd/pkg/store"
+	"github.com/containerd/cri/pkg/store"
 )
 
 // Sandbox contains all resources associated with the sandbox. All methods to

--- a/pkg/store/sandbox/sandbox_test.go
+++ b/pkg/store/sandbox/sandbox_test.go
@@ -22,7 +22,7 @@ import (
 	assertlib "github.com/stretchr/testify/assert"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	"github.com/containerd/cri-containerd/pkg/store"
+	"github.com/containerd/cri/pkg/store"
 )
 
 func TestSandboxStore(t *testing.T) {

--- a/pkg/store/sandbox/status.go
+++ b/pkg/store/sandbox/status.go
@@ -21,7 +21,7 @@ import (
 	"time"
 )
 
-// State is the sandbox state we use in cri-containerd.
+// State is the sandbox state we use in containerd/cri.
 // It has unknown state defined.
 type State uint32
 

--- a/pkg/store/snapshot/snapshot.go
+++ b/pkg/store/snapshot/snapshot.go
@@ -21,7 +21,7 @@ import (
 
 	snapshot "github.com/containerd/containerd/snapshots"
 
-	"github.com/containerd/cri-containerd/pkg/store"
+	"github.com/containerd/cri/pkg/store"
 )
 
 // Snapshot contains the information about the snapshot.

--- a/pkg/store/snapshot/snapshot_test.go
+++ b/pkg/store/snapshot/snapshot_test.go
@@ -23,7 +23,7 @@ import (
 	snapshot "github.com/containerd/containerd/snapshots"
 	assertlib "github.com/stretchr/testify/assert"
 
-	"github.com/containerd/cri-containerd/pkg/store"
+	"github.com/containerd/cri/pkg/store"
 )
 
 func TestSnapshotStore(t *testing.T) {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -22,18 +22,18 @@ import (
 	"github.com/blang/semver"
 )
 
-// CRIContainerdVersion is the version of the cri-containerd.
+// CRIContainerdVersion is the version of the cri plugin.
 var CRIContainerdVersion = "UNKNOWN"
 
 func validateSemver(sv string) error {
 	_, err := semver.Parse(sv)
 	if err != nil {
-		return fmt.Errorf("couldn't parse cri-containerd version %q: %v", sv, err)
+		return fmt.Errorf("couldn't parse version %q: %v", sv, err)
 	}
 	return nil
 }
 
-// PrintVersion outputs the release version of cri-containerd
+// PrintVersion outputs the release version of containerd/cri
 func PrintVersion() {
 	err := validateSemver(CRIContainerdVersion)
 	if err != nil {


### PR DESCRIPTION
Addressing: https://github.com/containerd/cri-containerd/issues/660

Renaming / moving containerd/cri-containerd to containerd/cri

Making first pass 

Signed-off-by: Mike Brown <brownwm@us.ibm.com>