### PR TITLE
Fix double /dev/shm mount.

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -777,6 +777,10 @@ func defaultRuntimeSpec(id string) (*runtimespec.Spec, error) {
 		if mount.Destination == "/run" {
 			continue
 		}
+		// CRI plugin handles `/dev/shm` itself.
+		if mount.Destination == "/dev/shm" {
+			continue
+		}
 		mounts = append(mounts, mount)
 	}
 	spec.Mounts = mounts

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -388,6 +388,14 @@ func (c *criService) generateSandboxContainerSpec(id string, config *runtime.Pod
 		g.RemoveLinuxNamespace(string(runtimespec.IPCNamespace)) // nolint: errcheck
 	}
 
+	// It's fine to generate the spec before the sandbox /dev/shm
+	// is actually created.
+	sandboxDevShm := c.getSandboxDevShm(id)
+	if nsOptions.GetIpc() == runtime.NamespaceMode_NODE {
+		sandboxDevShm = devShm
+	}
+	g.AddBindMount(sandboxDevShm, devShm, []string{"rbind", "ro"})
+
 	selinuxOpt := securityContext.GetSelinuxOptions()
 	processLabel, mountLabel, err := initSelinuxOpts(selinuxOpt)
 	if err != nil {


### PR DESCRIPTION
We have double `/dev/shm` mount now, one from containerd default runtime spec, one from our own `/dev/shm` mount.
```
# crictl exec 0c mount | grep shm
shm on /dev/shm type tmpfs (rw,nosuid,nodev,noexec,relatime,size=65536k)
shm on /dev/shm type tmpfs (rw,nosuid,nodev,noexec,relatime,size=65536k)
```

This PR fixes it:
```
# crictl exec 9 mount | grep shm
shm on /dev/shm type tmpfs (rw,nosuid,nodev,noexec,relatime,size=65536k)
```

Signed-off-by: Lantao Liu <lantaol@google.com>