### PR TITLE
Fix containerd repo test.

### DIFF
--- a/test/build-containerd.sh
+++ b/test/build-containerd.sh
@@ -39,7 +39,7 @@ fi
 # Make sure output directory is clean.
 make clean
 # Build and push test tarball.
-PUSH_VERSION=true DEPLOY_DIR=${DEPLOY_DIR:-""} \
+PUSH_VERSION=true DEPLOY_DIR=cri-containerd-staging/containerd \
   make push TARBALL_PREFIX=containerd-cni \
   INCLUDE_CNI=true \
   CHECKOUT_CONTAINERD=false \

--- a/test/configure.sh
+++ b/test/configure.sh
@@ -38,6 +38,13 @@ fetch_metadata() {
 
 # DEPLOY_PATH is the gcs path where cri-containerd tarball is stored.
 DEPLOY_PATH=${DEPLOY_PATH:-"cri-containerd-staging"}
+# DEPLOY_PATH_METADATA is the metadata key of DEPLOY_PATH.
+DEPLOY_PATH_METADATA="deploy-path"
+deploy_path=$(fetch_metadata "${DEPLOY_PATH_METADATA}")
+if [ ! -z "${deploy_path}" ]; then
+  DEPLOY_PATH=${deploy_path}
+fi
+
 # PULL_REFS_METADATA is the metadata key of PULL_REFS from prow.
 PULL_REFS_METADATA="PULL_REFS"
 pull_refs=$(fetch_metadata "${PULL_REFS_METADATA}")

--- a/test/e2e_node/image-config-containerd.yaml
+++ b/test/e2e_node/image-config-containerd.yaml
@@ -2,8 +2,8 @@ images:
   ubuntu:
     image: ubuntu-gke-1604-xenial-v20170420-1
     project: ubuntu-os-gke-cloud
-    metadata: "user-data<test/e2e_node/init.yaml,containerd-configure-sh<test/configure.sh,pkg-prefix=containerd-cni"
+    metadata: "user-data<test/e2e_node/init.yaml,containerd-configure-sh<test/configure.sh,pkg-prefix=containerd-cni,deploy-path=cri-containerd-staging/containerd"
   cos-stable:
     image_regex: cos-stable-60-9592-84-0
     project: cos-cloud
-    metadata: "user-data<test/e2e_node/init.yaml,containerd-configure-sh<test/configure.sh,extra-init-sh<test/e2e_node/gci-init.sh,gci-update-strategy=update_disabled,pkg-prefix=containerd-cni"
+    metadata: "user-data<test/e2e_node/init.yaml,containerd-configure-sh<test/configure.sh,extra-init-sh<test/e2e_node/gci-init.sh,gci-update-strategy=update_disabled,pkg-prefix=containerd-cni,deploy-path=cri-containerd-staging/containerd"


### PR DESCRIPTION
We should not use the same latest file for `containerd` and `cri-containerd` together.
Push containerd test tarball to a different bucket `cri-containerd-staging/containerd`.

Signed-off-by: Lantao Liu <lantaol@google.com>