### PR TITLE
Erase ambient capabilities.

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -372,6 +372,11 @@ func (c *criService) generateContainerSpec(id string, sandboxID string, sandboxP
 				securityContext.GetCapabilities())
 		}
 	}
+	// Clear all ambient capabilities. The implication of non-root + caps
+	// is not clearly defined in Kubernetes.
+	// See https://github.com/kubernetes/kubernetes/issues/56374
+	// Keep docker's behavior for now.
+	g.Spec().Process.Capabilities.Ambient = []string{}
 
 	g.SetProcessSelinuxLabel(processLabel)
 	g.SetLinuxMountLabel(mountLabel)

--- a/pkg/server/container_create_test.go
+++ b/pkg/server/container_create_test.go
@@ -261,6 +261,7 @@ func TestContainerCapabilities(t *testing.T) {
 			assert.NotContains(t, spec.Process.Capabilities.Inheritable, exclude)
 			assert.NotContains(t, spec.Process.Capabilities.Permitted, exclude)
 		}
+		assert.Empty(t, spec.Process.Capabilities.Ambient)
 	}
 }
 


### PR DESCRIPTION
This is not a huge problem to `containerd/cri`, because our default ambient list is empty. https://github.com/containerd/containerd/blob/master/oci/spec_unix.go#L97

However, we add ambient cap if user explicitly adds it. This is not a CVE, but a behavior change to me. We decided to follow docker's behavior for backward compatibility. And we can carry on discussion about how to better handle this in https://github.com/kubernetes/kubernetes/issues/56374.

Signed-off-by: Lantao Liu <lantaol@google.com>