### PR TITLE
Enable promisc mode because Kubernetes network model needs it.

### DIFF
--- a/hack/install-deps.sh
+++ b/hack/install-deps.sh
@@ -113,6 +113,7 @@ if ${INSTALL_CNI}; then
       "bridge": "cni0",
       "isGateway": true,
       "ipMasq": true,
+      "promiscMode": true,
       "ipam": {
         "type": "host-local",
         "subnet": "10.88.0.0/16",


### PR DESCRIPTION
We need promisc mode to handle the case that one pod talks to its own service.

Signed-off-by: Lantao Liu <lantaol@google.com>