### PR TITLE
Fix empty volume ownership.

### DIFF
--- a/integration/images/volume-ownership/Dockerfile
+++ b/integration/images/volume-ownership/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright 2018 The Containerd Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM busybox
+RUN mkdir -p /test_dir && \
+    chown -R nobody:nogroup /test_dir
+VOLUME /test_dir

--- a/integration/images/volume-ownership/Makefile
+++ b/integration/images/volume-ownership/Makefile
@@ -1,0 +1,27 @@
+# Copyright 2018 The Containerd Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+all: build
+
+PROJ=gcr.io/k8s-cri-containerd
+VERSION=1.0
+IMAGE=$(PROJ)/volume-ownership:$(VERSION)
+
+build:
+	docker build -t $(IMAGE) .
+
+push:
+	gcloud docker -- push $(IMAGE)
+
+.PHONY: build push

--- a/pkg/containerd/opts/container.go
+++ b/pkg/containerd/opts/container.go
@@ -53,7 +53,6 @@ func WithNewSnapshot(id string, i containerd.Image) containerd.NewContainerOpts 
 // WithVolumes copies ownership of volume in rootfs to its corresponding host path.
 // It doesn't update runtime spec.
 // The passed in map is a host path to container path map for all volumes.
-// TODO(random-liu): Figure out whether we need to copy volume content.
 func WithVolumes(volumeMounts map[string]string) containerd.NewContainerOpts {
 	return func(ctx context.Context, client *containerd.Client, c *containers.Container) (err error) {
 		if c.Snapshotter == "" {
@@ -108,14 +107,6 @@ func WithVolumes(volumeMounts map[string]string) containerd.NewContainerOpts {
 // copyExistingContents copies from the source to the destination and
 // ensures the ownership is appropriately set.
 func copyExistingContents(source, destination string) error {
-	srcList, err := ioutil.ReadDir(source)
-	if err != nil {
-		return err
-	}
-	if len(srcList) == 0 {
-		// Skip copying if source directory is empty.
-		return nil
-	}
 	dstList, err := ioutil.ReadDir(destination)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes https://github.com/containerd/cri/issues/809.

We should still copy file ownership even if the source volume directory is empty.

@ibuildthecloud