### PR TITLE
Address comments for privileged runtime code.

### DIFF
--- a/hack/test-utils.sh
+++ b/hack/test-utils.sh
@@ -18,12 +18,13 @@ source $(dirname "${BASH_SOURCE[0]}")/utils.sh
 
 # RESTART_WAIT_PERIOD is the period to wait before restarting containerd.
 RESTART_WAIT_PERIOD=${RESTART_WAIT_PERIOD:-10}
-CONTAINERD_CONFIG="--log-level=debug "
+# CONTAINERD_FLAGS contains all containerd flags.
+CONTAINERD_FLAGS="--log-level=debug "
 
 # Use a configuration file for containerd.
 CONTAINERD_CONFIG_FILE=${CONTAINERD_CONFIG_FILE:-""}
 if [ -f "${CONTAINERD_CONFIG_FILE}" ]; then
-	CONTAINERD_CONFIG+="--config $CONTAINERD_CONFIG_FILE"
+  CONTAINERD_FLAGS+="--config ${CONTAINERD_CONFIG_FILE} "
 fi
 
 CONTAINERD_SOCK=/run/containerd/containerd.sock
@@ -39,7 +40,7 @@ test_setup() {
     exit 1
   fi
   sudo pkill -x containerd
-  keepalive "sudo ${ROOT}/_output/containerd ${CONTAINERD_CONFIG}" \
+  keepalive "sudo ${ROOT}/_output/containerd ${CONTAINERD_FLAGS}" \
     ${RESTART_WAIT_PERIOD} &> ${report_dir}/containerd.log &
   containerd_pid=$!
   # Wait for containerd to be running by using the containerd client ctr to check the version

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -32,6 +32,7 @@ const (
 	// SandboxID is the sandbox ID annotation
 	SandboxID = "io.kubernetes.cri.sandbox-id"
 
-	// PrivilegedSandbox is the privileged annotation
-	PrivilegedSandbox = "io.kubernetes.cri.privileged-sandbox"
+	// UntrustedWorkload is the sandbox annotation for untrusted workload. Untrusted
+	// workload can only run on dedicated runtime for untrusted workload.
+	UntrustedWorkload = "io.kubernetes.cri.untrusted-workload"
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,9 +18,10 @@ package config
 
 import "github.com/containerd/containerd"
 
-// Runtime  struct to contain the type(ID), engine, and root variables for a default and a privileged runtime
+// Runtime struct to contain the type(ID), engine, and root variables for a default runtime
+// and a runtime for untrusted worload.
 type Runtime struct {
-	//Type is the runtime type to use in containerd e.g. io.containerd.runtime.v1.linux
+	// Type is the runtime type to use in containerd e.g. io.containerd.runtime.v1.linux
 	Type string `toml:"runtime_type" json:"runtimeType"`
 	// Engine is the name of the runtime engine used by containerd.
 	Engine string `toml:"runtime_engine" json:"runtimeEngine"`
@@ -34,8 +35,8 @@ type ContainerdConfig struct {
 	Snapshotter string `toml:"snapshotter" json:"snapshotter"`
 	// DefaultRuntime is the runtime to use in containerd.
 	DefaultRuntime Runtime `toml:"default_runtime" json:"defaultRuntime"`
-	// PrivilegedRuntime is a non-secure runtime used only to run trusted workloads on it
-	PrivilegedRuntime Runtime `toml:"privileged_runtime" json:"privilegedRuntime"`
+	// UntrustedWorkloadRuntime is a runtime to run untrusted workloads on it.
+	UntrustedWorkloadRuntime Runtime `toml:"untrusted_workload_runtime" json:"untrustedWorkloadRuntime"`
 }
 
 // CniConfig contains toml config related to cni
@@ -107,11 +108,6 @@ func DefaultConfig() PluginConfig {
 		ContainerdConfig: ContainerdConfig{
 			Snapshotter: containerd.DefaultSnapshotter,
 			DefaultRuntime: Runtime{
-				Type:   "io.containerd.runtime.v1.linux",
-				Engine: "",
-				Root:   "",
-			},
-			PrivilegedRuntime: Runtime{
 				Type:   "io.containerd.runtime.v1.linux",
 				Engine: "",
 				Root:   "",


### PR DESCRIPTION
Address some comments from https://github.com/containerd/cri/pull/657.

Changes need input:
1) I changed `privilegedSandbox` to `hostPrivilegedSandbox`. The reason is that `privileged` already has special meaning today, and `trusted` is still a bit confusing to me. I feel that `hostPrivileged` is more accurate, but a bit long.
2) I changed `containerRuntime` and `getRuntime` to `ociRuntime` and `getOCIRuntime` to make it more clear.
3) I changed sandbox to use privileged runtime if `annotations.HostPrivilegedSandbox` is "true". This behavior is not included in the original PR, I'm not sure whether it is a mistake.

@jcvenegas Thanks a lot for contributing this! :)
/cc @mikebrow @jcvenegas 

Signed-off-by: Lantao Liu <lantaol@google.com>