### PR TITLE
Make DEPLOY_PATH configurable.

### DIFF
--- a/test/containerd/build.sh
+++ b/test/containerd/build.sh
@@ -39,7 +39,7 @@ fi
 # Make sure output directory is clean.
 make clean
 # Build and push test tarball.
-PUSH_VERSION=true DEPLOY_DIR=containerd \
+PUSH_VERSION=true DEPLOY_DIR=${DEPLOY_DIR:-"containerd"} \
   make push TARBALL_PREFIX=containerd-cni \
   INCLUDE_CNI=true \
   CHECKOUT_CONTAINERD=false \


### PR DESCRIPTION
Make `DEPLOY_PATH` configurable.
This is useful for branch test. See https://github.com/kubernetes/test-infra/pull/8158

Signed-off-by: Lantao Liu <lantaol@google.com>