### PR TITLE
Set stream server to serve on localhost on GCE.

### DIFF
--- a/cluster/gce/configure.sh
+++ b/cluster/gce/configure.sh
@@ -167,6 +167,7 @@ disabled_plugins = ["restart"]
   runtime = "${CONTAINERD_HOME}/usr/local/sbin/runc"
 
 [plugins.cri]
+  stream_server_address = "127.0.0.1"
   max_container_log_line_size = ${max_container_log_line}
 [plugins.cri.cni]
   bin_dir = "${cni_bin_dir}"


### PR DESCRIPTION
Fixes https://github.com/containerd/cri/issues/777.

Let stream server serve on localhost on GCE to work with newly introduced kubelet proxy streaming. https://github.com/kubernetes/kubernetes/pull/64006

Signed-off-by: Lantao Liu <lantaol@google.com>