### PR TITLE
Fix for kube-up.sh and update several documments.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ uninstall:
 	rm -f $(BINDIR)/ctr
 
 $(BUILD_DIR)/$(TARBALL): static-binaries vendor.conf
-	@BUILD_DIR=$(BUILD_DIR) TARBALL=$(TARBALL) ./hack/release.sh
+	@BUILD_DIR=$(BUILD_DIR) TARBALL=$(TARBALL) VERSION=$(VERSION) ./hack/release.sh
 
 release: $(BUILD_DIR)/$(TARBALL)
 

--- a/cluster/gce/configure.sh
+++ b/cluster/gce/configure.sh
@@ -61,7 +61,7 @@ curl -f --ipv4 -Lo "${TARBALL}" --connect-timeout 20 --max-time 300 --retry 6 --
 tar xvf "${TARBALL}"
 
 # Copy crictl config.
-cp "${CRI_CONTAINERD_HOME}/etc/crictl.yaml" /etc
+cp "${CONTAINERD_HOME}/etc/crictl.yaml" /etc
 
 echo "export PATH=${CONTAINERD_HOME}/usr/local/bin/:${CONTAINERD_HOME}/usr/local/sbin/:\$PATH" > \
   /etc/profile.d/containerd_env.sh

--- a/cluster/gce/env
+++ b/cluster/gce/env
@@ -3,12 +3,11 @@ GCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # TODO(random-liu): Upload release tarball to user's own GCS, and use it. We should
 # not let all nodes of all users download tarball from cri-containerd-release.
-if [ -z "${CRI_CONTAINERD_VERSION:-}" ]; then
-  CRI_CONTAINERD_VERSION=$(curl -f --ipv4 --retry 6 --retry-delay 3 --silent --show-error \
-    https://storage.googleapis.com/cri-containerd-release/latest)
+version_file=${GCE_DIR}/../version
+if [ ! -f "${version_file}" ]; then
+  echo "version file does not exist"
+  exit 1
 fi
-version_file=$(mktemp /tmp/version.XXXX)
-echo "${CRI_CONTAINERD_VERSION}" > "$version_file"
 export KUBE_MASTER_EXTRA_METADATA="user-data=${GCE_DIR}/cloud-init/master.yaml,containerd-configure-sh=${GCE_DIR}/configure.sh,version=${version_file}"
 export KUBE_NODE_EXTRA_METADATA="user-data=${GCE_DIR}/cloud-init/node.yaml,containerd-configure-sh=${GCE_DIR}/configure.sh,version=${version_file}"
 export KUBE_CONTAINER_RUNTIME="remote"

--- a/docs/crictl.md
+++ b/docs/crictl.md
@@ -51,7 +51,8 @@ $ docker pull k8s.gcr.io/pause-amd64:3.1
   Status: Downloaded newer image for k8s.gcr.io/pause-amd64:3.1
 $ docker save k8s.gcr.io/pause-amd64:3.1 -o pause.tar
 ```
-Then load the container image into the container runtime:
+Then use [`ctr`](https://github.com/containerd/containerd/blob/master/docs/man/ctr.1.md)
+to load the container image into the container runtime:
 ```console
 $ sudo ctr cri load pause.tar
   Loaded image: k8s.gcr.io/pause-amd64:3.1

--- a/docs/kube-up.md
+++ b/docs/kube-up.md
@@ -9,14 +9,12 @@ Unpack release tarball to any directory, using `${CRI_CONTAINERD_PATH}` to indic
 tar -C ${CRI_CONTAINERD_PATH} -xzf cri-containerd-${VERSION}.linux-amd64.tar.gz
 ```
 ## Set Environment Variables for CRI-Containerd
-Use environment variable `CRI_CONTAINERD_VERSION` to specify `cri-containerd` version. By default,
-latest version will be used.
 ```bash
-. ${CRI_CONTAINERD_PATH}/opt/cri-containerd/cluster/gce/env
+. ${CRI_CONTAINERD_PATH}/opt/containerd/cluster/gce/env
 ```
 ## Create Kubernetes Cluster on GCE
 Follow these instructions [here](https://kubernetes.io/docs/getting-started-guides/gce/) to create a production quality Kubernetes cluster on GCE.
 
-**Make sure the Kubernetes version you are using is v1.9 or greater:**
+**Make sure the Kubernetes version you are using is v1.10 or greater:**
 * When using `https://get.k8s.io`, use the environment variable `KUBERNETES_RELEASE` to set version.
-* When using a Kubernetes release tarball, make sure to select version 1.9 or greater.
+* When using a Kubernetes release tarball, make sure to select version 1.10 or greater.

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -34,6 +34,11 @@ CUSTOM_CONTAINERD=${CUSTOM_CONTAINERD:-false}
 
 destdir=${BUILD_DIR}/release-stage
 
+if [[ -z "${VERSION}" ]]; then
+  echo "VERSION is not set"
+  exit 1
+fi
+
 # Remove release-stage directory to avoid including old files.
 rm -rf ${destdir}
 
@@ -50,6 +55,8 @@ cp ${ROOT}/contrib/systemd-units/* ${destdir}/etc/systemd/system/
 # Install cluster directory into release stage.
 mkdir -p ${destdir}/opt/containerd
 cp -r ${ROOT}/cluster ${destdir}/opt/containerd
+# Write a version file into the release tarball.
+echo ${VERSION} > ${destdir}/opt/containerd/cluster/version
 
 # Create release tar
 tarball=${BUILD_DIR}/${TARBALL}


### PR DESCRIPTION
This PR:
1) Fix the `configure.sh` for `kube-up.sh`.
2) Write a `version` file into the release tarball, and use fixed version for `kube-up.sh`. We shouldn't let user specify arbitrary version of `cri-containerd` to use, because that may not be compatible with the cluster bootstrap scripts and cloud init files.
3) Update some documents.

Signed-off-by: Lantao Liu <lantaol@google.com>