### PR TITLE
Return error if host path does not exist.

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -17,7 +17,6 @@ limitations under the License.
 package server
 
 import (
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -596,18 +595,9 @@ func (c *criService) addOCIBindMounts(g *generate.Generator, mounts []*runtime.M
 	for _, mount := range mounts {
 		dst := mount.GetContainerPath()
 		src := mount.GetHostPath()
-		// Create the host path if it doesn't exist.
-		// TODO(random-liu): Add CRI validation test for this case.
 		if _, err := c.os.Stat(src); err != nil {
-			if !os.IsNotExist(err) {
-				return errors.Wrapf(err, "failed to stat %q", src)
-			}
-			if err := c.os.MkdirAll(src, 0755); err != nil {
-				return errors.Wrapf(err, "failed to mkdir %q", src)
-			}
+			return errors.Wrapf(err, "failed to stat %q", src)
 		}
-		// TODO(random-liu): Add cri-containerd integration test or cri validation test
-		// for this.
 		src, err := c.os.ResolveSymbolicLink(src)
 		if err != nil {
 			return errors.Wrapf(err, "failed to resolve symlink %q", src)


### PR DESCRIPTION
Follow CRI definition. See https://github.com/kubernetes/kubernetes/pull/61460

Since https://github.com/kubernetes/kubernetes/issues/52318 was in Kubernetes 1.8, kubelet should have made sure host path exist since that. It is safe to return error.

Signed-off-by: Lantao Liu <lantaol@google.com>