### PR TITLE
os.Unmount: do not consult mountinfo

### DIFF
--- a/pkg/os/testing/fake_os.go
+++ b/pkg/os/testing/fake_os.go
@@ -49,7 +49,7 @@ type FakeOS struct {
 	CopyFileFn             func(string, string, os.FileMode) error
 	WriteFileFn            func(string, []byte, os.FileMode) error
 	MountFn                func(source string, target string, fstype string, flags uintptr, data string) error
-	UnmountFn              func(target string, flags int) error
+	UnmountFn              func(target string) error
 	LookupMountFn          func(path string) (containerdmount.Info, error)
 	calls                  []CalledDetail
 	errors                 map[string]error
@@ -230,14 +230,14 @@ func (f *FakeOS) Mount(source string, target string, fstype string, flags uintpt
 }
 
 // Unmount is a fake call that invokes UnmountFn or just return nil.
-func (f *FakeOS) Unmount(target string, flags int) error {
-	f.appendCalls("Unmount", target, flags)
+func (f *FakeOS) Unmount(target string) error {
+	f.appendCalls("Unmount", target)
 	if err := f.getError("Unmount"); err != nil {
 		return err
 	}
 
 	if f.UnmountFn != nil {
-		return f.UnmountFn(target, flags)
+		return f.UnmountFn(target)
 	}
 	return nil
 }

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -494,16 +494,14 @@ func parseDNSOptions(servers, searches, options []string) (string, error) {
 }
 
 // unmountSandboxFiles unmount some sandbox files, we rely on the removal of sandbox root directory to
-// remove these files. Unmount should *NOT* return error when:
-//  1) The mount point is already unmounted.
-//  2) The mount point doesn't exist.
+// remove these files. Unmount should *NOT* return error if the mount point is already unmounted.
 func (c *criService) unmountSandboxFiles(id string, config *runtime.PodSandboxConfig) error {
 	if config.GetLinux().GetSecurityContext().GetNamespaceOptions().GetIpc() != runtime.NamespaceMode_NODE {
 		path, err := c.os.FollowSymlinkInScope(c.getSandboxDevShm(id), "/")
 		if err != nil {
 			return errors.Wrap(err, "failed to follow symlink")
 		}
-		if err := c.os.Unmount(path, unix.MNT_DETACH); err != nil && !os.IsNotExist(err) {
+		if err := c.os.Unmount(path); err != nil && !os.IsNotExist(err) {
 			return errors.Wrapf(err, "failed to unmount %q", path)
 		}
 	}

--- a/pkg/store/sandbox/netns.go
+++ b/pkg/store/sandbox/netns.go
@@ -23,7 +23,6 @@ import (
 	cnins "github.com/containernetworking/plugins/pkg/ns"
 	"github.com/docker/docker/pkg/symlink"
 	"github.com/pkg/errors"
-	"golang.org/x/sys/unix"
 
 	osinterface "github.com/containerd/cri/pkg/os"
 )
@@ -93,7 +92,7 @@ func (n *NetNS) Remove() error {
 		if err != nil {
 			return errors.Wrap(err, "failed to follow symlink")
 		}
-		if err := osinterface.Unmount(path, unix.MNT_DETACH); err != nil && !os.IsNotExist(err) {
+		if err := osinterface.Unmount(path); err != nil && !os.IsNotExist(err) {
 			return errors.Wrap(err, "failed to umount netns")
 		}
 		if err := os.RemoveAll(path); err != nil {


### PR DESCRIPTION
Currently, Unmount() call takes a burden to parse the whole nine yards of /proc/self/mountinfo to figure out whether the given mount point is mounted or not (and returns an error in case parsing fails somehow).

Instead, let's just call umount() and ignore EINVAL, which results in the same behavior, but much better performance.

Note that EINVAL is returned from umount(2) not only in the case when target is not mounted, but also for invalid flags. To avoid ignoring a valid error, the check for valid flags is added.

Note that MNT_EXPIRE is not allowed as it requires a special handling.

While at it, remove the 'containerdmount' alias from the package.