### PR TITLE
Change to keep in sync with latest cni config

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -22,6 +22,7 @@ import (
 	goruntime "runtime"
 
 	cni "github.com/containerd/go-cni"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 )
@@ -41,14 +42,16 @@ func (c *criService) Status(ctx context.Context, r *runtime.StatusRequest) (*run
 		Type:   runtime.NetworkReady,
 		Status: true,
 	}
+
+	// Load the latest cni configuration to be in sync with the latest network configuration
+	if err := c.netPlugin.Load(cni.WithLoNetwork(), cni.WithDefaultConf()); err != nil {
+		logrus.WithError(err).Errorf("Failed to load cni configuration")
+	}
 	// Check the status of the cni initialization
 	if err := c.netPlugin.Status(); err != nil {
-		// If it is not initialized, then load the config and retry
-		if err = c.netPlugin.Load(cni.WithLoNetwork(), cni.WithDefaultConf()); err != nil {
-			networkCondition.Status = false
-			networkCondition.Reason = networkNotReadyReason
-			networkCondition.Message = fmt.Sprintf("Network plugin returns error: %v", err)
-		}
+		networkCondition.Status = false
+		networkCondition.Reason = networkNotReadyReason
+		networkCondition.Message = fmt.Sprintf("Network plugin returns error: %v", err)
 	}
 
 	resp := &runtime.StatusResponse{

--- a/vendor/github.com/containerd/go-cni/cni.go
+++ b/vendor/github.com/containerd/go-cni/cni.go
@@ -72,16 +72,18 @@ func New(config ...ConfigOption) (CNI, error) {
 
 func (c *libcni) Load(opts ...LoadOption) error {
 	var err error
+	c.Lock()
+	defer c.Unlock()
+
 	// Reset the networks on a load operation to ensure
 	// config happens on a clean slate
 	c.reset()
-
 	for _, o := range opts {
 		if err = o(c); err != nil {
 			return errors.Wrapf(ErrLoad, fmt.Sprintf("cni config load failed: %v", err))
 		}
 	}
-	return c.Status()
+	return nil
 }
 
 func (c *libcni) Status() error {
@@ -95,16 +97,16 @@ func (c *libcni) Status() error {
 
 // Setup setups the network in the namespace
 func (c *libcni) Setup(id string, path string, opts ...NamespaceOpts) (*CNIResult, error) {
-	if err:=c.Status();err!=nil{
-		return nil,err
+	c.RLock()
+	defer c.RUnlock()
+	if err := c.Status(); err != nil {
+		return nil, err
 	}
 	ns, err := newNamespace(id, path, opts...)
 	if err != nil {
 		return nil, err
 	}
 	var results []*current.Result
-	c.RLock()
-	defer c.RUnlock()
 	for _, network := range c.networks {
 		r, err := network.Attach(ns)
 		if err != nil {
@@ -117,9 +119,11 @@ func (c *libcni) Setup(id string, path string, opts ...NamespaceOpts) (*CNIResul
 
 // Remove removes the network config from the namespace
 func (c *libcni) Remove(id string, path string, opts ...NamespaceOpts) error {
-	if err:=c.Status();err!=nil{
-           return err
-        }
+	c.RLock()
+	defer c.RUnlock()
+	if err := c.Status(); err != nil {
+		return err
+	}
 	ns, err := newNamespace(id, path, opts...)
 	if err != nil {
 		return err
@@ -135,7 +139,5 @@ func (c *libcni) Remove(id string, path string, opts ...NamespaceOpts) error {
 }
 
 func (c *libcni) reset() {
-	c.Lock()
-	defer c.Unlock()
 	c.networks = nil
 }


### PR DESCRIPTION
This commit contains change to pick the latest cni config from the configured CNIConfDir.
With this change any changes made to the cni config file will be picked up on the kubelet's runtime status check call.
Ofcourse this would lead to undefined behavior when the cni config change is made in parallel during pod creation. However its reasonable to assume that the operator is aware of the need to drain the nodes of pods before making cni configuration change. The behavior is currently not defined in kubernetes. However I see that similar approach being adopted in the upstream kubernetes with dockershim. Keeping the behavior consistent for now.

Signed-off-by: Abhinandan Prativadi <abhi@docker.com>