### PR TITLE
Cache image reference

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -115,13 +115,9 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 
 	// Prepare container image snapshot. For container, the image should have
 	// been pulled before creating the container, so do not ensure the image.
-	imageRef := config.GetImage().GetImage()
-	image, err := c.localResolve(ctx, imageRef)
+	image, err := c.localResolve(config.GetImage().GetImage())
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to resolve image %q", imageRef)
-	}
-	if image == nil {
-		return nil, errors.Errorf("image %q not found", imageRef)
+		return nil, errors.Wrapf(err, "failed to resolve image %q", config.GetImage().GetImage())
 	}
 
 	// Run container using the same runtime with sandbox.

--- a/pkg/server/container_status.go
+++ b/pkg/server/container_status.go
@@ -46,14 +46,15 @@ func (c *criService) ContainerStatus(ctx context.Context, r *runtime.ContainerSt
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get image %q", imageRef)
 	}
-	if len(image.RepoTags) > 0 {
+	repoTags, repoDigests := parseImageReferences(image.References)
+	if len(repoTags) > 0 {
 		// Based on current behavior of dockershim, this field should be
 		// image tag.
-		spec = &runtime.ImageSpec{Image: image.RepoTags[0]}
+		spec = &runtime.ImageSpec{Image: repoTags[0]}
 	}
-	if len(image.RepoDigests) > 0 {
+	if len(repoDigests) > 0 {
 		// Based on the CRI definition, this field will be consumed by user.
-		imageRef = image.RepoDigests[0]
+		imageRef = repoDigests[0]
 	}
 	status := toCRIContainerStatus(container, spec, imageRef)
 	info, err := toCRIContainerInfo(ctx, container, r.GetVerbose())

--- a/pkg/server/events_test.go
+++ b/pkg/server/events_test.go
@@ -94,11 +94,11 @@ func TestBackOff(t *testing.T) {
 	assert.Equal(t, actual.isInBackOff(notExistKey), false)
 
 	t.Logf("No containers should be expired")
-	assert.Empty(t, actual.getExpiredContainers())
+	assert.Empty(t, actual.getExpiredIDs())
 
 	t.Logf("Should be able to get all keys which are expired for backOff")
 	testClock.Sleep(backOffInitDuration)
-	actKeyList := actual.getExpiredContainers()
+	actKeyList := actual.getExpiredIDs()
 	assert.Equal(t, len(inputQueues), len(actKeyList))
 	for k := range inputQueues {
 		assert.Contains(t, actKeyList, k)

--- a/pkg/server/helpers.go
+++ b/pkg/server/helpers.go
@@ -17,7 +17,6 @@ limitations under the License.
 package server
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path"
@@ -26,15 +25,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/containers"
-	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/runtime/linux/runctypes"
 	"github.com/containerd/typeurl"
 	"github.com/docker/distribution/reference"
 	imagedigest "github.com/opencontainers/go-digest"
-	"github.com/opencontainers/image-spec/identity"
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
 	"github.com/opencontainers/selinux/go-selinux"
@@ -236,28 +231,25 @@ func getRepoDigestAndTag(namedRef reference.Named, digest imagedigest.Digest, sc
 	return repoDigest, repoTag
 }
 
-// localResolve resolves image reference locally and returns corresponding image metadata. It returns
-// nil without error if the reference doesn't exist.
-func (c *criService) localResolve(ctx context.Context, refOrID string) (*imagestore.Image, error) {
+// localResolve resolves image reference locally and returns corresponding image metadata. It
+// returns store.ErrNotExist if the reference doesn't exist.
+func (c *criService) localResolve(refOrID string) (imagestore.Image, error) {
 	getImageID := func(refOrId string) string {
 		if _, err := imagedigest.Parse(refOrID); err == nil {
 			return refOrID
 		}
 		return func(ref string) string {
 			// ref is not image id, try to resolve it locally.
+			// TODO(random-liu): Handle this error better for debugging.
 			normalized, err := util.NormalizeImageRef(ref)
 			if err != nil {
 				return ""
 			}
-			image, err := c.client.GetImage(ctx, normalized.String())
+			id, err := c.imageStore.Resolve(normalized.String())
 			if err != nil {
 				return ""
 			}
-			desc, err := image.Config(ctx)
-			if err != nil {
-				return ""
-			}
-			return desc.Digest.String()
+			return id
 		}(refOrID)
 	}
 
@@ -266,14 +258,7 @@ func (c *criService) localResolve(ctx context.Context, refOrID string) (*imagest
 		// Try to treat ref as imageID
 		imageID = refOrID
 	}
-	image, err := c.imageStore.Get(imageID)
-	if err != nil {
-		if err == store.ErrNotExist {
-			return nil, nil
-		}
-		return nil, errors.Wrapf(err, "failed to get image %q", imageID)
-	}
-	return &image, nil
+	return c.imageStore.Get(imageID)
 }
 
 // getUserFromImage gets uid or user name of the image user.
@@ -298,12 +283,12 @@ func getUserFromImage(user string) (*int64, string) {
 // ensureImageExists returns corresponding metadata of the image reference, if image is not
 // pulled yet, the function will pull the image.
 func (c *criService) ensureImageExists(ctx context.Context, ref string) (*imagestore.Image, error) {
-	image, err := c.localResolve(ctx, ref)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to resolve image %q", ref)
+	image, err := c.localResolve(ref)
+	if err != nil && err != store.ErrNotExist {
+		return nil, errors.Wrapf(err, "failed to get image %q", ref)
 	}
-	if image != nil {
-		return image, nil
+	if err == nil {
+		return &image, nil
 	}
 	// Pull image to ensure the image exists
 	resp, err := c.PullImage(ctx, &runtime.PullImageRequest{Image: &runtime.ImageSpec{Image: ref}})
@@ -314,54 +299,9 @@ func (c *criService) ensureImageExists(ctx context.Context, ref string) (*images
 	newImage, err := c.imageStore.Get(imageID)
 	if err != nil {
 		// It's still possible that someone removed the image right after it is pulled.
-		return nil, errors.Wrapf(err, "failed to get image %q metadata after pulling", imageID)
+		return nil, errors.Wrapf(err, "failed to get image %q after pulling", imageID)
 	}
 	return &newImage, nil
-}
-
-// imageInfo is the information about the image got from containerd.
-type imageInfo struct {
-	id        string
-	chainID   imagedigest.Digest
-	size      int64
-	imagespec imagespec.Image
-}
-
-// getImageInfo gets image info from containerd.
-func getImageInfo(ctx context.Context, image containerd.Image) (*imageInfo, error) {
-	// Get image information.
-	diffIDs, err := image.RootFS(ctx)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get image diffIDs")
-	}
-	chainID := identity.ChainID(diffIDs)
-
-	size, err := image.Size(ctx)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get image compressed resource size")
-	}
-
-	desc, err := image.Config(ctx)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get image config descriptor")
-	}
-	id := desc.Digest.String()
-
-	rb, err := content.ReadBlob(ctx, image.ContentStore(), desc)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to read image config from content store")
-	}
-	var ociimage imagespec.Image
-	if err := json.Unmarshal(rb, &ociimage); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal image config %s", rb)
-	}
-
-	return &imageInfo{
-		id:        id,
-		chainID:   chainID,
-		size:      size,
-		imagespec: ociimage,
-	}, nil
 }
 
 func initSelinuxOpts(selinuxOpt *runtime.SELinuxOption) (string, string, error) {
@@ -499,4 +439,22 @@ func (m orderedMounts) Swap(i, j int) {
 // parts returns the number of parts in the destination of a mount. Used in sorting.
 func (m orderedMounts) parts(i int) int {
 	return strings.Count(filepath.Clean(m[i].ContainerPath), string(os.PathSeparator))
+}
+
+// parseImageReferences parses a list of arbitrary image references and returns
+// the repotags and repodigests
+func parseImageReferences(refs []string) ([]string, []string) {
+	var tags, digests []string
+	for _, ref := range refs {
+		parsed, err := reference.ParseAnyReference(ref)
+		if err != nil {
+			continue
+		}
+		if _, ok := parsed.(reference.Canonical); ok {
+			digests = append(digests, parsed.String())
+		} else if _, ok := parsed.(reference.Tagged); ok {
+			tags = append(tags, parsed.String())
+		}
+	}
+	return tags, digests
 }

--- a/pkg/server/image_list.go
+++ b/pkg/server/image_list.go
@@ -19,8 +19,6 @@ package server
 import (
 	"golang.org/x/net/context"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
-
-	imagestore "github.com/containerd/cri/pkg/store/image"
 )
 
 // ListImages lists existing images.
@@ -37,20 +35,4 @@ func (c *criService) ListImages(ctx context.Context, r *runtime.ListImagesReques
 	}
 
 	return &runtime.ListImagesResponse{Images: images}, nil
-}
-
-// toCRIImage converts image to CRI image type.
-func toCRIImage(image imagestore.Image) *runtime.Image {
-	runtimeImage := &runtime.Image{
-		Id:          image.ID,
-		RepoTags:    image.RepoTags,
-		RepoDigests: image.RepoDigests,
-		Size_:       uint64(image.Size),
-	}
-	uid, username := getUserFromImage(image.ImageSpec.Config.User)
-	if uid != nil {
-		runtimeImage.Uid = &runtime.Int64Value{Value: *uid}
-	}
-	runtimeImage.Username = username
-	return runtimeImage
 }

--- a/pkg/server/image_list_test.go
+++ b/pkg/server/image_list_test.go
@@ -32,11 +32,13 @@ func TestListImages(t *testing.T) {
 	c := newTestCRIService()
 	imagesInStore := []imagestore.Image{
 		{
-			ID:          "sha256:1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-			ChainID:     "test-chainid-1",
-			RepoTags:    []string{"tag-a-1", "tag-b-1"},
-			RepoDigests: []string{"digest-a-1", "digest-b-1"},
-			Size:        1000,
+			ID:      "sha256:1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			ChainID: "test-chainid-1",
+			References: []string{
+				"gcr.io/library/busybox:latest",
+				"gcr.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
+			},
+			Size: 1000,
 			ImageSpec: imagespec.Image{
 				Config: imagespec.ImageConfig{
 					User: "root",
@@ -44,11 +46,13 @@ func TestListImages(t *testing.T) {
 			},
 		},
 		{
-			ID:          "sha256:2123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-			ChainID:     "test-chainid-2",
-			RepoTags:    []string{"tag-a-2", "tag-b-2"},
-			RepoDigests: []string{"digest-a-2", "digest-b-2"},
-			Size:        2000,
+			ID:      "sha256:2123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			ChainID: "test-chainid-2",
+			References: []string{
+				"gcr.io/library/alpine:latest",
+				"gcr.io/library/alpine@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
+			},
+			Size: 2000,
 			ImageSpec: imagespec.Image{
 				Config: imagespec.ImageConfig{
 					User: "1234:1234",
@@ -56,11 +60,13 @@ func TestListImages(t *testing.T) {
 			},
 		},
 		{
-			ID:          "sha256:3123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-			ChainID:     "test-chainid-3",
-			RepoTags:    []string{"tag-a-3", "tag-b-3"},
-			RepoDigests: []string{"digest-a-3", "digest-b-3"},
-			Size:        3000,
+			ID:      "sha256:3123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			ChainID: "test-chainid-3",
+			References: []string{
+				"gcr.io/library/ubuntu:latest",
+				"gcr.io/library/ubuntu@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
+			},
+			Size: 3000,
 			ImageSpec: imagespec.Image{
 				Config: imagespec.ImageConfig{
 					User: "nobody",
@@ -71,30 +77,30 @@ func TestListImages(t *testing.T) {
 	expect := []*runtime.Image{
 		{
 			Id:          "sha256:1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-			RepoTags:    []string{"tag-a-1", "tag-b-1"},
-			RepoDigests: []string{"digest-a-1", "digest-b-1"},
+			RepoTags:    []string{"gcr.io/library/busybox:latest"},
+			RepoDigests: []string{"gcr.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582"},
 			Size_:       uint64(1000),
 			Username:    "root",
 		},
 		{
 			Id:          "sha256:2123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-			RepoTags:    []string{"tag-a-2", "tag-b-2"},
-			RepoDigests: []string{"digest-a-2", "digest-b-2"},
+			RepoTags:    []string{"gcr.io/library/alpine:latest"},
+			RepoDigests: []string{"gcr.io/library/alpine@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582"},
 			Size_:       uint64(2000),
 			Uid:         &runtime.Int64Value{Value: 1234},
 		},
 		{
 			Id:          "sha256:3123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-			RepoTags:    []string{"tag-a-3", "tag-b-3"},
-			RepoDigests: []string{"digest-a-3", "digest-b-3"},
+			RepoTags:    []string{"gcr.io/library/ubuntu:latest"},
+			RepoDigests: []string{"gcr.io/library/ubuntu@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582"},
 			Size_:       uint64(3000),
 			Username:    "nobody",
 		},
 	}
 
-	for _, i := range imagesInStore {
-		c.imageStore.Add(i)
-	}
+	var err error
+	c.imageStore, err = imagestore.NewFakeStore(imagesInStore)
+	assert.NoError(t, err)
 
 	resp, err := c.ListImages(context.Background(), &runtime.ListImagesRequest{})
 	assert.NoError(t, err)

--- a/pkg/server/image_status_test.go
+++ b/pkg/server/image_status_test.go
@@ -31,11 +31,13 @@ import (
 func TestImageStatus(t *testing.T) {
 	testID := "sha256:d848ce12891bf78792cda4a23c58984033b0c397a55e93a1556202222ecc5ed4"
 	image := imagestore.Image{
-		ID:          testID,
-		ChainID:     "test-chain-id",
-		RepoTags:    []string{"a", "b"},
-		RepoDigests: []string{"c", "d"},
-		Size:        1234,
+		ID:      testID,
+		ChainID: "test-chain-id",
+		References: []string{
+			"gcr.io/library/busybox:latest",
+			"gcr.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582",
+		},
+		Size: 1234,
 		ImageSpec: imagespec.Image{
 			Config: imagespec.ImageConfig{
 				User: "user:group",
@@ -44,8 +46,8 @@ func TestImageStatus(t *testing.T) {
 	}
 	expected := &runtime.Image{
 		Id:          testID,
-		RepoTags:    []string{"a", "b"},
-		RepoDigests: []string{"c", "d"},
+		RepoTags:    []string{"gcr.io/library/busybox:latest"},
+		RepoDigests: []string{"gcr.io/library/busybox@sha256:e6693c20186f837fc393390135d8a598a96a833917917789d63766cab6c59582"},
 		Size_:       uint64(1234),
 		Username:    "user",
 	}
@@ -59,7 +61,8 @@ func TestImageStatus(t *testing.T) {
 	require.NotNil(t, resp)
 	assert.Nil(t, resp.GetImage())
 
-	c.imageStore.Add(image)
+	c.imageStore, err = imagestore.NewFakeStore([]imagestore.Image{image})
+	assert.NoError(t, err)
 
 	t.Logf("should return correct image status for exist image")
 	resp, err = c.ImageStatus(context.Background(), &runtime.ImageStatusRequest{

--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -113,7 +113,7 @@ func NewCRIService(config criconfig.Config, client *containerd.Client) (CRIServi
 		os:                 osinterface.RealOS{},
 		sandboxStore:       sandboxstore.NewStore(),
 		containerStore:     containerstore.NewStore(),
-		imageStore:         imagestore.NewStore(),
+		imageStore:         imagestore.NewStore(client),
 		snapshotStore:      snapshotstore.NewStore(),
 		sandboxNameIndex:   registrar.NewRegistrar(),
 		containerNameIndex: registrar.NewRegistrar(),
@@ -157,7 +157,7 @@ func NewCRIService(config criconfig.Config, client *containerd.Client) (CRIServi
 		return nil, errors.Wrap(err, "failed to create stream server")
 	}
 
-	c.eventMonitor = newEventMonitor(c.containerStore, c.sandboxStore)
+	c.eventMonitor = newEventMonitor(c.containerStore, c.sandboxStore, c.imageStore)
 
 	return c, nil
 }

--- a/pkg/server/service_test.go
+++ b/pkg/server/service_test.go
@@ -50,7 +50,7 @@ func newTestCRIService() *criService {
 		imageFSPath:        testImageFSPath,
 		os:                 ostesting.NewFakeOS(),
 		sandboxStore:       sandboxstore.NewStore(),
-		imageStore:         imagestore.NewStore(),
+		imageStore:         imagestore.NewStore(nil),
 		snapshotStore:      snapshotstore.NewStore(),
 		sandboxNameIndex:   registrar.NewRegistrar(),
 		containerStore:     containerstore.NewStore(),

--- a/pkg/store/image/fake_image.go
+++ b/pkg/store/image/fake_image.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2018 The Containerd Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package image
+
+import "github.com/pkg/errors"
+
+// NewFakeStore returns an image store with predefined images.
+// Update is not allowed for this fake store.
+func NewFakeStore(images []Image) (*Store, error) {
+	s := NewStore(nil)
+	for _, i := range images {
+		for _, ref := range i.References {
+			s.refCache[ref] = i.ID
+		}
+		if err := s.store.add(i); err != nil {
+			return nil, errors.Wrapf(err, "add image %q", i)
+		}
+	}
+	return s, nil
+}

--- a/pkg/store/image/image.go
+++ b/pkg/store/image/image.go
@@ -17,14 +17,21 @@ limitations under the License.
 package image
 
 import (
+	"context"
+	"encoding/json"
 	"sync"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/errdefs"
 	"github.com/docker/distribution/digestset"
-	godigest "github.com/opencontainers/go-digest"
+	imagedigest "github.com/opencontainers/go-digest"
+	imageidentity "github.com/opencontainers/image-spec/identity"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
 
-	"github.com/containerd/cri/pkg/store"
+	storeutil "github.com/containerd/cri/pkg/store"
+	"github.com/containerd/cri/pkg/util"
 )
 
 // Image contains all resources associated with the image. All fields
@@ -32,10 +39,8 @@ import (
 type Image struct {
 	// Id of the image. Normally the digest of image config.
 	ID string
-	// Other names by which this image is known.
-	RepoTags []string
-	// Digests by which this image is known.
-	RepoDigests []string
+	// References are references to the image, e.g. RepoTag and RepoDigest.
+	References []string
 	// ChainID is the chainID of the image.
 	ChainID string
 	// Size is the compressed size of the image.
@@ -48,28 +53,156 @@ type Image struct {
 
 // Store stores all images.
 type Store struct {
+	lock sync.RWMutex
+	// refCache is a containerd image reference to image id cache.
+	refCache map[string]string
+	// client is the containerd client.
+	client *containerd.Client
+	// store is the internal image store indexed by image id.
+	store *store
+}
+
+// NewStore creates an image store.
+func NewStore(client *containerd.Client) *Store {
+	return &Store{
+		refCache: make(map[string]string),
+		client:   client,
+		store: &store{
+			images:    make(map[string]Image),
+			digestSet: digestset.NewSet(),
+		},
+	}
+}
+
+// Update updates cache for a reference.
+func (s *Store) Update(ctx context.Context, ref string) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	i, err := s.client.GetImage(ctx, ref)
+	if err != nil && !errdefs.IsNotFound(err) {
+		return errors.Wrap(err, "get image from containerd")
+	}
+	var img *Image
+	if err == nil {
+		img, err = getImage(ctx, i)
+		if err != nil {
+			return errors.Wrap(err, "get image info from containerd")
+		}
+	}
+	return s.update(ref, img)
+}
+
+// update updates the internal cache. img == nil means that
+// the image does not exist in containerd.
+func (s *Store) update(ref string, img *Image) error {
+	oldID, oldExist := s.refCache[ref]
+	if img == nil {
+		// The image reference doesn't exist in containerd.
+		if oldExist {
+			// Remove the reference from the store.
+			s.store.delete(oldID, ref)
+			delete(s.refCache, ref)
+		}
+		return nil
+	}
+	if oldExist {
+		if oldID == img.ID {
+			return nil
+		}
+		// Updated. Remove tag from old image.
+		s.store.delete(oldID, ref)
+	}
+	// New image. Add new image.
+	s.refCache[ref] = img.ID
+	return s.store.add(*img)
+}
+
+// getImage gets image information from containerd.
+func getImage(ctx context.Context, i containerd.Image) (*Image, error) {
+	// Get image information.
+	diffIDs, err := i.RootFS(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "get image diffIDs")
+	}
+	chainID := imageidentity.ChainID(diffIDs)
+
+	size, err := i.Size(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "get image compressed resource size")
+	}
+
+	desc, err := i.Config(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "get image config descriptor")
+	}
+	id := desc.Digest.String()
+
+	rb, err := content.ReadBlob(ctx, i.ContentStore(), desc)
+	if err != nil {
+		return nil, errors.Wrap(err, "read image config from content store")
+	}
+	var ociimage imagespec.Image
+	if err := json.Unmarshal(rb, &ociimage); err != nil {
+		return nil, errors.Wrapf(err, "unmarshal image config %s", rb)
+	}
+
+	return &Image{
+		ID:         id,
+		References: []string{i.Name()},
+		ChainID:    chainID.String(),
+		Size:       size,
+		ImageSpec:  ociimage,
+		Image:      i,
+	}, nil
+}
+
+// Resolve resolves a image reference to image id.
+func (s *Store) Resolve(ref string) (string, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	id, ok := s.refCache[ref]
+	if !ok {
+		return "", storeutil.ErrNotExist
+	}
+	return id, nil
+}
+
+// Get gets image metadata by image id. The id can be truncated.
+// Returns various validation errors if the image id is invalid.
+// Returns storeutil.ErrNotExist if the image doesn't exist.
+func (s *Store) Get(id string) (Image, error) {
+	return s.store.get(id)
+}
+
+// List lists all images.
+func (s *Store) List() []Image {
+	return s.store.list()
+}
+
+type store struct {
 	lock      sync.RWMutex
 	images    map[string]Image
 	digestSet *digestset.Set
 }
 
-// NewStore creates an image store.
-func NewStore() *Store {
-	return &Store{
-		images:    make(map[string]Image),
-		digestSet: digestset.NewSet(),
+func (s *store) list() []Image {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	var images []Image
+	for _, i := range s.images {
+		images = append(images, i)
 	}
+	return images
 }
 
-// Add an image into the store.
-func (s *Store) Add(img Image) error {
+func (s *store) add(img Image) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	if _, err := s.digestSet.Lookup(img.ID); err != nil {
 		if err != digestset.ErrDigestNotFound {
 			return err
 		}
-		if err := s.digestSet.Add(godigest.Digest(img.ID)); err != nil {
+		if err := s.digestSet.Add(imagedigest.Digest(img.ID)); err != nil {
 			return err
 		}
 	}
@@ -80,44 +213,29 @@ func (s *Store) Add(img Image) error {
 		s.images[img.ID] = img
 		return nil
 	}
-	// Or else, merge the repo tags/digests.
-	i.RepoTags = mergeStringSlices(i.RepoTags, img.RepoTags)
-	i.RepoDigests = mergeStringSlices(i.RepoDigests, img.RepoDigests)
+	// Or else, merge the references.
+	i.References = util.MergeStringSlices(i.References, img.References)
 	s.images[img.ID] = i
 	return nil
 }
 
-// Get returns the image with specified id. Returns store.ErrNotExist if the
-// image doesn't exist.
-func (s *Store) Get(id string) (Image, error) {
+func (s *store) get(id string) (Image, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	digest, err := s.digestSet.Lookup(id)
 	if err != nil {
 		if err == digestset.ErrDigestNotFound {
-			err = store.ErrNotExist
+			err = storeutil.ErrNotExist
 		}
 		return Image{}, err
 	}
 	if i, ok := s.images[digest.String()]; ok {
 		return i, nil
 	}
-	return Image{}, store.ErrNotExist
+	return Image{}, storeutil.ErrNotExist
 }
 
-// List lists all images.
-func (s *Store) List() []Image {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-	var images []Image
-	for _, i := range s.images {
-		images = append(images, i)
-	}
-	return images
-}
-
-// Delete deletes the image with specified id.
-func (s *Store) Delete(id string) {
+func (s *store) delete(id, ref string) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	digest, err := s.digestSet.Lookup(id)
@@ -126,22 +244,16 @@ func (s *Store) Delete(id string) {
 		// So we need to return if there are error.
 		return
 	}
+	i, ok := s.images[digest.String()]
+	if !ok {
+		return
+	}
+	i.References = util.SubtractStringSlice(i.References, ref)
+	if len(i.References) != 0 {
+		s.images[digest.String()] = i
+		return
+	}
+	// Remove the image if it is not referenced any more.
 	s.digestSet.Remove(digest) // nolint: errcheck
 	delete(s.images, digest.String())
-}
-
-// mergeStringSlices merges 2 string slices into one and remove duplicated elements.
-func mergeStringSlices(a []string, b []string) []string {
-	set := map[string]struct{}{}
-	for _, s := range a {
-		set[s] = struct{}{}
-	}
-	for _, s := range b {
-		set[s] = struct{}{}
-	}
-	var ss []string
-	for s := range set {
-		ss = append(ss, s)
-	}
-	return ss
 }

--- a/pkg/store/image/image_test.go
+++ b/pkg/store/image/image_test.go
@@ -17,65 +17,61 @@ limitations under the License.
 package image
 
 import (
+	"sort"
 	"strings"
 	"testing"
 
-	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/docker/distribution/digestset"
 	assertlib "github.com/stretchr/testify/assert"
 
-	"github.com/containerd/cri/pkg/store"
+	storeutil "github.com/containerd/cri/pkg/store"
 )
 
-func TestImageStore(t *testing.T) {
+func TestInternalStore(t *testing.T) {
 	images := []Image{
 		{
-			ID:          "sha256:1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-			ChainID:     "test-chain-id-1",
-			RepoTags:    []string{"tag-1"},
-			RepoDigests: []string{"digest-1"},
-			Size:        10,
-			ImageSpec:   imagespec.Image{},
+			ID:         "sha256:1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			ChainID:    "test-chain-id-1",
+			References: []string{"ref-1"},
+			Size:       10,
 		},
 		{
-			ID:          "sha256:2123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-			ChainID:     "test-chain-id-2abcd",
-			RepoTags:    []string{"tag-2abcd"},
-			RepoDigests: []string{"digest-2abcd"},
-			Size:        20,
-			ImageSpec:   imagespec.Image{},
+			ID:         "sha256:2123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			ChainID:    "test-chain-id-2abcd",
+			References: []string{"ref-2abcd"},
+			Size:       20,
 		},
 		{
-			ID:          "sha256:3123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-			RepoTags:    []string{"tag-4a333"},
-			RepoDigests: []string{"digest-4a333"},
-			ChainID:     "test-chain-id-4a333",
-			Size:        30,
-			ImageSpec:   imagespec.Image{},
+			ID:         "sha256:3123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			References: []string{"ref-4a333"},
+			ChainID:    "test-chain-id-4a333",
+			Size:       30,
 		},
 		{
-			ID:          "sha256:4123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-			RepoTags:    []string{"tag-4abcd"},
-			RepoDigests: []string{"digest-4abcd"},
-			ChainID:     "test-chain-id-4abcd",
-			Size:        40,
-			ImageSpec:   imagespec.Image{},
+			ID:         "sha256:4123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			References: []string{"ref-4abcd"},
+			ChainID:    "test-chain-id-4abcd",
+			Size:       40,
 		},
 	}
 	assert := assertlib.New(t)
 	genTruncIndex := func(normalName string) string { return normalName[:(len(normalName)+1)/2] }
 
-	s := NewStore()
+	s := &store{
+		images:    make(map[string]Image),
+		digestSet: digestset.NewSet(),
+	}
 
 	t.Logf("should be able to add image")
 	for _, img := range images {
-		err := s.Add(img)
+		err := s.add(img)
 		assert.NoError(err)
 	}
 
 	t.Logf("should be able to get image")
 	for _, v := range images {
 		truncID := genTruncIndex(v.ID)
-		got, err := s.Get(truncID)
+		got, err := s.get(truncID)
 		assert.NoError(err, "truncID:%s, fullID:%s", truncID, v.ID)
 		assert.Equal(v, got)
 	}
@@ -83,7 +79,7 @@ func TestImageStore(t *testing.T) {
 	t.Logf("should be able to get image by truncated imageId without algorithm")
 	for _, v := range images {
 		truncID := genTruncIndex(v.ID[strings.Index(v.ID, ":")+1:])
-		got, err := s.Get(truncID)
+		got, err := s.get(truncID)
 		assert.NoError(err, "truncID:%s, fullID:%s", truncID, v.ID)
 		assert.Equal(v, got)
 	}
@@ -91,54 +87,162 @@ func TestImageStore(t *testing.T) {
 	t.Logf("should not be able to get image by ambiguous prefix")
 	ambiguousPrefixs := []string{"sha256", "sha256:"}
 	for _, v := range ambiguousPrefixs {
-		_, err := s.Get(v)
+		_, err := s.get(v)
 		assert.NotEqual(nil, err)
 	}
 
 	t.Logf("should be able to list images")
-	imgs := s.List()
+	imgs := s.list()
 	assert.Len(imgs, len(images))
 
 	imageNum := len(images)
 	for _, v := range images {
 		truncID := genTruncIndex(v.ID)
-		oldRepoTag := v.RepoTags[0]
-		oldRepoDigest := v.RepoDigests[0]
-		newRepoTag := oldRepoTag + "new"
-		newRepoDigest := oldRepoDigest + "new"
+		oldRef := v.References[0]
+		newRef := oldRef + "new"
 
-		t.Logf("should be able to add new repo tags/digests")
+		t.Logf("should be able to add new references")
 		newImg := v
-		newImg.RepoTags = []string{newRepoTag}
-		newImg.RepoDigests = []string{newRepoDigest}
-		err := s.Add(newImg)
+		newImg.References = []string{newRef}
+		err := s.add(newImg)
 		assert.NoError(err)
-		got, err := s.Get(truncID)
+		got, err := s.get(truncID)
 		assert.NoError(err)
-		assert.Len(got.RepoTags, 2)
-		assert.Contains(got.RepoTags, oldRepoTag, newRepoTag)
-		assert.Len(got.RepoDigests, 2)
-		assert.Contains(got.RepoDigests, oldRepoDigest, newRepoDigest)
+		assert.Len(got.References, 2)
+		assert.Contains(got.References, oldRef, newRef)
 
-		t.Logf("should not be able to add duplicated repo tags/digests")
-		err = s.Add(newImg)
+		t.Logf("should not be able to add duplicated references")
+		err = s.add(newImg)
 		assert.NoError(err)
-		got, err = s.Get(truncID)
+		got, err = s.get(truncID)
 		assert.NoError(err)
-		assert.Len(got.RepoTags, 2)
-		assert.Contains(got.RepoTags, oldRepoTag, newRepoTag)
-		assert.Len(got.RepoDigests, 2)
-		assert.Contains(got.RepoDigests, oldRepoDigest, newRepoDigest)
+		assert.Len(got.References, 2)
+		assert.Contains(got.References, oldRef, newRef)
+
+		t.Logf("should be able to delete image references")
+		s.delete(truncID, oldRef)
+		got, err = s.get(truncID)
+		assert.NoError(err)
+		assert.Equal([]string{newRef}, got.References)
 
 		t.Logf("should be able to delete image")
-		s.Delete(truncID)
-		imageNum--
-		imgs = s.List()
-		assert.Len(imgs, imageNum)
+		s.delete(truncID, newRef)
+		got, err = s.get(truncID)
+		assert.Equal(storeutil.ErrNotExist, err)
+		assert.Equal(Image{}, got)
 
-		t.Logf("get should return empty struct and ErrNotExist after deletion")
-		img, err := s.Get(truncID)
-		assert.Equal(Image{}, img)
-		assert.Equal(store.ErrNotExist, err)
+		imageNum--
+		imgs = s.list()
+		assert.Len(imgs, imageNum)
+	}
+}
+
+func TestImageStore(t *testing.T) {
+	id := "sha256:1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	newID := "sha256:9923456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	image := Image{
+		ID:         id,
+		ChainID:    "test-chain-id-1",
+		References: []string{"ref-1"},
+		Size:       10,
+	}
+	assert := assertlib.New(t)
+
+	equal := func(i1, i2 Image) {
+		sort.Strings(i1.References)
+		sort.Strings(i2.References)
+		assert.Equal(i1, i2)
+	}
+	for desc, test := range map[string]struct {
+		ref      string
+		image    *Image
+		expected []Image
+	}{
+		"nothing should happen if a non-exist ref disappear": {
+			ref:      "ref-2",
+			image:    nil,
+			expected: []Image{image},
+		},
+		"new ref for an existing image": {
+			ref: "ref-2",
+			image: &Image{
+				ID:         id,
+				ChainID:    "test-chain-id-1",
+				References: []string{"ref-2"},
+				Size:       10,
+			},
+			expected: []Image{
+				{
+					ID:         id,
+					ChainID:    "test-chain-id-1",
+					References: []string{"ref-1", "ref-2"},
+					Size:       10,
+				},
+			},
+		},
+		"new ref for a new image": {
+			ref: "ref-2",
+			image: &Image{
+				ID:         newID,
+				ChainID:    "test-chain-id-2",
+				References: []string{"ref-2"},
+				Size:       20,
+			},
+			expected: []Image{
+				image,
+				{
+					ID:         newID,
+					ChainID:    "test-chain-id-2",
+					References: []string{"ref-2"},
+					Size:       20,
+				},
+			},
+		},
+		"existing ref point to a new image": {
+			ref: "ref-1",
+			image: &Image{
+				ID:         newID,
+				ChainID:    "test-chain-id-2",
+				References: []string{"ref-1"},
+				Size:       20,
+			},
+			expected: []Image{
+				{
+					ID:         newID,
+					ChainID:    "test-chain-id-2",
+					References: []string{"ref-1"},
+					Size:       20,
+				},
+			},
+		},
+		"existing ref disappear": {
+			ref:      "ref-1",
+			image:    nil,
+			expected: []Image{},
+		},
+	} {
+		t.Logf("TestCase %q", desc)
+		s, err := NewFakeStore([]Image{image})
+		assert.NoError(err)
+		assert.NoError(s.update(test.ref, test.image))
+
+		assert.Len(s.List(), len(test.expected))
+		for _, expect := range test.expected {
+			got, err := s.Get(expect.ID)
+			assert.NoError(err)
+			equal(got, expect)
+			for _, ref := range expect.References {
+				id, err := s.Resolve(ref)
+				assert.NoError(err)
+				assert.Equal(expect.ID, id)
+			}
+		}
+
+		if test.image == nil {
+			// Shouldn't be able to index by removed ref.
+			id, err := s.Resolve(test.ref)
+			assert.Equal(storeutil.ErrNotExist, err)
+			assert.Empty(id)
+		}
 	}
 }

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -41,3 +41,19 @@ func SubtractStringSlice(ss []string, str string) []string {
 	}
 	return res
 }
+
+// MergeStringSlices merges 2 string slices into one and remove duplicated elements.
+func MergeStringSlices(a []string, b []string) []string {
+	set := map[string]struct{}{}
+	for _, s := range a {
+		set[s] = struct{}{}
+	}
+	for _, s := range b {
+		set[s] = struct{}{}
+	}
+	var ss []string
+	for s := range set {
+		ss = append(ss, s)
+	}
+	return ss
+}

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -46,3 +46,14 @@ func TestSubtractStringSlice(t *testing.T) {
 	assert.Empty(t, SubtractStringSlice(nil, "hij"))
 	assert.Empty(t, SubtractStringSlice([]string{}, "hij"))
 }
+
+func TestMergeStringSlices(t *testing.T) {
+	s1 := []string{"abc", "def", "ghi"}
+	s2 := []string{"def", "jkl", "mno"}
+	expect := []string{"abc", "def", "ghi", "jkl", "mno"}
+	result := MergeStringSlices(s1, s2)
+	assert.Len(t, result, len(expect))
+	for _, s := range expect {
+		assert.Contains(t, result, s)
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/containerd/cri/issues/760.
Based on https://github.com/containerd/cri/pull/864.

This PR:
* Creates an in memory cache of containerd image references.
  * The cache is updated when:
    a) `cri` plugin creates or removes an image reference. This makes sure image reference cache is up-to-date after `cri` pulling or deleting an image.
    b) Event monitor receives an image event (create/update/delete). This makes sure image references created/deleted outside of `cri` can trigger a cache update, e.g. `ctr --namespace=k8s.io images pull`.
  * All other `cri` functions, which only read data image information, will treat the cache as the source of truth for images, so that `cri` doesn't need to frequently access containerd metadata/content store and easily index by image id.
  * Please note that all data in the cache is generated from containerd. a) and b) above only triggers a cache update. This makes sure there is no multi-writer race condition.
* Merge `RepoTags` and `RepoDigests` into a `References` field in the image store. For containerd, there is only image reference, only CRI has the `RepoTag` and `RepoDigest` concepts.
  * The `References` field reflects the references in containerd regardless of the reference format.
  * When `cri` generates CRI image status, it goes through all references, and pick out `RepoTags` and `RepoDigests`.
  * When `cri` pulls images, we'll still create repodigest and repotag as the image references, because of https://github.com/containerd/cri/issues/760#issuecomment-386752652. However, when users use `ctr --namespace=k8s.io images pull` to pull images, they can do whatever they want. They just need to understand that if their image doesn't have a reference in `repotag` or `repodigest` format, the corresponding CRI fields `RepoTags` and `RepoDigests` will be empty.

With this PR:
1) `cri` will be able to see images pulled/loaded with `ctr`, and we can remove `ctr cri` command once we have `ctr import` ready.
2) `repotag` which has pointed to a new image, won't show up in  `RepoTags` field of the old image. We have this bug before this PR.

/cc @crosbymichael @dmcgowan @stevvooe 