### PR TITLE
Enable TLS streaming in all the setup.

### DIFF
--- a/cluster/gce/cloud-init/master.yaml
+++ b/cluster/gce/cloud-init/master.yaml
@@ -34,6 +34,8 @@ write_files:
         shim = "/home/containerd/usr/local/bin/containerd-shim"
         runtime = "/home/containerd/usr/local/sbin/runc"
 
+      [plugins.cri]
+        enable_tls_streaming = true
       [plugins.cri.cni]
         bin_dir = "/home/containerd/opt/cni/bin"
         conf_dir = "/home/containerd/etc/cni/net.d"

--- a/cluster/gce/cloud-init/node.yaml
+++ b/cluster/gce/cloud-init/node.yaml
@@ -32,6 +32,8 @@ write_files:
         shim = "/home/containerd/usr/local/bin/containerd-shim"
         runtime = "/home/containerd/usr/local/sbin/runc"
 
+      [plugins.cri]
+        enable_tls_streaming = true
       [plugins.cri.cni]
         bin_dir = "/home/kubernetes/bin"
         conf_dir = "/etc/cni/net.d"

--- a/contrib/ansible/cri-containerd.yaml
+++ b/contrib/ansible/cri-containerd.yaml
@@ -13,6 +13,14 @@
     - name: "Create a directory for containerd config"
       file: path=/etc/containerd state=directory
 
+    - name: "Add containerd config file"
+      blockinfile:
+        path: /etc/containerd/config.toml
+        create: yes
+        block: |
+          [plugins.cri]
+            enable_tls_streaming = true
+
     - name: "Start Containerd"
       systemd: name=containerd daemon_reload=yes state=started enabled=yes
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -24,6 +24,9 @@ The explanation and default value of each configuration item are as follows:
   # systemd_cgroup enables systemd cgroup support.
   systemd_cgroup = false
 
+  # enable_tls_streaming enables the TLS streaming support.
+  enable_tls_streaming = false
+
   # "plugins.cri.containerd" contains config related to containerd
   [plugins.cri.containerd]
 

--- a/test/e2e_node/init.yaml
+++ b/test/e2e_node/init.yaml
@@ -31,6 +31,8 @@ write_files:
         shim = "/home/containerd/usr/local/bin/containerd-shim"
         runtime = "/home/containerd/usr/local/sbin/runc"
 
+      [plugins.cri]
+        enable_tls_streaming = true
       [plugins.cri.cni]
         bin_dir = "/home/containerd/opt/cni/bin"
         conf_dir = "/home/containerd/etc/cni/net.d"


### PR DESCRIPTION
Enable it in all the setup. We don't enable it by default, because we don't know whether it works for other setup. But we are confident that it works for all our supported setup.

We can switch the default in the future.

Signed-off-by: Lantao Liu <lantaol@google.com>