### PR TITLE
Fix snapshotter nil panic.

### DIFF
--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -128,6 +128,10 @@ func NewCRIService(config criconfig.Config, client *containerd.Client) (CRIServi
 		selinux.SetDisabled()
 	}
 
+	if client.SnapshotService(c.config.ContainerdConfig.Snapshotter) == nil {
+		return nil, errors.Errorf("failed to find snapshotter %q", c.config.ContainerdConfig.Snapshotter)
+	}
+
 	c.imageFSPath = imageFSPath(config.ContainerdRootDir, config.ContainerdConfig.Snapshotter)
 	logrus.Infof("Get image filesystem path %q", c.imageFSPath)
 


### PR DESCRIPTION
The specified snapshotter can be `nil`. When that happens, it is better to log a clear fatal error than panic for nil pointer access.

/cc @dmcgowan 
Signed-off-by: Lantao Liu <lantaol@google.com>