### PR TITLE
Change node e2e to use cni template.

### DIFF
--- a/test/e2e_node/init.yaml
+++ b/test/e2e_node/init.yaml
@@ -35,7 +35,8 @@ write_files:
         enable_tls_streaming = true
       [plugins.cri.cni]
         bin_dir = "/home/containerd/opt/cni/bin"
-        conf_dir = "/home/containerd/etc/cni/net.d"
+        conf_dir = "/etc/cni/net.d"
+        conf_template = "/home/containerd/opt/containerd/cluster/gce/cni.template"
       [plugins.cri.registry.mirrors."docker.io"]
         endpoint = ["https://mirror.gcr.io","https://registry-1.docker.io"]
 


### PR DESCRIPTION
Node e2e should also use cni template.

Signed-off-by: Lantao Liu <lantaol@google.com>