### PR TITLE
Use crictl installed in kube-up.sh

### DIFF
--- a/cluster/gce/cloud-init/master.yaml
+++ b/cluster/gce/cloud-init/master.yaml
@@ -51,25 +51,6 @@ write_files:
       [Install]
       WantedBy=containerd.target
 
-  - path: /etc/systemd/system/containerd-monitor.service
-    permissions: 0644
-    owner: root
-    content: |
-      [Unit]
-      Description=Kubernetes health monitoring for containerd
-      After=containerd.service
-
-      [Service]
-      Restart=always
-      RestartSec=10
-      RemainAfterExit=yes
-      ExecStartPre=/bin/chmod 544 /home/containerd/opt/containerd/cluster/health-monitor.sh
-      ExecStart=/bin/bash -c 'CRICTL=/home/containerd/usr/local/bin/crictl \
-      /home/containerd/opt/containerd/cluster/health-monitor.sh'
-
-      [Install]
-      WantedBy=containerd.target
-
   - path: /etc/systemd/system/containerd.target
     permissions: 0644
     owner: root
@@ -116,6 +97,23 @@ write_files:
       ExecStartPre=/bin/chmod 544 /home/kubernetes/bin/configure-helper.sh
       ExecStart=/home/kubernetes/bin/configure-helper.sh
 
+      [Install]
+      WantedBy=kubernetes.target
+
+  - path: /etc/systemd/system/kube-container-runtime-monitor.service
+    permissions: 0644
+    owner: root
+    content: |
+      [Unit]
+      Description=Kubernetes health monitoring for container runtime
+      After=kube-master-configuration.service
+      [Service]
+      Restart=always
+      RestartSec=10
+      RemainAfterExit=yes
+      RemainAfterExit=yes
+      ExecStartPre=/bin/chmod 544 /home/kubernetes/bin/health-monitor.sh
+      ExecStart=/home/kubernetes/bin/health-monitor.sh container-runtime
       [Install]
       WantedBy=kubernetes.target
 

--- a/cluster/gce/cloud-init/node.yaml
+++ b/cluster/gce/cloud-init/node.yaml
@@ -51,25 +51,6 @@ write_files:
       [Install]
       WantedBy=containerd.target
 
-  - path: /etc/systemd/system/containerd-monitor.service
-    permissions: 0644
-    owner: root
-    content: |
-      [Unit]
-      Description=Kubernetes health monitoring for containerd
-      After=containerd.service
-
-      [Service]
-      Restart=always
-      RestartSec=10
-      RemainAfterExit=yes
-      ExecStartPre=/bin/chmod 544 /home/containerd/opt/containerd/cluster/health-monitor.sh
-      ExecStart=/bin/bash -c 'CRICTL=/home/containerd/usr/local/bin/crictl \
-      /home/containerd/opt/containerd/cluster/health-monitor.sh'
-
-      [Install]
-      WantedBy=containerd.target
-
   - path: /etc/systemd/system/containerd.target
     permissions: 0644
     owner: root
@@ -116,6 +97,23 @@ write_files:
       ExecStartPre=/bin/chmod 544 /home/kubernetes/bin/configure-helper.sh
       ExecStart=/home/kubernetes/bin/configure-helper.sh
 
+      [Install]
+      WantedBy=kubernetes.target
+
+  - path: /etc/systemd/system/kube-container-runtime-monitor.service
+    permissions: 0644
+    owner: root
+    content: |
+      [Unit]
+      Description=Kubernetes health monitoring for container runtime
+      After=kube-node-configuration.service
+      [Service]
+      Restart=always
+      RestartSec=10
+      RemainAfterExit=yes
+      RemainAfterExit=yes
+      ExecStartPre=/bin/chmod 544 /home/kubernetes/bin/health-monitor.sh
+      ExecStart=/home/kubernetes/bin/health-monitor.sh container-runtime
       [Install]
       WantedBy=kubernetes.target
 

--- a/cluster/gce/configure.sh
+++ b/cluster/gce/configure.sh
@@ -133,13 +133,13 @@ else
     # Download and untar the release tar ball.
     curl -f --ipv4 -Lo "${TARBALL}" --connect-timeout 20 --max-time 300 --retry 6 --retry-delay 10 "${TARBALL_GCS_PATH}"
     tar xvf "${TARBALL}"
+    # Use crictl installed by kube-up.sh.
+    # TODO(random-liu): Create release tarball for GCE, and do not package crictl.
+    rm "${CONTAINERD_HOME}/usr/local/bin/crictl"
+    rm "${CONTAINERD_HOME}/etc/crictl.yaml"
     rm -f "${TARBALL}"
   fi
 fi
-
-# Configure containerd.
-# Copy crictl config.
-cp "${CONTAINERD_HOME}/etc/crictl.yaml" /etc
 
 # Generate containerd config
 config_path="${CONTAINERD_CONFIG_PATH:-"/etc/containerd/config.toml"}"

--- a/cluster/health-monitor.sh
+++ b/cluster/health-monitor.sh
@@ -17,6 +17,10 @@
 set -o nounset
 set -o pipefail
 
+# TODO(#780): This file is not used by kube-up.sh on
+# GCE anymore. We'll get rid of this file in 1.12 release.
+# Please stop relying on this script if you are.
+
 # CRICTL is the path of crictl
 CRICTL=${CRICTL:-"crictl"}
 # INITIAL_WAIT_ATTEMPTS is the number to attempt, before start


### PR DESCRIPTION
Depends on https://github.com/kubernetes/kubernetes/pull/63357.

kube-up.sh will install crictl on GCE. We don't need to install it our own.

Signed-off-by: Lantao Liu <lantaol@google.com>