### PR TITLE
Add socat back.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
     - sudo apt-get install btrfs-tools
     - sudo apt-get install libseccomp2/trusty-backports
     - sudo apt-get install libseccomp-dev/trusty-backports
+    - sudo apt-get install socat
 
 before_script:
     - export PATH=$HOME/gopath/bin:$PATH

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ specifications as appropriate.
 (Fedora, CentOS, RHEL). On releases of Ubuntu <=Trusty and Debian <=jessie a
 backport version of `libseccomp-dev` is required. See [travis.yml](.travis.yml) for an example on trusty.
 * **btrfs development library.** Required by containerd btrfs support. `btrfs-tools`(Ubuntu, Debian) / `btrfs-progs-devel`(Fedora, CentOS, RHEL)
+2. Install **`socat`** (required by portforward).
 2. Install and setup a go 1.10 development environment.
 3. Make a local clone of this repository.
 4. Install binary dependencies by running the following command from your cloned `cri/` project directory:

--- a/contrib/ansible/tasks/bootstrap_centos.yaml
+++ b/contrib/ansible/tasks/bootstrap_centos.yaml
@@ -8,5 +8,6 @@
     - tar
     - btrfs-progs
     - libseccomp
-    - util-linux 
+    - util-linux
+    - socat
     - libselinux-python

--- a/contrib/ansible/tasks/bootstrap_ubuntu.yaml
+++ b/contrib/ansible/tasks/bootstrap_ubuntu.yaml
@@ -9,4 +9,5 @@
       - apt-transport-https
       - btrfs-tools
       - libseccomp2
+      - socat
       - util-linux


### PR DESCRIPTION
`io.Copy` doesn't work for us. The main problem is that:
1) When one side (either pod side or user side) of portforward is closed, we should stop port forwarding.
2) When one side is closed, the `io.Copy` use that side as source will close, but the `io.Copy` use that side as dest won't. (`io.Copy` doesn't stop when dest is closed until there is new input from source)
3) However, we can't simply forcibly stop the hanging `io.Copy` by closing the source. Because TCP is bi-direction, even though one direction is closed (we know because one `io.Copy` stops), the other direction may not, and that `io.Copy` might be working. There is no way for us to know it now.

There should be some solution for this problem, and socat must have implemented that. We need more time to investigate it.

So let's switch back to `socat` for this release.

@abhi

Signed-off-by: Lantao Liu <lantaol@google.com>