### PR TITLE
Log task exit event.

### DIFF
--- a/pkg/server/events.go
+++ b/pkg/server/events.go
@@ -186,6 +186,7 @@ func (em *eventMonitor) handleEvent(any interface{}) error {
 	// TODO(random-liu): [P2] Handle containerd-shim exit.
 	case *eventtypes.TaskExit:
 		e := any.(*eventtypes.TaskExit)
+		logrus.Infof("TaskExit event %+v", e)
 		cntr, err := em.containerStore.Get(e.ContainerID)
 		if err == nil {
 			if err := handleContainerExit(ctx, e, cntr); err != nil {


### PR DESCRIPTION
Log task exit event which is useful for debugging issues like https://github.com/containerd/containerd/issues/2392.

Signed-off-by: Lantao Liu <lantaol@google.com>