### PR TITLE
Add KUBE_CONTAINER_RUNTIME_NAME to fix fluentd support.

### DIFF
--- a/cluster/gce/env
+++ b/cluster/gce/env
@@ -12,6 +12,7 @@ export KUBE_MASTER_EXTRA_METADATA="user-data=${GCE_DIR}/cloud-init/master.yaml,c
 export KUBE_NODE_EXTRA_METADATA="user-data=${GCE_DIR}/cloud-init/node.yaml,containerd-configure-sh=${GCE_DIR}/configure.sh,containerd-env=${version_file}"
 export KUBE_CONTAINER_RUNTIME="remote"
 export KUBE_CONTAINER_RUNTIME_ENDPOINT="/run/containerd/containerd.sock"
+export KUBE_CONTAINER_RUNTIME_NAME=containerd
 export KUBE_LOAD_IMAGE_COMMAND="/home/containerd/usr/local/bin/ctr cri load"
 export NETWORK_PROVIDER=""
 export NON_MASQUERADE_CIDR="0.0.0.0/0"


### PR DESCRIPTION
This was missed. This is needed for fluentd support. See https://github.com/kubernetes/kubernetes/blob/master/cluster/gce/gci/configure-helper.sh#L2087.

Signed-off-by: Lantao Liu <lantaol@google.com>