### PR TITLE
Disable TLS streaming to work with new kubelet streaming proxy.

### DIFF
--- a/cluster/gce/configure.sh
+++ b/cluster/gce/configure.sh
@@ -162,8 +162,6 @@ cat > ${config_path} <<EOF
   shim = "${CONTAINERD_HOME}/usr/local/bin/containerd-shim"
   runtime = "${CONTAINERD_HOME}/usr/local/sbin/runc"
 
-[plugins.cri]
-  enable_tls_streaming = true
 [plugins.cri.cni]
   bin_dir = "${cni_bin_dir}"
   conf_dir = "/etc/cni/net.d"

--- a/contrib/ansible/cri-containerd.yaml
+++ b/contrib/ansible/cri-containerd.yaml
@@ -13,14 +13,6 @@
     - name: "Create a directory for containerd config"
       file: path=/etc/containerd state=directory
 
-    - name: "Add containerd config file"
-      blockinfile:
-        path: /etc/containerd/config.toml
-        create: yes
-        block: |
-          [plugins.cri]
-            enable_tls_streaming = true
-
     - name: "Start Containerd"
       systemd: name=containerd daemon_reload=yes state=started enabled=yes
 


### PR DESCRIPTION
Disable TLS streaming to work with new kubelet streaming proxy added in https://github.com/kubernetes/kubernetes/pull/64006.

Signed-off-by: Lantao Liu <lantaol@google.com>