### PR TITLE
Download containerd binaries from official release.

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -19,9 +19,9 @@ Publish the release tarball `cri-containerd-${CONTAINERD_VERSION}.${OS}-${ARCH}.
 git checkout ${RELEASE_VERSION}
 
 # Publish the release tarball without cni.
-DEPLOY_BUCKET=cri-containerd-release make push TARBALL_PREFIX=cri-containerd VERSION=${CONTAINERD_VERSION}
+DEPLOY_BUCKET=cri-containerd-release make push TARBALL_PREFIX=cri-containerd OFFICIAL_RELEASE=true VERSION=${CONTAINERD_VERSION}
 
 # Publish the release tarball with cni.
-DEPLOY_BUCKET=cri-containerd-release make push TARBALL_PREFIX=cri-containerd-cni INCLUDE_CNI=true VERSION=${CONTAINERD_VERSION}
+DEPLOY_BUCKET=cri-containerd-release make push TARBALL_PREFIX=cri-containerd-cni OFFICIAL_RELEASE=true INCLUDE_CNI=true VERSION=${CONTAINERD_VERSION}
 ```
 ## Step 6: Update release note with release tarball information

--- a/hack/install/install-deps.sh
+++ b/hack/install/install-deps.sh
@@ -28,27 +28,14 @@ set -o pipefail
 
 cd $(dirname "${BASH_SOURCE[0]}")
 
-# INSTALL_CNI indicates whether to install CNI. CNI installation
-# makes sense for local testing, but doesn't make sense for cluster
-# setup, because CNI daemonset is usually used to deploy CNI binaries
-# and configurations in cluster.
-INSTALL_CNI=${INSTALL_CNI:-true}
-
-# INSTALL_CNI indicates whether to install CNI config.
-INSTALL_CNI_CONFIG=${INSTALL_CNI_CONFIG:-true}
-
 # Install runc
 ./install-runc.sh
 
 # Install cni
-if ${INSTALL_CNI}; then
-  ./install-cni.sh
-fi
+./install-cni.sh
 
 # Install cni config
-if ${INSTALL_CNI_CONFIG}; then
-  ./install-cni-config.sh
-fi
+./install-cni-config.sh
 
 # Install containerd
 ./install-containerd.sh


### PR DESCRIPTION
Fixes #737.

I've uploaded 1.1.0 release tarballs, and updated the release note https://github.com/containerd/containerd/releases/tag/v1.1.0. Containerd binaries in the release tarball are downloaded from containerd github release.

Signed-off-by: Lantao Liu <lantaol@google.com>