### PR TITLE
Update crictl to v1.11.1.

### DIFF
--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -17,7 +17,7 @@
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
 
 # Not from vendor.conf.
-CRITOOL_VERSION=v1.11.0
+CRITOOL_VERSION=v1.11.1
 CRITOOL_PKG=github.com/kubernetes-incubator/cri-tools
 CRITOOL_REPO=github.com/kubernetes-incubator/cri-tools
 


### PR DESCRIPTION
crictl v1.11.1 has some useful bug fix.

See https://github.com/kubernetes-incubator/cri-tools/releases/tag/v1.11.1

We should cherrypick this to the release/1.11 branch.

Signed-off-by: Lantao Liu <lantaol@google.com>