### PR TITLE
Update cri-tools to fix `crictl logs` output.

### DIFF
--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -17,7 +17,7 @@
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
 
 # Not from vendor.conf.
-CRITOOL_VERSION=f37a5a1edb69ee742c6e42c57413fe6b63788085
+CRITOOL_VERSION=34ce008eb986641743a1230b4800a74f6829ecbb
 CRITOOL_PKG=github.com/kubernetes-incubator/cri-tools
 CRITOOL_REPO=github.com/kubernetes-incubator/cri-tools
 


### PR DESCRIPTION
See: https://github.com/kubernetes-incubator/cri-tools/pull/293

Update cri-tools to fix `crictl logs` output issue.

Signed-off-by: Lantao Liu <lantaol@google.com>