### PR TITLE
Drop libapparmor dependency from build docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ install:
     - sudo apt-get install btrfs-tools
     - sudo apt-get install libseccomp2/trusty-backports
     - sudo apt-get install libseccomp-dev/trusty-backports
-    - sudo apt-get install libapparmor-dev
     - sudo apt-get install socat
     - docker run --rm -v /usr/local/bin:/target jpetazzo/nsenter
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ specifications as appropriate.
 * **libseccomp development library.** Required by `cri` and runc seccomp support. `libseccomp-dev` (Ubuntu, Debian) / `libseccomp-devel`
 (Fedora, CentOS, RHEL). On releases of Ubuntu <=Trusty and Debian <=jessie a
 backport version of `libseccomp-dev` is required. See [travis.yml](.travis.yml) for an example on trusty.
-* **libapparmor development library.** Required by `cri` and runc apparmor support. To use apparmor on Debian, Ubuntu, and related distributions the installation of `libapparmor-dev` is required.
 * **btrfs development library.** Required by containerd btrfs support. `btrfs-tools`(Ubuntu, Debian) / `btrfs-progs-devel`(Fedora, CentOS, RHEL)
 2. Install other dependencies:
 * **`nsenter`**: Required by portforward.
@@ -102,7 +101,7 @@ make BUILD_TAGS='seccomp apparmor'
 |-----------|------------------------------------|---------------------------------|
 | seccomp   | syscall filtering                  | libseccomp development library  |
 | selinux   | selinux process and mount labeling | <none>                          |
-| apparmor  | apparmor profile support           | libapparmor development library |
+| apparmor  | apparmor profile support           | <none>                          |
 ### Validate Your `cri` Setup
 A Kubernetes incubator project called [cri-tools](https://github.com/kubernetes-incubator/cri-tools)
 includes programs for exercising CRI implementations such as the `cri` plugin.

--- a/contrib/ansible/tasks/bootstrap_ubuntu.yaml
+++ b/contrib/ansible/tasks/bootstrap_ubuntu.yaml
@@ -8,7 +8,6 @@
       - tar
       - apt-transport-https
       - btrfs-tools
-      - libapparmor1
       - libseccomp2
       - socat
       - util-linux

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -64,15 +64,13 @@ If you have other requirements for the binaries, e.g. selinux support, another a
 The release tarball could be downloaded from the release GCS bucket https://storage.googleapis.com/cri-containerd-release/.
 
 ## Step 0: Install Dependent Libraries
-Install required libraries for seccomp and libapparmor.
+Install required library for seccomp.
 ```bash
 sudo apt-get update
 sudo apt-get install libseccomp2
-sudo apt-get install libapparmor
 ```
 Note that:
 1) If you are using Ubuntu <=Trusty or Debian <=jessie, a backported version of `libseccomp2` is needed. (See the [trusty-backports](https://packages.ubuntu.com/trusty-backports/libseccomp2) and [jessie-backports](https://packages.debian.org/jessie-backports/libseccomp2)).
-2) If your OS distro doesn't support AppArmor, please skip installing `libapparmor`, and AppArmor will be disabled.
 ## Step 1: Download Release Tarball
 Download release tarball for the `containerd` version you want to install from the GCS bucket.
 ```bash

--- a/hack/install/install-deps.sh
+++ b/hack/install/install-deps.sh
@@ -19,7 +19,6 @@
 # - libseccomp-dev(Ubuntu,Debian)/libseccomp-devel(Fedora, CentOS, RHEL). Note that
 # libseccomp in ubuntu <=trusty and debian <=jessie is not new enough, backport
 # is required.
-# - libapparmor-dev(Ubuntu,Debian)/libapparmor-devel(Fedora, CentOS, RHEL)
 # containerd:
 # - btrfs-tools(Ubuntu,Debian)/btrfs-progs-devel(Fedora, CentOS, RHEL)
 

--- a/test/build-utils.sh
+++ b/test/build-utils.sh
@@ -34,7 +34,6 @@ apt-get update
 apt-get install -y btrfs-tools
 apt-get install -y libseccomp2/jessie-backports
 apt-get install -y libseccomp-dev/jessie-backports
-apt-get install -y libapparmor-dev
 
 # PULL_REFS is from prow.
 if [ ! -z "${PULL_REFS:-""}" ]; then


### PR DESCRIPTION
As of opencontainers/runc@db093f6 runc no longer depends on libapparmor
thus libapparmor-dev no longer needs to be installed to build it or
anythind that depends on it (like containerd or cri-containerd). Adjust
the documentation accordingly.

containerd/containerd#2238 did the same for containerd.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>