### PR TITLE
Support `Cmd` for sandbox container.

### DIFF
--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -344,9 +344,9 @@ func (c *criService) generateSandboxContainerSpec(id string, config *runtime.Pod
 		g.SetProcessCwd(imageConfig.WorkingDir)
 	}
 
-	if len(imageConfig.Entrypoint) == 0 {
-		// Pause image must have entrypoint.
-		return nil, errors.Errorf("invalid empty entrypoint in image config %+v", imageConfig)
+	if len(imageConfig.Entrypoint) == 0 && len(imageConfig.Cmd) == 0 {
+		// Pause image must have entrypoint or cmd.
+		return nil, errors.Errorf("invalid empty entrypoint and cmd in image config %+v", imageConfig)
 	}
 	// Set process commands.
 	g.SetProcessArgs(append(imageConfig.Entrypoint, imageConfig.Cmd...))

--- a/pkg/server/sandbox_run_test.go
+++ b/pkg/server/sandbox_run_test.go
@@ -128,9 +128,10 @@ func TestGenerateSandboxContainerSpec(t *testing.T) {
 				})
 			},
 		},
-		"should return error when entrypoint is empty": {
+		"should return error when entrypoint and cmd are empty": {
 			imageConfigChange: func(c *imagespec.ImageConfig) {
 				c.Entrypoint = nil
+				c.Cmd = nil
 			},
 			expectErr: true,
 		},


### PR DESCRIPTION
I tried to use `nginx` as sandbox container image, but failed because of this.

This is not super important, so no need to cherrypick.

Signed-off-by: Lantao Liu <lantaol@google.com>