### PR TITLE
Only set deploy dir.

### DIFF
--- a/test/containerd/build.sh
+++ b/test/containerd/build.sh
@@ -39,7 +39,7 @@ fi
 # Make sure output directory is clean.
 make clean
 # Build and push test tarball.
-PUSH_VERSION=true DEPLOY_DIR=cri-containerd-staging/containerd \
+PUSH_VERSION=true DEPLOY_DIR=containerd \
   make push TARBALL_PREFIX=containerd-cni \
   INCLUDE_CNI=true \
   CHECKOUT_CONTAINERD=false \


### PR DESCRIPTION
Deploy bucket is set via `DEPLOY_BUCKET`, and the default `cri-containerd-staging` is just what we want. https://github.com/containerd/cri/blob/master/hack/push.sh#L24

We should only set `DEPLOY_DIR`.
 
Signed-off-by: Lantao Liu <lantaol@google.com>