### PR TITLE
Write all instance metadata to files.

### DIFF
--- a/test/containerd/build.sh
+++ b/test/containerd/build.sh
@@ -22,7 +22,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-source $(dirname "${BASH_SOURCE[0]}")/build-utils.sh
+source $(dirname "${BASH_SOURCE[0]}")/../build-utils.sh
 cd "${ROOT}"
 
 if [ -z "${GOPATH}" ]; then

--- a/test/containerd/deploy-path
+++ b/test/containerd/deploy-path
@@ -1,0 +1,1 @@
+cri-containerd-staging/containerd

--- a/test/containerd/image-config.yaml
+++ b/test/containerd/image-config.yaml
@@ -1,0 +1,9 @@
+images:
+  ubuntu:
+    image: ubuntu-gke-1604-xenial-v20170420-1
+    project: ubuntu-os-gke-cloud
+    metadata: "user-data<test/e2e_node/init.yaml,containerd-configure-sh<test/configure.sh,pkg-prefix<test/containerd/pkg-prefix,deploy-path<test/containerd/deploy-path"
+  cos-stable:
+    image_regex: cos-stable-60-9592-84-0
+    project: cos-cloud
+    metadata: "user-data<test/e2e_node/init.yaml,containerd-configure-sh<test/configure.sh,extra-init-sh<test/e2e_node/gci-init.sh,gci-update-strategy=update_disabled,pkg-prefix<test/containerd/pkg-prefix,deploy-path<test/containerd/deploy-path"

--- a/test/containerd/pkg-prefix
+++ b/test/containerd/pkg-prefix
@@ -1,0 +1,1 @@
+containerd-cni

--- a/test/e2e_node/image-config-containerd.yaml
+++ b/test/e2e_node/image-config-containerd.yaml
@@ -1,9 +1,0 @@
-images:
-  ubuntu:
-    image: ubuntu-gke-1604-xenial-v20170420-1
-    project: ubuntu-os-gke-cloud
-    metadata: "user-data<test/e2e_node/init.yaml,containerd-configure-sh<test/configure.sh,pkg-prefix=containerd-cni,deploy-path=cri-containerd-staging/containerd"
-  cos-stable:
-    image_regex: cos-stable-60-9592-84-0
-    project: cos-cloud
-    metadata: "user-data<test/e2e_node/init.yaml,containerd-configure-sh<test/configure.sh,extra-init-sh<test/e2e_node/gci-init.sh,gci-update-strategy=update_disabled,pkg-prefix=containerd-cni,deploy-path=cri-containerd-staging/containerd"


### PR DESCRIPTION
Kubernetes test-infra only supports load instance metadata from files. This PR write both `pkg-prefix` and `deploy-path` into files to work around this.

The test-infra side change is https://github.com/kubernetes/test-infra/pull/7328.

Signed-off-by: Lantao Liu <lantaol@google.com>