### PR TITLE
Use `--no-overwrite-dir` in installation doc.

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -84,7 +84,7 @@ curl https://storage.googleapis.com/cri-containerd-release/cri-containerd-${VERS
 ## Step 2: Install Containerd
 If you are using systemd, just simply unpack the tarball to the root directory:
 ```bash
-sudo tar -C / -xzf cri-containerd-${VERSION}.linux-amd64.tar.gz
+sudo tar --no-overwrite-dir -C / -xzf cri-containerd-${VERSION}.linux-amd64.tar.gz
 sudo systemctl start containerd
 ```
 If you are not using systemd, please unpack all binaries into a directory in your `PATH`, and start `containerd` as monitored long running services with the service manager you are using e.g. `supervisord`, `upstart` etc.

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -21,6 +21,8 @@ set -o pipefail
 source $(dirname "${BASH_SOURCE[0]}")/utils.sh
 cd ${ROOT}
 
+umask 0022
+
 # BUILD_DIR is the directory to generate release tar.
 # TARBALL is the name of the release tar.
 BUILD_DIR=${BUILD_DIR:-"_output"}


### PR DESCRIPTION
Fixes https://github.com/containerd/cri/issues/842.

Without this flag, `tar` will overwrite metadata of existing directories including `/usr`, `/etc` and `/opt`.

Another problem is that in our release tarball those directories have `750` permission, but the permissions inside the tarball shouldn't be applied to existing directories during installation anyway.

We should cherrypick this to the document in old branches.

Signed-off-by: Lantao Liu <lantaol@google.com>