### PR TITLE
support no_pivot option for runc

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -38,6 +38,9 @@ The explanation and default value of each configuration item are as follows:
     # snapshotter is the snapshotter used by containerd.
     snapshotter = "overlayfs"
 
+    # no_pivot disables pivot-root (linux only), required when running a container in a RamDisk with runc
+    no_pivot = false
+
     # "plugins.cri.containerd.default_runtime" is the runtime to use in containerd.
     [plugins.cri.containerd.default_runtime]
       # runtime_type is the runtime type to use in containerd e.g. io.containerd.runtime.v1.linux

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,6 +37,8 @@ type ContainerdConfig struct {
 	DefaultRuntime Runtime `toml:"default_runtime" json:"defaultRuntime"`
 	// UntrustedWorkloadRuntime is a runtime to run untrusted workloads on it.
 	UntrustedWorkloadRuntime Runtime `toml:"untrusted_workload_runtime" json:"untrustedWorkloadRuntime"`
+	// NoPivot disables pivot-root (linux only), required when running a container in a RamDisk with runc
+	NoPivot bool `toml:"no_pivot" json:"noPivot"`
 }
 
 // CniConfig contains toml config related to cni
@@ -148,6 +150,7 @@ func DefaultConfig() PluginConfig {
 				Engine: "",
 				Root:   "",
 			},
+			NoPivot: false,
 		},
 		StreamServerAddress:     "",
 		StreamServerPort:        "10010",

--- a/pkg/server/container_start.go
+++ b/pkg/server/container_start.go
@@ -108,7 +108,11 @@ func (c *criService) startContainer(ctx context.Context,
 		return cntr.IO, nil
 	}
 
-	task, err := container.NewTask(ctx, ioCreation)
+	var taskOpts []containerd.NewTaskOpts
+	if c.config.NoPivot {
+		taskOpts = append(taskOpts, containerd.WithNoPivotRoot)
+	}
+	task, err := container.NewTask(ctx, ioCreation, taskOpts...)
 	if err != nil {
 		return errors.Wrap(err, "failed to create containerd task")
 	}

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -293,8 +293,13 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		// Create sandbox task in containerd.
 		log.Tracef("Create sandbox container (id=%q, name=%q).",
 			id, name)
+
+		var taskOpts []containerd.NewTaskOpts
+		if c.config.NoPivot {
+			taskOpts = append(taskOpts, containerd.WithNoPivotRoot)
+		}
 		// We don't need stdio for sandbox container.
-		task, err := container.NewTask(ctx, containerdio.NullIO)
+		task, err := container.NewTask(ctx, containerdio.NullIO, taskOpts...)
 		if err != nil {
 			return status, errors.Wrap(err, "failed to create containerd task")
 		}


### PR DESCRIPTION
Signed-off-by: yanxuean <yan.xuean@zte.com.cn>

For minikube #462, If not, we will fail to create sandbox.
```
FATA[0003] run pod sandbox failed: rpc error: code = Unknown desc = failed to start sandbox container: failed to create containerd task: OCI runtime create failed: container_linux.go:296: starting container process caused "process_linux.go:398: container init caused \"rootfs_linux.go:107: jailing process inside rootfs caused \\\"pivot_root invalid argument\\\"\"": unknown
```

refer to https://github.com/containerd/containerd/issues/1973