### PR TITLE
Fix containerd logo link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # cri
 <p align="center">
 <img src="https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png" width="50" height="50">
-<img src="https://github.com/containerd/containerd/blob/master/docs/images/containerd-dark.png" width="200" >
+<img src="https://github.com/containerd/containerd/blob/v1.1.0/docs/images/containerd-dark.png" width="200" >
 </p>
 
 *Note: The standalone `cri-containerd` binary is end-of-life. `cri-containerd` is


### PR DESCRIPTION
The image was moved by https://github.com/containerd/containerd/pull/2342.

Use a link to a specific tag.

Signed-off-by: Lantao Liu <lantaol@google.com>