### PR TITLE
Update cri-tools and build critest into release tarball again.

### DIFF
--- a/hack/install/install-critools.sh
+++ b/hack/install/install-critools.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 source $(dirname "${BASH_SOURCE[0]}")/utils.sh
-CRICTL_DIR=${DESTDIR}/usr/local/bin
+CRITOOL_DIR=${DESTDIR}/usr/local/bin
 CRICTL_CONFIG_DIR=${DESTDIR}/etc
 
 # Create a temporary GOPATH for crictl installation.
@@ -29,8 +29,8 @@ GOPATH=${TMPGOPATH}
 #Install crictl
 checkout_repo ${CRITOOL_PKG} ${CRITOOL_VERSION} ${CRITOOL_REPO}
 cd ${GOPATH}/src/${CRITOOL_PKG}
-make crictl
-${SUDO} make install-crictl -e BINDIR=${CRICTL_DIR} GOPATH=${GOPATH}
+make
+${SUDO} make install -e BINDIR=${CRITOOL_DIR} GOPATH=${GOPATH}
 ${SUDO} mkdir -p ${CRICTL_CONFIG_DIR}
 ${SUDO} bash -c 'cat >'${CRICTL_CONFIG_DIR}'/crictl.yaml <<EOF
 runtime-endpoint: /run/containerd/containerd.sock

--- a/hack/install/install-deps.sh
+++ b/hack/install/install-deps.sh
@@ -46,5 +46,5 @@ fi
 # Install containerd
 ./install-containerd.sh
 
-#Install crictl
-./install-crictl.sh
+#Install critools
+./install-critools.sh

--- a/hack/test-cri.sh
+++ b/hack/test-cri.sh
@@ -37,6 +37,13 @@ GOPATH=${GOPATH%%:*}
 
 CRITEST=${GOPATH}/bin/critest
 
+GINKGO_PKG=github.com/onsi/ginkgo/ginkgo
+
+# Install ginkgo
+if [ ! -x "$(command -v ginkgo)" ]; then
+  go get -u ${GINKGO_PKG}
+fi
+
 # Install critest
 if [ ! -x "$(command -v ${CRITEST})" ]; then
   go get -d ${CRITOOL_PKG}/...
@@ -51,7 +58,7 @@ mkdir -p ${REPORT_DIR}
 test_setup ${REPORT_DIR}
 
 # Run cri validation test
-sudo env PATH=${PATH} GOPATH=${GOPATH} ${CRITEST} --runtime-endpoint=${CONTAINERD_SOCK} --focus="${FOCUS}" --ginkgo-flags="--skip=\"${SKIP}\" --nodes=8" validation
+sudo env PATH=${PATH} GOPATH=${GOPATH} ${CRITEST} --runtime-endpoint=${CONTAINERD_SOCK} --ginkgo.focus="${FOCUS}" --ginkgo.skip="${SKIP}" --parallel=8
 test_exit_code=$?
 
 test_teardown

--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -17,7 +17,7 @@
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
 
 # Not from vendor.conf.
-CRITOOL_VERSION=b184f9aefe60a4441330e615ee20634ee26474fb
+CRITOOL_VERSION=976680c4aa382339ccba214d1f1a88fdc8638b78
 CRITOOL_PKG=github.com/kubernetes-incubator/cri-tools
 CRITOOL_REPO=github.com/kubernetes-incubator/cri-tools
 


### PR DESCRIPTION
Build `critest` into release tarball again, because we've got rid of the dependency on the source code. https://github.com/kubernetes-incubator/cri-tools/pull/261

Now `critest` binary is usable itself.

Signed-off-by: Lantao Liu <lantaol@google.com>