### PR TITLE
Unpack image during import.

### DIFF
--- a/hack/verify-lint.sh
+++ b/hack/verify-lint.sh
@@ -29,6 +29,7 @@ for d in $(find . -type d -a \( -iwholename './pkg*' -o -iwholename './cmd*' \) 
 		 --disable=aligncheck \
 		 --disable=gotype \
 		 --disable=gas \
+		 --disable=gosec \
 		 --cyclo-over=60 \
 		 --dupl-threshold=100 \
 		 --tests \

--- a/pkg/server/image_load.go
+++ b/pkg/server/image_load.go
@@ -39,7 +39,7 @@ func (c *criService) LoadImage(ctx context.Context, r *api.LoadImageRequest) (*a
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to open file")
 	}
-	repoTags, err := importer.Import(ctx, c.client, f)
+	repoTags, err := importer.Import(ctx, c.client, f, importer.WithUnpack(c.config.ContainerdConfig.Snapshotter))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to import image")
 	}
@@ -47,10 +47,6 @@ func (c *criService) LoadImage(ctx context.Context, r *api.LoadImageRequest) (*a
 		image, err := c.client.GetImage(ctx, repoTag)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to get image %q", repoTag)
-		}
-		if err := image.Unpack(ctx, c.config.ContainerdConfig.Snapshotter); err != nil {
-			logrus.WithError(err).Warnf("Failed to unpack image %q", repoTag)
-			// Do not fail image importing. Unpack will be retried when container creation.
 		}
 		info, err := getImageInfo(ctx, image)
 		if err != nil {


### PR DESCRIPTION
We should unpack image during import, so that the lease can help us hold the resource.

Similar issue with https://github.com/containerd/containerd/pull/2331.

Signed-off-by: Lantao Liu <lantaol@google.com>