### PR TITLE
adds a new flag to enable TLS support (insecure for now)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -83,6 +83,8 @@ type PluginConfig struct {
 	StatsCollectPeriod int `toml:"stats_collect_period" json:"statsCollectPeriod"`
 	// SystemdCgroup enables systemd cgroup support.
 	SystemdCgroup bool `toml:"systemd_cgroup" json:"systemdCgroup"`
+	// EnableTLSStreaming indicates to enable the TLS streaming support.
+	EnableTLSStreaming bool `toml:"enable_tls_streaming" json:"enableTLSStreaming"`
 }
 
 // Config contains all configurations for cri server.
@@ -118,6 +120,7 @@ func DefaultConfig() PluginConfig {
 		StreamServerAddress: "",
 		StreamServerPort:    "10010",
 		EnableSelinux:       false,
+		EnableTLSStreaming:  false,
 		SandboxImage:        "k8s.gcr.io/pause:3.1",
 		StatsCollectPeriod:  10,
 		SystemdCgroup:       false,

--- a/pkg/server/streaming.go
+++ b/pkg/server/streaming.go
@@ -60,13 +60,15 @@ func newStreamServer(c *criService, addr, port string) (streaming.Server, error)
 	config := streaming.DefaultConfig
 	config.Addr = net.JoinHostPort(addr, port)
 	runtime := newStreamRuntime(c)
-	tlsCert, err := newTLSCert()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to generate tls certificate for stream server")
-	}
-	config.TLSConfig = &tls.Config{
-		Certificates:       []tls.Certificate{tlsCert},
-		InsecureSkipVerify: true,
+	if c.config.EnableTLSStreaming {
+		tlsCert, err := newTLSCert()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to generate tls certificate for stream server")
+		}
+		config.TLSConfig = &tls.Config{
+			Certificates:       []tls.Certificate{tlsCert},
+			InsecureSkipVerify: true,
+		}
 	}
 	return streaming.NewServer(config, runtime)
 }


### PR DESCRIPTION
Addresses issue  #712 by disabling TLS support by default. Some clients do not support insecure TLS.


Signed-off-by: Mike Brown <brownwm@us.ibm.com>