### PR TITLE
Add log max size

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -27,6 +27,11 @@ The explanation and default value of each configuration item are as follows:
   # enable_tls_streaming enables the TLS streaming support.
   enable_tls_streaming = false
 
+  # max_container_log_line_size is the maximum log line size in bytes for a container.
+  # Log line longer than the limit will be split into multiple lines. -1 means no
+  # limit.
+  max_container_log_line_size = 16384
+
   # "plugins.cri.containerd" contains config related to containerd
   [plugins.cri.containerd]
 

--- a/integration/container_log_test.go
+++ b/integration/container_log_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2018 The containerd Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
+)
+
+func TestLongContainerLog(t *testing.T) {
+	testPodLogDir, err := ioutil.TempDir("/tmp", "long-container-log")
+	require.NoError(t, err)
+	defer os.RemoveAll(testPodLogDir)
+
+	t.Log("Create a sandbox with log directory")
+	sbConfig := PodSandboxConfig("sandbox", "long-container-log",
+		WithPodLogDirectory(testPodLogDir),
+	)
+	sb, err := runtimeService.RunPodSandbox(sbConfig)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, runtimeService.StopPodSandbox(sb))
+		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
+	}()
+
+	const (
+		testImage     = "busybox"
+		containerName = "test-container"
+	)
+	t.Logf("Pull test image %q", testImage)
+	img, err := imageService.PullImage(&runtime.ImageSpec{Image: testImage}, nil)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, imageService.RemoveImage(&runtime.ImageSpec{Image: img}))
+	}()
+
+	t.Log("Create a container with log path")
+	config, err := CRIConfig()
+	require.NoError(t, err)
+	maxSize := config.MaxContainerLogLineSize
+	shortLineCmd := fmt.Sprintf("i=0; while [ $i -lt %d ]; do printf %s; i=$((i+1)); done", maxSize-1, "a")
+	maxLenLineCmd := fmt.Sprintf("i=0; while [ $i -lt %d ]; do printf %s; i=$((i+1)); done", maxSize, "b")
+	longLineCmd := fmt.Sprintf("i=0; while [ $i -lt %d ]; do printf %s; i=$((i+1)); done", maxSize+1, "c")
+	cnConfig := ContainerConfig(
+		containerName,
+		"busybox",
+		WithCommand("sh", "-c",
+			fmt.Sprintf("%s; echo; %s; echo; %s", shortLineCmd, maxLenLineCmd, longLineCmd)),
+		WithLogPath(containerName),
+	)
+	cn, err := runtimeService.CreateContainer(sb, cnConfig, sbConfig)
+	require.NoError(t, err)
+
+	t.Log("Start the container")
+	require.NoError(t, runtimeService.StartContainer(cn))
+
+	t.Log("Wait for container to finish running")
+	require.NoError(t, Eventually(func() (bool, error) {
+		s, err := runtimeService.ContainerStatus(cn)
+		if err != nil {
+			return false, err
+		}
+		if s.GetState() == runtime.ContainerState_CONTAINER_EXITED {
+			return true, nil
+		}
+		return false, nil
+	}, time.Second, 30*time.Second))
+
+	t.Log("Check container log")
+	content, err := ioutil.ReadFile(filepath.Join(testPodLogDir, containerName))
+	assert.NoError(t, err)
+	checkContainerLog(t, string(content), []string{
+		fmt.Sprintf("%s %s %s", runtime.Stdout, runtime.LogTagFull, strings.Repeat("a", maxSize-1)),
+		fmt.Sprintf("%s %s %s", runtime.Stdout, runtime.LogTagFull, strings.Repeat("b", maxSize)),
+		fmt.Sprintf("%s %s %s", runtime.Stdout, runtime.LogTagPartial, strings.Repeat("c", maxSize)),
+		fmt.Sprintf("%s %s %s", runtime.Stdout, runtime.LogTagFull, "c"),
+	})
+}
+
+func checkContainerLog(t *testing.T, log string, messages []string) {
+	lines := strings.Split(strings.TrimSpace(log), "\n")
+	require.Len(t, lines, len(messages), "log line number should match")
+	for i, line := range lines {
+		parts := strings.SplitN(line, " ", 2)
+		require.Len(t, parts, 2)
+		_, err := time.Parse(time.RFC3339Nano, parts[0])
+		assert.NoError(t, err, "timestamp should be in RFC3339Nano format")
+		assert.Equal(t, messages[i], parts[1], "log content should match")
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -96,6 +96,10 @@ type PluginConfig struct {
 	SystemdCgroup bool `toml:"systemd_cgroup" json:"systemdCgroup"`
 	// EnableTLSStreaming indicates to enable the TLS streaming support.
 	EnableTLSStreaming bool `toml:"enable_tls_streaming" json:"enableTLSStreaming"`
+	// MaxContainerLogLineSize is the maximum log line size in bytes for a container.
+	// Log line longer than the limit will be split into multiple lines. Non-positive
+	// value means no limit.
+	MaxContainerLogLineSize int `toml:"max_container_log_line_size" json:"maxContainerLogSize"`
 }
 
 // Config contains all configurations for cri server.
@@ -129,13 +133,14 @@ func DefaultConfig() PluginConfig {
 				Root:   "",
 			},
 		},
-		StreamServerAddress: "",
-		StreamServerPort:    "10010",
-		EnableSelinux:       false,
-		EnableTLSStreaming:  false,
-		SandboxImage:        "k8s.gcr.io/pause:3.1",
-		StatsCollectPeriod:  10,
-		SystemdCgroup:       false,
+		StreamServerAddress:     "",
+		StreamServerPort:        "10010",
+		EnableSelinux:           false,
+		EnableTLSStreaming:      false,
+		SandboxImage:            "k8s.gcr.io/pause:3.1",
+		StatsCollectPeriod:      10,
+		SystemdCgroup:           false,
+		MaxContainerLogLineSize: 16 * 1024,
 		Registry: Registry{
 			Mirrors: map[string]Mirror{
 				"docker.io": {

--- a/pkg/server/container_log_reopen.go
+++ b/pkg/server/container_log_reopen.go
@@ -36,7 +36,7 @@ func (c *criService) ReopenContainerLog(ctx context.Context, r *runtime.ReopenCo
 	}
 
 	// Create new container logger and replace the existing ones.
-	stdoutWC, stderrWC, err := createContainerLoggers(container.LogPath, container.Config.GetTty())
+	stdoutWC, stderrWC, err := c.createContainerLoggers(container.LogPath, container.Config.GetTty())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/io/logger.go
+++ b/pkg/server/io/logger.go
@@ -21,10 +21,8 @@ import (
 	"bytes"
 	"io"
 	"io/ioutil"
-	"os"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
@@ -38,11 +36,8 @@ const (
 	eol = '\n'
 	// timestampFormat is the timestamp format used in CRI logging format.
 	timestampFormat = time.RFC3339Nano
-	// pipeBufSize is the system PIPE_BUF size, on linux it is 4096 bytes.
-	// POSIX.1 says that write less than PIPE_BUF is atmoic.
-	pipeBufSize = 4096
-	// bufSize is the size of the read buffer.
-	bufSize = pipeBufSize - len(timestampFormat) - len(Stdout) - len(runtime.LogTagPartial) - 3 /*3 delimiter*/ - 1 /*eol*/
+	// defaultBufSize is the default size of the read buffer in bytes.
+	defaultBufSize = 4096
 )
 
 // NewDiscardLogger creates logger which discards all the input.
@@ -51,46 +46,91 @@ func NewDiscardLogger() io.WriteCloser {
 }
 
 // NewCRILogger returns a write closer which redirect container log into
-// log file, and decorate the log line into CRI defined format.
-func NewCRILogger(path string, stream StreamType) (io.WriteCloser, error) {
-	logrus.Debugf("Start writing log file %q", path)
+// log file, and decorate the log line into CRI defined format. It also
+// returns a channel which indicates whether the logger is stopped.
+// maxLen is the max length limit of a line. A line longer than the
+// limit will be cut into multiple lines.
+func NewCRILogger(path string, w io.Writer, stream StreamType, maxLen int) (io.WriteCloser, <-chan struct{}) {
+	logrus.Debugf("Start writing stream %q to log file %q", stream, path)
 	prc, pwc := io.Pipe()
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0640)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to open log file")
-	}
-	go redirectLogs(path, prc, f, stream)
-	return pwc, nil
+	stop := make(chan struct{})
+	go func() {
+		redirectLogs(path, prc, w, stream, maxLen)
+		close(stop)
+	}()
+	return pwc, stop
 }
 
-func redirectLogs(path string, rc io.ReadCloser, wc io.WriteCloser, stream StreamType) {
+func redirectLogs(path string, rc io.ReadCloser, w io.Writer, s StreamType, maxLen int) {
 	defer rc.Close()
-	defer wc.Close()
-	streamBytes := []byte(stream)
-	delimiterBytes := []byte{delimiter}
-	partialBytes := []byte(runtime.LogTagPartial)
-	fullBytes := []byte(runtime.LogTagFull)
-	r := bufio.NewReaderSize(rc, bufSize)
-	for {
-		lineBytes, isPrefix, err := r.ReadLine()
-		if err == io.EOF {
-			logrus.Debugf("Finish redirecting log file %q", path)
-			return
-		}
-		if err != nil {
-			logrus.WithError(err).Errorf("An error occurred when redirecting log file %q", path)
-			return
-		}
-		tagBytes := fullBytes
-		if isPrefix {
-			tagBytes = partialBytes
-		}
-		timestampBytes := time.Now().AppendFormat(nil, time.RFC3339Nano)
-		data := bytes.Join([][]byte{timestampBytes, streamBytes, tagBytes, lineBytes}, delimiterBytes)
-		data = append(data, eol)
-		if _, err := wc.Write(data); err != nil {
-			logrus.WithError(err).Errorf("Fail to write %q log to log file %q", stream, path)
-		}
-		// Continue on write error to drain the input.
+	var (
+		stream    = []byte(s)
+		delimiter = []byte{delimiter}
+		partial   = []byte(runtime.LogTagPartial)
+		full      = []byte(runtime.LogTagFull)
+		buf       [][]byte
+		length    int
+		bufSize   = defaultBufSize
+	)
+	// Make sure bufSize <= maxLen
+	if maxLen > 0 && maxLen < bufSize {
+		bufSize = maxLen
 	}
+	r := bufio.NewReaderSize(rc, bufSize)
+	writeLine := func(tag, line []byte) {
+		timestamp := time.Now().AppendFormat(nil, timestampFormat)
+		data := bytes.Join([][]byte{timestamp, stream, tag, line}, delimiter)
+		data = append(data, eol)
+		if _, err := w.Write(data); err != nil {
+			logrus.WithError(err).Errorf("Fail to write %q log to log file %q", s, path)
+			// Continue on write error to drain the container output.
+		}
+	}
+	for {
+		var stop bool
+		newLine, isPrefix, err := r.ReadLine()
+		if err != nil {
+			if err == io.EOF {
+				logrus.Debugf("Getting EOF from stream %q while redirecting to log file %q", s, path)
+			} else {
+				logrus.WithError(err).Errorf("An error occurred when redirecting stream %q to log file %q", s, path)
+			}
+			if length == 0 {
+				// No content left to write, break.
+				break
+			}
+			// Stop after writing the content left in buffer.
+			stop = true
+		} else {
+			// Buffer returned by ReadLine will change after
+			// next read, copy it.
+			l := make([]byte, len(newLine))
+			copy(l, newLine)
+			buf = append(buf, l)
+			length += len(l)
+		}
+		if maxLen > 0 && length > maxLen {
+			exceedLen := length - maxLen
+			last := buf[len(buf)-1]
+			if exceedLen > len(last) {
+				// exceedLen must <= len(last), or else the buffer
+				// should have be written in the previous iteration.
+				panic("exceed length should <= last buffer size")
+			}
+			buf[len(buf)-1] = last[:len(last)-exceedLen]
+			writeLine(partial, bytes.Join(buf, nil))
+			buf = [][]byte{last[len(last)-exceedLen:]}
+			length = exceedLen
+		}
+		if isPrefix {
+			continue
+		}
+		writeLine(full, bytes.Join(buf, nil))
+		buf = nil
+		length = 0
+		if stop {
+			break
+		}
+	}
+	logrus.Debugf("Finish redirecting stream %q to log file %q", s, path)
 }

--- a/pkg/server/io/logger_test.go
+++ b/pkg/server/io/logger_test.go
@@ -31,15 +31,19 @@ import (
 )
 
 func TestRedirectLogs(t *testing.T) {
+	// defaultBufSize is even number
+	const maxLen = defaultBufSize * 4
 	for desc, test := range map[string]struct {
 		input   string
 		stream  StreamType
+		maxLen  int
 		tag     []runtime.LogTag
 		content []string
 	}{
 		"stdout log": {
-			input:  "test stdout log 1\ntest stdout log 2",
+			input:  "test stdout log 1\ntest stdout log 2\n",
 			stream: Stdout,
+			maxLen: maxLen,
 			tag: []runtime.LogTag{
 				runtime.LogTagFull,
 				runtime.LogTagFull,
@@ -50,8 +54,9 @@ func TestRedirectLogs(t *testing.T) {
 			},
 		},
 		"stderr log": {
-			input:  "test stderr log 1\ntest stderr log 2",
+			input:  "test stderr log 1\ntest stderr log 2\n",
 			stream: Stderr,
+			maxLen: maxLen,
 			tag: []runtime.LogTag{
 				runtime.LogTagFull,
 				runtime.LogTagFull,
@@ -61,18 +66,160 @@ func TestRedirectLogs(t *testing.T) {
 				"test stderr log 2",
 			},
 		},
-		"long log": {
-			input:  strings.Repeat("a", 2*bufSize+10) + "\n",
-			stream: Stdout,
+		"log ends without newline": {
+			input:  "test stderr log 1\ntest stderr log 2",
+			stream: Stderr,
+			maxLen: maxLen,
 			tag: []runtime.LogTag{
+				runtime.LogTagFull,
+				runtime.LogTagFull,
+			},
+			content: []string{
+				"test stderr log 1",
+				"test stderr log 2",
+			},
+		},
+		"log length equal to buffer size": {
+			input:  strings.Repeat("a", defaultBufSize) + "\n" + strings.Repeat("a", defaultBufSize) + "\n",
+			stream: Stdout,
+			maxLen: maxLen,
+			tag: []runtime.LogTag{
+				runtime.LogTagFull,
+				runtime.LogTagFull,
+			},
+			content: []string{
+				strings.Repeat("a", defaultBufSize),
+				strings.Repeat("a", defaultBufSize),
+			},
+		},
+		"log length longer than buffer size": {
+			input:  strings.Repeat("a", defaultBufSize*2+10) + "\n" + strings.Repeat("a", defaultBufSize*2+20) + "\n",
+			stream: Stdout,
+			maxLen: maxLen,
+			tag: []runtime.LogTag{
+				runtime.LogTagFull,
+				runtime.LogTagFull,
+			},
+			content: []string{
+				strings.Repeat("a", defaultBufSize*2+10),
+				strings.Repeat("a", defaultBufSize*2+20),
+			},
+		},
+		"log length equal to max length": {
+			input:  strings.Repeat("a", maxLen) + "\n" + strings.Repeat("a", maxLen) + "\n",
+			stream: Stdout,
+			maxLen: maxLen,
+			tag: []runtime.LogTag{
+				runtime.LogTagFull,
+				runtime.LogTagFull,
+			},
+			content: []string{
+				strings.Repeat("a", maxLen),
+				strings.Repeat("a", maxLen),
+			},
+		},
+		"log length exceed max length by 1": {
+			input:  strings.Repeat("a", maxLen+1) + "\n" + strings.Repeat("a", maxLen+1) + "\n",
+			stream: Stdout,
+			maxLen: maxLen,
+			tag: []runtime.LogTag{
+				runtime.LogTagPartial,
+				runtime.LogTagFull,
+				runtime.LogTagPartial,
+				runtime.LogTagFull,
+			},
+			content: []string{
+				strings.Repeat("a", maxLen),
+				"a",
+				strings.Repeat("a", maxLen),
+				"a",
+			},
+		},
+		"log length longer than max length": {
+			input:  strings.Repeat("a", maxLen*2) + "\n" + strings.Repeat("a", maxLen*2+1) + "\n",
+			stream: Stdout,
+			maxLen: maxLen,
+			tag: []runtime.LogTag{
+				runtime.LogTagPartial,
+				runtime.LogTagFull,
 				runtime.LogTagPartial,
 				runtime.LogTagPartial,
 				runtime.LogTagFull,
 			},
 			content: []string{
-				strings.Repeat("a", bufSize),
-				strings.Repeat("a", bufSize),
+				strings.Repeat("a", maxLen),
+				strings.Repeat("a", maxLen),
+				strings.Repeat("a", maxLen),
+				strings.Repeat("a", maxLen),
+				"a",
+			},
+		},
+		"max length shorter than buffer size": {
+			input:  strings.Repeat("a", defaultBufSize*3/2+10) + "\n" + strings.Repeat("a", defaultBufSize*3/2+20) + "\n",
+			stream: Stdout,
+			maxLen: defaultBufSize / 2,
+			tag: []runtime.LogTag{
+				runtime.LogTagPartial,
+				runtime.LogTagPartial,
+				runtime.LogTagPartial,
+				runtime.LogTagFull,
+				runtime.LogTagPartial,
+				runtime.LogTagPartial,
+				runtime.LogTagPartial,
+				runtime.LogTagFull,
+			},
+			content: []string{
+				strings.Repeat("a", defaultBufSize*1/2),
+				strings.Repeat("a", defaultBufSize*1/2),
+				strings.Repeat("a", defaultBufSize*1/2),
 				strings.Repeat("a", 10),
+				strings.Repeat("a", defaultBufSize*1/2),
+				strings.Repeat("a", defaultBufSize*1/2),
+				strings.Repeat("a", defaultBufSize*1/2),
+				strings.Repeat("a", 20),
+			},
+		},
+		"log length longer than max length, and (maxLen % defaultBufSize != 0)": {
+			input:  strings.Repeat("a", defaultBufSize*2+10) + "\n" + strings.Repeat("a", defaultBufSize*2+20) + "\n",
+			stream: Stdout,
+			maxLen: defaultBufSize * 3 / 2,
+			tag: []runtime.LogTag{
+				runtime.LogTagPartial,
+				runtime.LogTagFull,
+				runtime.LogTagPartial,
+				runtime.LogTagFull,
+			},
+			content: []string{
+				strings.Repeat("a", defaultBufSize*3/2),
+				strings.Repeat("a", defaultBufSize*1/2+10),
+				strings.Repeat("a", defaultBufSize*3/2),
+				strings.Repeat("a", defaultBufSize*1/2+20),
+			},
+		},
+		"no limit if max length is 0": {
+			input:  strings.Repeat("a", defaultBufSize*10+10) + "\n" + strings.Repeat("a", defaultBufSize*10+20) + "\n",
+			stream: Stdout,
+			maxLen: 0,
+			tag: []runtime.LogTag{
+				runtime.LogTagFull,
+				runtime.LogTagFull,
+			},
+			content: []string{
+				strings.Repeat("a", defaultBufSize*10+10),
+				strings.Repeat("a", defaultBufSize*10+20),
+			},
+		},
+		"no limit if max length is negative": {
+			input:  strings.Repeat("a", defaultBufSize*10+10) + "\n" + strings.Repeat("a", defaultBufSize*10+20) + "\n",
+			stream: Stdout,
+			maxLen: -1,
+			tag: []runtime.LogTag{
+				runtime.LogTagFull,
+				runtime.LogTagFull,
+			},
+			content: []string{
+				strings.Repeat("a", defaultBufSize*10+10),
+				strings.Repeat("a", defaultBufSize*10+20),
 			},
 		},
 	} {
@@ -80,7 +227,7 @@ func TestRedirectLogs(t *testing.T) {
 		rc := ioutil.NopCloser(strings.NewReader(test.input))
 		buf := bytes.NewBuffer(nil)
 		wc := cioutil.NewNopWriteCloser(buf)
-		redirectLogs("test-path", rc, wc, test.stream)
+		redirectLogs("test-path", rc, wc, test.stream, test.maxLen)
 		output := buf.String()
 		lines := strings.Split(output, "\n")
 		lines = lines[:len(lines)-1] // Discard empty string after last \n


### PR DESCRIPTION
Fixes https://github.com/containerd/cri/issues/283.

This PR added a configuration `max_container_log_size` for configuring max container log line size. Log line longer than the size limit will be split into multiple lines.

@yujuhong 