### PR TITLE
Upgrade cri-tools to v1.0.0-beta.1

### DIFF
--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -17,7 +17,7 @@
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
 
 # Not from vendor.conf.
-CRITOOL_VERSION=34ce008eb986641743a1230b4800a74f6829ecbb
+CRITOOL_VERSION=v1.0.0-beta.1
 CRITOOL_PKG=github.com/kubernetes-incubator/cri-tools
 CRITOOL_REPO=github.com/kubernetes-incubator/cri-tools
 


### PR DESCRIPTION
Upgrade cri-tools to [v1.0.0-beta.1](https://github.com/kubernetes-incubator/cri-tools/releases/tag/v1.0.0-beta.1)

Signed-off-by: Lantao Liu <lantaol@google.com>