### PR TITLE
Add RunAsGroup support.

### DIFF
--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -145,8 +145,16 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	logrus.Debugf("Sandbox container spec: %+v", spec)
 
 	var specOpts []oci.SpecOpts
-	if uid := securityContext.GetRunAsUser(); uid != nil {
-		specOpts = append(specOpts, oci.WithUserID(uint32(uid.GetValue())))
+	userstr, err := generateUserString(
+		"",
+		securityContext.GetRunAsUser(),
+		securityContext.GetRunAsGroup(),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to generate user string")
+	}
+	if userstr != "" {
+		specOpts = append(specOpts, oci.WithUser(userstr))
 	}
 
 	seccompSpecOpts, err := generateSeccompSpecOpts(

--- a/vendor.conf
+++ b/vendor.conf
@@ -4,7 +4,7 @@ github.com/boltdb/bolt e9cf4fae01b5a8ff89d0ec6b32f0d9c9f79aefdd
 github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
 github.com/containerd/cgroups fe281dd265766145e943a034aa41086474ea6130
 github.com/containerd/console cb7008ab3d8359b78c5f464cb7cf160107ad5925
-github.com/containerd/containerd v1.1.0-rc.0
+github.com/containerd/containerd c0f7fcd910a02cd388c089525d7ea17f9f229a43
 github.com/containerd/continuity 3e8f2ea4b190484acb976a5b378d373429639a1a
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
 github.com/containerd/go-runc bcb223a061a3dd7de1a89c0b402a60f4dd9bd307

--- a/vendor/github.com/containerd/containerd/archive/tar_windows.go
+++ b/vendor/github.com/containerd/containerd/archive/tar_windows.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/Microsoft/go-winio"
 	"github.com/Microsoft/hcsshim"
-	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/sys"
 )
 
@@ -180,8 +179,12 @@ func applyWindowsLayer(ctx context.Context, root string, tr *tar.Reader, options
 		return 0, err
 	}
 	defer func() {
-		if err := w.Close(); err != nil {
-			log.G(ctx).Errorf("failed to close layer writer: %v", err)
+		if err2 := w.Close(); err2 != nil {
+			// This error should not be discarded as a failure here
+			// could result in an invalid layer on disk
+			if err == nil {
+				err = err2
+			}
 		}
 	}()
 

--- a/vendor/github.com/containerd/containerd/contrib/seccomp/seccomp_default.go
+++ b/vendor/github.com/containerd/containerd/contrib/seccomp/seccomp_default.go
@@ -444,25 +444,8 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 		})
 	}
 
-	// make a map of enabled capabilities
-	caps := make(map[string]bool)
+	admin := false
 	for _, c := range sp.Process.Capabilities.Bounding {
-		caps[c] = true
-	}
-	for _, c := range sp.Process.Capabilities.Effective {
-		caps[c] = true
-	}
-	for _, c := range sp.Process.Capabilities.Inheritable {
-		caps[c] = true
-	}
-	for _, c := range sp.Process.Capabilities.Permitted {
-		caps[c] = true
-	}
-	for _, c := range sp.Process.Capabilities.Ambient {
-		caps[c] = true
-	}
-
-	for c := range caps {
 		switch c {
 		case "CAP_DAC_READ_SEARCH":
 			s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
@@ -471,6 +454,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 				Args:   []specs.LinuxSeccompArg{},
 			})
 		case "CAP_SYS_ADMIN":
+			admin = true
 			s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{
 				Names: []string{
 					"bpf",
@@ -558,7 +542,7 @@ func DefaultProfile(sp *specs.Spec) *specs.LinuxSeccomp {
 		}
 	}
 
-	if !caps["CAP_SYS_ADMIN"] {
+	if !admin {
 		switch runtime.GOARCH {
 		case "s390", "s390x":
 			s.Syscalls = append(s.Syscalls, specs.LinuxSyscall{

--- a/vendor/github.com/containerd/containerd/image.go
+++ b/vendor/github.com/containerd/containerd/image.go
@@ -25,7 +25,6 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/rootfs"
-	"github.com/containerd/containerd/snapshots"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -124,13 +123,23 @@ func (i *image) Unpack(ctx context.Context, snapshotterName string) error {
 		unpacked bool
 	)
 	for _, layer := range layers {
-		labels := map[string]string{
-			"containerd.io/uncompressed": layer.Diff.Digest.String(),
-		}
-
-		unpacked, err = rootfs.ApplyLayer(ctx, layer, chain, sn, a, snapshots.WithLabels(labels))
+		unpacked, err = rootfs.ApplyLayer(ctx, layer, chain, sn, a)
 		if err != nil {
 			return err
+		}
+
+		if unpacked {
+			// Set the uncompressed label after the uncompressed
+			// digest has been verified through apply.
+			cinfo := content.Info{
+				Digest: layer.Blob.Digest,
+				Labels: map[string]string{
+					"containerd.io/uncompressed": layer.Diff.Digest.String(),
+				},
+			}
+			if _, err := cs.Update(ctx, cinfo, "labels.containerd.io/uncompressed"); err != nil {
+				return err
+			}
 		}
 
 		chain = append(chain, layer.Diff.Digest)

--- a/vendor/github.com/containerd/containerd/linux/shim/client/client.go
+++ b/vendor/github.com/containerd/containerd/linux/shim/client/client.go
@@ -145,7 +145,7 @@ func newCommand(binary, daemonAddress string, debug bool, config shim.Config, so
 
 func newSocket(address string) (*net.UnixListener, error) {
 	if len(address) > 106 {
-		return nil, errors.Errorf("%q: unix socket path too long (limit 106)", address)
+		return nil, errors.Errorf("%q: unix socket path too long (> 106)", address)
 	}
 	l, err := net.Listen("unix", "\x00"+address)
 	if err != nil {

--- a/vendor/github.com/containerd/containerd/sys/socket_unix.go
+++ b/vendor/github.com/containerd/containerd/sys/socket_unix.go
@@ -23,11 +23,16 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
 // CreateUnixSocket creates a unix socket and returns the listener
 func CreateUnixSocket(path string) (net.Listener, error) {
+	// BSDs have a 104 limit
+	if len(path) > 104 {
+		return nil, errors.Errorf("%q: unix socket path too long (> 106)", path)
+	}
 	if err := os.MkdirAll(filepath.Dir(path), 0660); err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/containerd/containerd/vendor.conf
+++ b/vendor/github.com/containerd/containerd/vendor.conf
@@ -76,9 +76,9 @@ k8s.io/kubernetes v1.10.0-rc.1
 k8s.io/utils 258e2a2fa64568210fbd6267cf1d8fd87c3cb86e
 
 # zfs dependencies
-github.com/containerd/zfs 2e6f60521b5690bf2f265c416a42b251c2a3ec8e
+github.com/containerd/zfs 9a0b8b8b5982014b729cd34eb7cd7a11062aa6ec
 github.com/mistifyio/go-zfs 166add352731e515512690329794ee593f1aaff2
 github.com/pborman/uuid c65b2f87fee37d1c7854c9164a450713c28d50cd
 
 # aufs dependencies
-github.com/containerd/aufs 049ef88d84c1f49e52479d9f5f10d6756dd03a8b
+github.com/containerd/aufs a7fbd554da7a9eafbe5a460a421313a9fd18d988


### PR DESCRIPTION
Based on https://github.com/containerd/containerd/pull/2257.

`RunAsGroup` is added in Kubernetes 1.10 https://github.com/kubernetes/kubernetes/pull/52077. We should support it.

Please hold this PR until I add CRI validation test. https://github.com/kubernetes-incubator/cri-tools/issues/280

Signed-off-by: Lantao Liu <lantaol@google.com>