### PR TITLE
start tracking golang updates for 1.10.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
         - make install.tools
         - make .gitvalidation
         - make binaries
-      go: "1.10"
+      go: "1.10.x"
     - stage: Test
       script:
         - make install.deps
@@ -46,4 +46,4 @@ jobs:
         # Abuse travis to preserve the log.
         - cat /tmp/test-integration/containerd.log
         - cat /tmp/test-cri/containerd.log
-      go: "1.10"
+      go: "1.10.x"


### PR DESCRIPTION
It's time to start tracking point release updates for golang See: https://github.com/containerd/containerd/commit/37765fbde5b297b81bba2d1306f9abc84e8f775d


Signed-off-by: Mike Brown <brownwm@us.ibm.com>