### PR TITLE
Add `unix://` prefix for socket addresses used by CRI remote client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ sudo containerd
 ```
 2. From the Kubernetes project directory startup a local cluster using `containerd`:
 ```bash
-CONTAINER_RUNTIME=remote CONTAINER_RUNTIME_ENDPOINT='/run/containerd/containerd.sock' ./hack/local-up-cluster.sh
+CONTAINER_RUNTIME=remote CONTAINER_RUNTIME_ENDPOINT='unix:///run/containerd/containerd.sock' ./hack/local-up-cluster.sh
 ```
 ### Test
 See [here](./docs/testing.md) for information about test.

--- a/cluster/gce/env
+++ b/cluster/gce/env
@@ -11,7 +11,7 @@ fi
 export KUBE_MASTER_EXTRA_METADATA="user-data=${GCE_DIR}/cloud-init/master.yaml,containerd-configure-sh=${GCE_DIR}/configure.sh,containerd-env=${version_file}"
 export KUBE_NODE_EXTRA_METADATA="user-data=${GCE_DIR}/cloud-init/node.yaml,containerd-configure-sh=${GCE_DIR}/configure.sh,containerd-env=${version_file}"
 export KUBE_CONTAINER_RUNTIME="remote"
-export KUBE_CONTAINER_RUNTIME_ENDPOINT="/run/containerd/containerd.sock"
+export KUBE_CONTAINER_RUNTIME_ENDPOINT="unix:///run/containerd/containerd.sock"
 export KUBE_CONTAINER_RUNTIME_NAME=containerd
 export KUBE_LOAD_IMAGE_COMMAND="/home/containerd/usr/local/bin/ctr cri load"
 export NETWORK_PROVIDER=""

--- a/contrib/ansible/cri-containerd.yaml
+++ b/contrib/ansible/cri-containerd.yaml
@@ -46,7 +46,7 @@
     - name: "Add runtime args in kubelet conf"
       lineinfile:
         dest: "/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
-        line: "Environment=\"KUBELET_EXTRA_ARGS= --runtime-cgroups=/system.slice/containerd.service --container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=/run/containerd/containerd.sock\""
+        line: "Environment=\"KUBELET_EXTRA_ARGS= --runtime-cgroups=/system.slice/containerd.service --container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock\""
         insertafter: '\[Service\]'
       when: check_args.stdout == ""
     
@@ -57,5 +57,5 @@
     - name: "Pre-pull pause container image"
       shell: |
         /usr/local/bin/ctr pull k8s.gcr.io/pause:3.1
-        /usr/local/bin/crictl --runtime-endpoint /run/containerd/containerd.sock \
+        /usr/local/bin/crictl --runtime-endpoint unix:///run/containerd/containerd.sock \
         pull k8s.gcr.io/pause:3.1

--- a/docs/crictl.md
+++ b/docs/crictl.md
@@ -22,8 +22,8 @@ so you don't have to repeatedly specify the runtime sock used to connect crictl
 to the container runtime:
 ```console
 $ cat /etc/crictl.yaml
-runtime-endpoint: /run/containerd/containerd.sock
-image-endpoint: /run/containerd/containerd.sock
+runtime-endpoint: unix:///run/containerd/containerd.sock
+image-endpoint: unix:///run/containerd/containerd.sock
 timeout: 10
 debug: true
 ```
@@ -188,7 +188,7 @@ $ crictl info
     "sandboxImage": "k8s.gcr.io/pause:3.1",
     "statsCollectPeriod": 10,
     "containerdRootDir": "/var/lib/containerd",
-    "containerdEndpoint": "/run/containerd/containerd.sock",
+    "containerdEndpoint": "unix:///run/containerd/containerd.sock",
     "rootDir": "/var/lib/containerd/io.containerd.grpc.v1.cri",
     "stateDir": "/run/containerd/io.containerd.grpc.v1.cri",
   },

--- a/hack/install/install-critools.sh
+++ b/hack/install/install-critools.sh
@@ -33,7 +33,7 @@ make
 ${SUDO} make install -e BINDIR=${CRITOOL_DIR} GOPATH=${GOPATH}
 ${SUDO} mkdir -p ${CRICTL_CONFIG_DIR}
 ${SUDO} bash -c 'cat >'${CRICTL_CONFIG_DIR}'/crictl.yaml <<EOF
-runtime-endpoint: /run/containerd/containerd.sock
+runtime-endpoint: unix:///run/containerd/containerd.sock
 EOF'
 
 # Clean the tmp GOPATH dir.

--- a/hack/test-utils.sh
+++ b/hack/test-utils.sh
@@ -27,7 +27,7 @@ if [ -f "${CONTAINERD_CONFIG_FILE}" ]; then
   CONTAINERD_FLAGS+="--config ${CONTAINERD_CONFIG_FILE} "
 fi
 
-CONTAINERD_SOCK=/run/containerd/containerd.sock
+CONTAINERD_SOCK=unix:///run/containerd/containerd.sock
 
 containerd_pid=
 

--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -17,7 +17,7 @@
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
 
 # Not from vendor.conf.
-CRITOOL_VERSION=db53d78569a8116fff1f60366a8de3130e767eeb
+CRITOOL_VERSION=f37a5a1edb69ee742c6e42c57413fe6b63788085
 CRITOOL_PKG=github.com/kubernetes-incubator/cri-tools
 CRITOOL_REPO=github.com/kubernetes-incubator/cri-tools
 

--- a/integration/test_utils.go
+++ b/integration/test_utils.go
@@ -51,7 +51,7 @@ var (
 	criPluginClient  api.CRIPluginServiceClient
 )
 
-var criEndpoint = flag.String("cri-endpoint", "/run/containerd/containerd.sock", "The endpoint of cri plugin.")
+var criEndpoint = flag.String("cri-endpoint", "unix:///run/containerd/containerd.sock", "The endpoint of cri plugin.")
 var criRoot = flag.String("cri-root", "/var/lib/containerd/io.containerd.grpc.v1.cri", "The root directory of cri plugin.")
 
 func init() {


### PR DESCRIPTION
Kubelet and `crictl` prefers socket address with `unix://` prefix, or else it prints out warning. https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/util/util_unix.go#L75

For example:
```
# crictl ps
W0420 17:20:40.130286  237131 util_unix.go:75] Using "/run/containerd/containerd.sock" as endpoint is deprecated, please consider using full url format "unix:///run/containerd/containerd.sock".
CONTAINER ID        IMAGE               CREATED             STATE               NAME                ATTEMPT
```

This PR adds `unix://` prefix to all containerd socket addresses except the ones passed to containerd client, because containerd client doesn't work with the `unix://` prefix.

Signed-off-by: Lantao Liu <lantaol@google.com>