### PR TITLE
Remove omitempty from config json.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,36 +21,36 @@ import "github.com/containerd/containerd"
 // Runtime  struct to contain the type(ID), engine, and root variables for a default and a privileged runtime
 type Runtime struct {
 	//Type is the runtime type to use in containerd e.g. io.containerd.runtime.v1.linux
-	Type string `toml:"runtime_type" json:"runtimeType,omitempty"`
+	Type string `toml:"runtime_type" json:"runtimeType"`
 	// Engine is the name of the runtime engine used by containerd.
-	Engine string `toml:"runtime_engine" json:"runtimeEngine,omitempty"`
+	Engine string `toml:"runtime_engine" json:"runtimeEngine"`
 	// Root is the directory used by containerd for runtime state.
-	Root string `toml:"runtime_root" json:"runtimeRoot,omitempty"`
+	Root string `toml:"runtime_root" json:"runtimeRoot"`
 }
 
 // ContainerdConfig contains toml config related to containerd
 type ContainerdConfig struct {
 	// Snapshotter is the snapshotter used by containerd.
-	Snapshotter string `toml:"snapshotter" json:"snapshotter,omitempty"`
+	Snapshotter string `toml:"snapshotter" json:"snapshotter"`
 	// DefaultRuntime is the runtime to use in containerd.
-	DefaultRuntime Runtime `toml:"default_runtime" json:"defaultRuntime,omitempty"`
+	DefaultRuntime Runtime `toml:"default_runtime" json:"defaultRuntime"`
 	// PrivilegedRuntime is a non-secure runtime used only to run trusted workloads on it
-	PrivilegedRuntime Runtime `toml:"privileged_runtime" json:"privilegedRuntime,omitempty"`
+	PrivilegedRuntime Runtime `toml:"privileged_runtime" json:"privilegedRuntime"`
 }
 
 // CniConfig contains toml config related to cni
 type CniConfig struct {
 	// NetworkPluginBinDir is the directory in which the binaries for the plugin is kept.
-	NetworkPluginBinDir string `toml:"bin_dir" json:"binDir,omitempty"`
+	NetworkPluginBinDir string `toml:"bin_dir" json:"binDir"`
 	// NetworkPluginConfDir is the directory in which the admin places a CNI conf.
-	NetworkPluginConfDir string `toml:"conf_dir" json:"confDir,omitempty"`
+	NetworkPluginConfDir string `toml:"conf_dir" json:"confDir"`
 }
 
 // Mirror contains the config related to the registry mirror
 type Mirror struct {
 	// Endpoints are endpoints for a namespace. CRI plugin will try the endpoints
 	// one by one until a working one is found.
-	Endpoints []string `toml:"endpoint" json:"endpoint,omitempty"`
+	Endpoints []string `toml:"endpoint" json:"endpoint"`
 	// TODO (Abhi) We might need to add auth per namespace. Looks like
 	// image auth information is passed by kube itself.
 }
@@ -58,30 +58,30 @@ type Mirror struct {
 // Registry is registry settings configured
 type Registry struct {
 	// Mirrors are namespace to mirror mapping for all namespaces.
-	Mirrors map[string]Mirror `toml:"mirrors" json:"mirrors,omitempty"`
+	Mirrors map[string]Mirror `toml:"mirrors" json:"mirrors"`
 }
 
 // PluginConfig contains toml config related to CRI plugin,
 // it is a subset of Config.
 type PluginConfig struct {
 	// ContainerdConfig contains config related to containerd
-	ContainerdConfig `toml:"containerd" json:"containerd,omitempty"`
+	ContainerdConfig `toml:"containerd" json:"containerd"`
 	// CniConfig contains config related to cni
-	CniConfig `toml:"cni" json:"cni,omitempty"`
+	CniConfig `toml:"cni" json:"cni"`
 	// Registry contains config related to the registry
-	Registry `toml:"registry" json:"registry,omitempty"`
+	Registry `toml:"registry" json:"registry"`
 	// StreamServerAddress is the ip address streaming server is listening on.
-	StreamServerAddress string `toml:"stream_server_address" json:"streamServerAddress,omitempty"`
+	StreamServerAddress string `toml:"stream_server_address" json:"streamServerAddress"`
 	// StreamServerPort is the port streaming server is listening on.
-	StreamServerPort string `toml:"stream_server_port" json:"streamServerPort,omitempty"`
+	StreamServerPort string `toml:"stream_server_port" json:"streamServerPort"`
 	// EnableSelinux indicates to enable the selinux support.
-	EnableSelinux bool `toml:"enable_selinux" json:"enableSelinux,omitempty"`
+	EnableSelinux bool `toml:"enable_selinux" json:"enableSelinux"`
 	// SandboxImage is the image used by sandbox container.
-	SandboxImage string `toml:"sandbox_image" json:"sandboxImage,omitempty"`
+	SandboxImage string `toml:"sandbox_image" json:"sandboxImage"`
 	// StatsCollectPeriod is the period (in seconds) of snapshots stats collection.
-	StatsCollectPeriod int `toml:"stats_collect_period" json:"statsCollectPeriod,omitempty"`
+	StatsCollectPeriod int `toml:"stats_collect_period" json:"statsCollectPeriod"`
 	// SystemdCgroup enables systemd cgroup support.
-	SystemdCgroup bool `toml:"systemd_cgroup" json:"systemdCgroup,omitempty"`
+	SystemdCgroup bool `toml:"systemd_cgroup" json:"systemdCgroup"`
 }
 
 // Config contains all configurations for cri server.
@@ -89,12 +89,12 @@ type Config struct {
 	// PluginConfig is the config for CRI plugin.
 	PluginConfig
 	// ContainerdRootDir is the root directory path for containerd.
-	ContainerdRootDir string `json:"containerdRootDir,omitempty"`
+	ContainerdRootDir string `json:"containerdRootDir"`
 	// ContainerdEndpoint is the containerd endpoint path.
-	ContainerdEndpoint string `json:"containerdEndpoint,omitempty"`
+	ContainerdEndpoint string `json:"containerdEndpoint"`
 	// RootDir is the root directory path for managing cri plugin files
 	// (metadata checkpoint etc.)
-	RootDir string `json:"rootDir,omitempty"`
+	RootDir string `json:"rootDir"`
 }
 
 // DefaultConfig returns default configurations of cri plugin.


### PR DESCRIPTION
Remove `omitempty` from config json.

We should show empty config option in `crictl info`:
```console
# crictl info
{
  "status": {
    "conditions": [
      {
        "type": "RuntimeReady",
        "status": true,
        "reason": "",
        "message": ""
      },
      {
        "type": "NetworkReady",
        "status": true,
        "reason": "",
        "message": ""
      }
    ]
  },
  "config": {
    "containerd": {
      "snapshotter": "overlayfs",
      "defaultRuntime": {
        "runtimeType": "io.containerd.runtime.v1.linux",
        "runtimeEngine": "",
        "runtimeRoot": ""
      },
      "privilegedRuntime": {
        "runtimeType": "io.containerd.runtime.v1.linux",
        "runtimeEngine": "",
        "runtimeRoot": ""
      }
    },
    "cni": {
      "binDir": "/opt/cni/bin",
      "confDir": "/etc/cni/net.d"
    },
    "registry": {
      "mirrors": {
        "docker.io": {
          "endpoint": [
            "https://registry-1.docker.io"
          ]
        }
      }
    },
    "streamServerAddress": "",
    "streamServerPort": "10010",
    "enableSelinux": false,
    "sandboxImage": "gcr.io/google_containers/pause:3.0",
    "statsCollectPeriod": 10,
    "systemdCgroup": false,
    "containerdRootDir": "/var/lib/containerd",
    "containerdEndpoint": "/run/containerd/containerd.sock",
    "rootDir": "/var/lib/containerd/io.containerd.grpc.v1.cri"
  },
  "golang": "go1.10"
}
```
Signed-off-by: Lantao Liu <lantaol@google.com>