### PR TITLE
Change to keep in sync with latest cni config

### DIFF
--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -144,7 +144,7 @@ func NewCRIService(config criconfig.Config, client *containerd.Client) (CRIServi
 
 	// Try to load the config if it exists. Just log the error if load fails
 	// This is not disruptive for containerd to panic
-	if err := c.netPlugin.Load(cni.WithLoNetwork(), cni.WithDefaultConf()); err != nil {
+	if err := c.netPlugin.Load(cni.WithLoNetwork, cni.WithDefaultConf); err != nil {
 		logrus.WithError(err).Error("Failed to load cni during init, please check CRI plugin status before setting up network for pods")
 	}
 	// prepare streaming server

--- a/pkg/server/testing/fake_cni_plugin.go
+++ b/pkg/server/testing/fake_cni_plugin.go
@@ -47,6 +47,6 @@ func (f *FakeCNIPlugin) Status() error {
 }
 
 // Load loads the network config.
-func (f *FakeCNIPlugin) Load(opts ...cni.LoadOption) error {
+func (f *FakeCNIPlugin) Load(opts ...cni.CNIOpt) error {
 	return f.LoadErr
 }

--- a/pkg/server/update_runtime_config.go
+++ b/pkg/server/update_runtime_config.go
@@ -52,7 +52,7 @@ func (c *criService) UpdateRuntimeConfig(ctx context.Context, r *runtime.UpdateR
 	if err := c.netPlugin.Status(); err == nil {
 		logrus.Infof("Network plugin is ready, skip generating cni config from template %q", confTemplate)
 		return &runtime.UpdateRuntimeConfigResponse{}, nil
-	} else if err := c.netPlugin.Load(cni.WithLoNetwork(), cni.WithDefaultConf()); err == nil {
+	} else if err := c.netPlugin.Load(cni.WithLoNetwork, cni.WithDefaultConf); err == nil {
 		logrus.Infof("CNI config is successfully loaded, skip generating cni config from template %q", confTemplate)
 		return &runtime.UpdateRuntimeConfigResponse{}, nil
 	}

--- a/vendor.conf
+++ b/vendor.conf
@@ -7,7 +7,7 @@ github.com/containerd/console cb7008ab3d8359b78c5f464cb7cf160107ad5925
 github.com/containerd/containerd 84bebdd91d347c99069d1705b7d4e6d6f746160c
 github.com/containerd/continuity d3c23511c1bf5851696cba83143d9cbcd666869b
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
-github.com/containerd/go-cni f2d7272f12d045b16ed924f50e91f9f9cecc55a7
+github.com/containerd/go-cni 5882530828ecf62032409b298a3e8b19e08b6534 
 github.com/containerd/go-runc f271fa2021de855d4d918dbef83c5fe19db1bdd5
 github.com/containerd/typeurl f6943554a7e7e88b3c14aad190bf05932da84788
 github.com/containernetworking/cni v0.6.0

--- a/vendor/github.com/containerd/go-cni/opts.go
+++ b/vendor/github.com/containerd/go-cni/opts.go
@@ -24,11 +24,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-type ConfigOption func(c *libcni) error
+type CNIOpt func(c *libcni) error
 
 // WithInterfacePrefix sets the prefix for network interfaces
 // e.g. eth or wlan
-func WithInterfacePrefix(prefix string) ConfigOption {
+func WithInterfacePrefix(prefix string) CNIOpt {
 	return func(c *libcni) error {
 		c.prefix = prefix
 		return nil
@@ -37,7 +37,7 @@ func WithInterfacePrefix(prefix string) ConfigOption {
 
 // WithPluginDir can be used to set the locations of
 // the cni plugin binaries
-func WithPluginDir(dirs []string) ConfigOption {
+func WithPluginDir(dirs []string) CNIOpt {
 	return func(c *libcni) error {
 		c.pluginDirs = dirs
 		c.cniConfig = &cnilibrary.CNIConfig{Path: dirs}
@@ -47,7 +47,7 @@ func WithPluginDir(dirs []string) ConfigOption {
 
 // WithPluginConfDir can be used to configure the
 // cni configuration directory.
-func WithPluginConfDir(dir string) ConfigOption {
+func WithPluginConfDir(dir string) CNIOpt {
 	return func(c *libcni) error {
 		c.pluginConfDir = dir
 		return nil
@@ -57,23 +57,17 @@ func WithPluginConfDir(dir string) ConfigOption {
 // WithMinNetworkCount can be used to configure the
 // minimum networks to be configured and initalized
 // for the status to report success. By default its 1.
-func WithMinNetworkCount(count int) ConfigOption {
+func WithMinNetworkCount(count int) CNIOpt {
 	return func(c *libcni) error {
 		c.networkCount = count
 		return nil
 	}
 }
 
-// LoadOption can be used with Load API
-// to load network configuration from different
-// sources.
-type LoadOption func(c *libcni) error
-
 // WithLoNetwork can be used to load the loopback
 // network config.
-func WithLoNetwork() LoadOption {
-	return func(c *libcni) error {
-		loConfig, _ := cnilibrary.ConfListFromBytes([]byte(`{
+func WithLoNetwork(c *libcni) error {
+	loConfig, _ := cnilibrary.ConfListFromBytes([]byte(`{
 "cniVersion": "0.3.1",
 "name": "cni-loopback",
 "plugins": [{
@@ -81,20 +75,17 @@ func WithLoNetwork() LoadOption {
 }]
 }`))
 
-		c.Lock()
-		defer c.Unlock()
-		c.networks = append(c.networks,&Network{
-			cni:    c.cniConfig,
-			config: loConfig,
-			ifName: "lo",
-		})
-		return nil
-	}
+	c.networks = append(c.networks, &Network{
+		cni:    c.cniConfig,
+		config: loConfig,
+		ifName: "lo",
+	})
+	return nil
 }
 
 // WithConf can be used to load config directly
 // from byte.
-func WithConf(bytes []byte) LoadOption {
+func WithConf(bytes []byte) CNIOpt {
 	return func(c *libcni) error {
 		conf, err := cnilibrary.ConfFromBytes(bytes)
 		if err != nil {
@@ -104,8 +95,6 @@ func WithConf(bytes []byte) LoadOption {
 		if err != nil {
 			return err
 		}
-		c.Lock()
-		defer c.Unlock()
 		c.networks = append(c.networks, &Network{
 			cni:    c.cniConfig,
 			config: confList,
@@ -118,7 +107,7 @@ func WithConf(bytes []byte) LoadOption {
 // WithConfFile can be used to load network config
 // from an .conf file. Supported with absolute fileName
 // with path only.
-func WithConfFile(fileName string) LoadOption {
+func WithConfFile(fileName string) CNIOpt {
 	return func(c *libcni) error {
 		conf, err := cnilibrary.ConfFromFile(fileName)
 		if err != nil {
@@ -129,8 +118,6 @@ func WithConfFile(fileName string) LoadOption {
 		if err != nil {
 			return err
 		}
-		c.Lock()
-		defer c.Unlock()
 		c.networks = append(c.networks, &Network{
 			cni:    c.cniConfig,
 			config: confList,
@@ -143,15 +130,13 @@ func WithConfFile(fileName string) LoadOption {
 // WithConfListFile can be used to load network config
 // from an .conflist file. Supported with absolute fileName
 // with path only.
-func WithConfListFile(fileName string) LoadOption {
+func WithConfListFile(fileName string) CNIOpt {
 	return func(c *libcni) error {
 		confList, err := cnilibrary.ConfListFromFile(fileName)
 		if err != nil {
 			return err
 		}
-		c.Lock()
-		defer c.Unlock()
-		c.networks = append(c.networks,&Network{
+		c.networks = append(c.networks, &Network{
 			cni:    c.cniConfig,
 			config: confList,
 			ifName: getIfName(c.prefix, 0),
@@ -163,64 +148,60 @@ func WithConfListFile(fileName string) LoadOption {
 // WithDefaultConf can be used to detect network config
 // files from the configured cni config directory and load
 // them.
-func WithDefaultConf() LoadOption {
-	return func(c *libcni) error {
-		files, err := cnilibrary.ConfFiles(c.pluginConfDir, []string{".conf", ".conflist", ".json"})
-		switch {
-		case err != nil:
-			return errors.Wrapf(ErrRead, "failed to read config file: %v", err)
-		case len(files) == 0:
-			return errors.Wrapf(ErrCNINotInitialized, "no network config found in %s", c.pluginConfDir)
-		}
-
-		// files contains the network config files associated with cni network.
-		// Use lexicographical way as a defined order for network config files.
-		sort.Strings(files)
-		// Since the CNI spec does not specify a way to detect default networks,
-		// the convention chosen is - the first network configuration in the sorted
-		// list of network conf files as the default network and choose the default
-		// interface provided during init as the network interface for this default
-		// network. For every other network use a generated interface id.
-		i := 0
-		c.Lock()
-		defer c.Unlock()
-		for _, confFile := range files {
-			var confList *cnilibrary.NetworkConfigList
-			if strings.HasSuffix(confFile, ".conflist") {
-				confList, err = cnilibrary.ConfListFromFile(confFile)
-				if err != nil {
-					return errors.Wrapf(ErrInvalidConfig, "failed to load CNI config list file %s: %v", confFile, err)
-				}
-			} else {
-				conf, err := cnilibrary.ConfFromFile(confFile)
-				if err != nil {
-					return errors.Wrapf(ErrInvalidConfig, "failed to load CNI config file %s: %v", confFile, err)
-				}
-				// Ensure the config has a "type" so we know what plugin to run.
-				// Also catches the case where somebody put a conflist into a conf file.
-				if conf.Network.Type == "" {
-					return errors.Wrapf(ErrInvalidConfig, "network type not found in %s", confFile)
-				}
-
-				confList, err = cnilibrary.ConfListFromConf(conf)
-				if err != nil {
-					return errors.Wrapf(ErrInvalidConfig, "failed to convert CNI config file %s to list: %v", confFile, err)
-				}
-			}
-			if len(confList.Plugins) == 0 {
-				return errors.Wrapf(ErrInvalidConfig, "CNI config list %s has no networks, skipping", confFile)
-
-			}
-			c.networks = append(c.networks, &Network{
-				cni:    c.cniConfig,
-				config: confList,
-				ifName: getIfName(c.prefix, i),
-			})
-			i++
-		}
-		if len(c.networks) == 0 {
-			return errors.Wrapf(ErrCNINotInitialized, "no valid networks found in %s", c.pluginDirs)
-		}
-		return nil
+func WithDefaultConf(c *libcni) error {
+	files, err := cnilibrary.ConfFiles(c.pluginConfDir, []string{".conf", ".conflist", ".json"})
+	switch {
+	case err != nil:
+		return errors.Wrapf(ErrRead, "failed to read config file: %v", err)
+	case len(files) == 0:
+		return errors.Wrapf(ErrCNINotInitialized, "no network config found in %s", c.pluginConfDir)
 	}
+
+	// files contains the network config files associated with cni network.
+	// Use lexicographical way as a defined order for network config files.
+	sort.Strings(files)
+	// Since the CNI spec does not specify a way to detect default networks,
+	// the convention chosen is - the first network configuration in the sorted
+	// list of network conf files as the default network and choose the default
+	// interface provided during init as the network interface for this default
+	// network. For every other network use a generated interface id.
+	i := 0
+	for _, confFile := range files {
+		var confList *cnilibrary.NetworkConfigList
+		if strings.HasSuffix(confFile, ".conflist") {
+			confList, err = cnilibrary.ConfListFromFile(confFile)
+			if err != nil {
+				return errors.Wrapf(ErrInvalidConfig, "failed to load CNI config list file %s: %v", confFile, err)
+			}
+		} else {
+			conf, err := cnilibrary.ConfFromFile(confFile)
+			if err != nil {
+				return errors.Wrapf(ErrInvalidConfig, "failed to load CNI config file %s: %v", confFile, err)
+			}
+			// Ensure the config has a "type" so we know what plugin to run.
+			// Also catches the case where somebody put a conflist into a conf file.
+			if conf.Network.Type == "" {
+				return errors.Wrapf(ErrInvalidConfig, "network type not found in %s", confFile)
+			}
+
+			confList, err = cnilibrary.ConfListFromConf(conf)
+			if err != nil {
+				return errors.Wrapf(ErrInvalidConfig, "failed to convert CNI config file %s to list: %v", confFile, err)
+			}
+		}
+		if len(confList.Plugins) == 0 {
+			return errors.Wrapf(ErrInvalidConfig, "CNI config list %s has no networks, skipping", confFile)
+
+		}
+		c.networks = append(c.networks, &Network{
+			cni:    c.cniConfig,
+			config: confList,
+			ifName: getIfName(c.prefix, i),
+		})
+		i++
+	}
+	if len(c.networks) == 0 {
+		return errors.Wrapf(ErrCNINotInitialized, "no valid networks found in %s", c.pluginDirs)
+	}
+	return nil
 }


### PR DESCRIPTION
This commit contains change to pick the latest cni config from the configured CNIConfDir.
With this change any changes made to the cni config file will be picked up on the kubelet's runtime status check call.
Ofcourse this would lead to undefined behavior when the cni config change is made in parallel during pod creation. However its reasonable to assume that the operator is aware of the need to drain the nodes of pods before making cni configuration change. The behavior is currently not defined in kubernetes. However I see that similar approach being adopted in the upstream kubernetes with dockershim. Keeping the behavior consistent for now.

Signed-off-by: Abhinandan Prativadi abhi@docker.com