### PR TITLE
WIP - do not merge - switches from config.digest to target.digest

### DIFF
--- a/hack/verify-lint.sh
+++ b/hack/verify-lint.sh
@@ -29,6 +29,7 @@ for d in $(find . -type d -a \( -iwholename './pkg*' -o -iwholename './cmd*' \) 
 		 --disable=aligncheck \
 		 --disable=gotype \
 		 --disable=gas \
+		 --disable=gosec \
 		 --cyclo-over=60 \
 		 --dupl-threshold=100 \
 		 --tests \

--- a/pkg/server/helpers.go
+++ b/pkg/server/helpers.go
@@ -251,11 +251,7 @@ func (c *criService) localResolve(ctx context.Context, refOrID string) (*imagest
 			if err != nil {
 				return ""
 			}
-			desc, err := image.Config(ctx)
-			if err != nil {
-				return ""
-			}
-			return desc.Digest.String()
+			return image.Target().Digest.String()
 		}(refOrID)
 	}
 
@@ -343,7 +339,6 @@ func getImageInfo(ctx context.Context, image containerd.Image) (*imageInfo, erro
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get image config descriptor")
 	}
-	id := desc.Digest.String()
 
 	rb, err := content.ReadBlob(ctx, image.ContentStore(), desc)
 	if err != nil {
@@ -353,6 +348,8 @@ func getImageInfo(ctx context.Context, image containerd.Image) (*imageInfo, erro
 	if err := json.Unmarshal(rb, &ociimage); err != nil {
 		return nil, errors.Wrapf(err, "failed to unmarshal image config %s", rb)
 	}
+
+	id := image.Target().Digest.String()
 
 	return &imageInfo{
 		id:        id,

--- a/pkg/server/restart.go
+++ b/pkg/server/restart.go
@@ -411,12 +411,8 @@ func loadImages(ctx context.Context, cImages []containerd.Image,
 	// Group images by image id.
 	imageMap := make(map[string][]containerd.Image)
 	for _, i := range cImages {
-		desc, err := i.Config(ctx)
-		if err != nil {
-			logrus.WithError(err).Warnf("Failed to get image config for %q", i.Name())
-			continue
-		}
-		id := desc.Digest.String()
+		target := i.Target()
+		id := target.Digest.String()
 		imageMap[id] = append(imageMap[id], i)
 	}
 	var images []imagestore.Image


### PR DESCRIPTION
Testing how best to normalize the image id for crictl and ctr.

> In a casual conversation @stevvooe asked @crosbymichael shouldn’t they be sharing the cache? It seems the problems is the continued dependence of cri on image id. @random-liu any chance we can get rid of image id and use the actual digest as the image id?

I thought we were using the right image digest, but in debugging with @estesp help it turns out we are using the digest of the config (which is the digest for the config.json). Ok, I don't remember if this was on purpose, or is just a misunderstanding. This seems to lead us to the situation where we have one id in cri on up to kubernetes and/or crictl. And another id in containerd/ctr.

Looking for thoughts / ideas here.

What is the right digest to use, the digest for the target of the image reference which may be a manifest list or the digest for the platform image referenced in the manifest list.

Before commit:
```
mike@mike-VirtualBox:~/go/src/github.com/containerd/cri$ sudo crictl pull busybox
Image is update to date for sha256:22c2dd5ee85dc01136051800684b0bf30016a3082f97093c806152bf43d4e089
mike@mike-VirtualBox:~/go/src/github.com/containerd/cri$ sudo crictl inspecti busybox
{
 "status": {
   "id": "sha256:22c2dd5ee85dc01136051800684b0bf30016a3082f97093c806152bf43d4e089",
   "repoTags": [
     "docker.io/library/busybox:latest"
   ],
   "repoDigests": [
     "docker.io/library/busybox@sha256:d21b79794850b4b15d8d332b451d95351d14c951542942a816eea69c9e04b240"
   ],
   "size": "737920",
   "username": ""
 },
 "info": {
   "chainID": "sha256:8e9a7d50b12c4249f7473606c9685f4f4be919a3c00e49a7c3a314ae9de52ed5",
   "imageSpec": {
     "created": "2018-07-16T22:19:42.049157642Z",
     "architecture": "amd64",
     "os": "linux",
     "config": {
       "Env": [
         "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
       ],
       "Cmd": [
         "sh"
       ]
     },
     "rootfs": {
       "type": "layers",
       "diff_ids": [
         "sha256:8e9a7d50b12c4249f7473606c9685f4f4be919a3c00e49a7c3a314ae9de52ed5"
       ]
     },
     "history": [
       {
         "created": "2018-07-16T22:19:41.841251284Z",
         "created_by": "/bin/sh -c #(nop) ADD file:2a4c44bdcb743a52ffa1c4b07ce471d8735a5d59cb45da2e6bfe0c2b5311ca90 in / "
       },
       {
         "created": "2018-07-16T22:19:42.049157642Z",
         "created_by": "/bin/sh -c #(nop)  CMD [\"sh\"]",
         "empty_layer": true
       }
     ]
   }
 }
}
https://github.com/containerd/cri/blob/master/pkg/server/helpers.go#L346
GitHub
containerd/cri
cri - Containerd Plugin for Kubernetes Container Runtime Interface
and here: https://github.com/containerd/cri/blob/master/pkg/server/helpers.go#L240
GitHub
containerd/cri
cri - Containerd Plugin for Kubernetes Container Runtime Interface
mike@mike-VirtualBox:~/go/src/github.com/docker/distribution$ sudo ctr -n k8s.io i ls
REF                                                                                                              TYPE                                                      DIGEST                                                                  SIZE      PLATFORMS                                                                                             LABELS 
...docker.io/library/busybox:latest                                                                                 application/vnd.docker.distribution.manifest.list.v2+json sha256:d21b79794850b4b15d8d332b451d95351d14c951542942a816eea69c9e04b240 720.6 KiB linux/386,linux/amd64,linux/arm/v5,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x -      
docker.io/library/busybox@sha256:be3c11fdba7cfe299214e46edc642e09514dbb9bbefcd0d3836c05a1e0cd0642                application/vnd.docker.distribution.manifest.v2+json      sha256:be3c11fdba7cfe299214e46edc642e09514dbb9bbefcd0d3836c05a1e0cd0642 684.8 KiB linux/amd64                                                                                           -      
docker.io/library/busybox@sha256:d21b79794850b4b15d8d332b451d95351d14c951542942a816eea69c9e04b240                application/vnd.docker.distribution.manifest.list.v2+json sha256:d21b79794850b4b15d8d332b451d95351d14c951542942a816eea69c9e04b240 720.6 KiB linux/386,linux/amd64,linux/arm/v5,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x - (edited)
```

After commit:
```
mike@mike-VirtualBox:~/go/src/github.com/containerd/cri$ sudo crictl pull busybox
Image is update to date for sha256:d21b79794850b4b15d8d332b451d95351d14c951542942a816eea69c9e04b240
mike@mike-VirtualBox:~/go/src/github.com/containerd/cri$ sudo crictl inspecti busybox
{
  "status": {
    "id": "sha256:d21b79794850b4b15d8d332b451d95351d14c951542942a816eea69c9e04b240",
    "repoTags": [
      "docker.io/library/busybox:latest"
    ],
    "repoDigests": [
      "docker.io/library/busybox@sha256:d21b79794850b4b15d8d332b451d95351d14c951542942a816eea69c9e04b240"
    ],
    "size": "737920",
    "username": ""
  },
  "info": {
    "chainID": "sha256:8e9a7d50b12c4249f7473606c9685f4f4be919a3c00e49a7c3a314ae9de52ed5",
    "imageSpec": {
      "created": "2018-07-16T22:19:42.049157642Z",
      "architecture": "amd64",
      "os": "linux",
      "config": {
        "Env": [
          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
        ],
        "Cmd": [
          "sh"
        ]
      },
      "rootfs": {
        "type": "layers",
        "diff_ids": [
          "sha256:8e9a7d50b12c4249f7473606c9685f4f4be919a3c00e49a7c3a314ae9de52ed5"
        ]
      },
      "history": [
        {
          "created": "2018-07-16T22:19:41.841251284Z",
          "created_by": "/bin/sh -c #(nop) ADD file:2a4c44bdcb743a52ffa1c4b07ce471d8735a5d59cb45da2e6bfe0c2b5311ca90 in / "
        },
        {
          "created": "2018-07-16T22:19:42.049157642Z",
          "created_by": "/bin/sh -c #(nop)  CMD [\"sh\"]",
          "empty_layer": true
        }
      ]
    }
  }
}
```


Signed-off-by: Mike Brown <brownwm@us.ibm.com>