### PR TITLE
Sort volume mount.

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -19,6 +19,7 @@ package server
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -349,8 +350,8 @@ func (c *criService) generateContainerSpec(id string, sandboxID string, sandboxP
 		return nil, errors.Wrapf(err, "failed to init selinux options %+v", securityContext.GetSelinuxOptions())
 	}
 
-	// Add extra mounts first so that CRI specified mounts can override.
-	mounts := append(extraMounts, config.GetMounts()...)
+	// Merge extra mounts and CRI mounts.
+	mounts := mergeMounts(config.GetMounts(), extraMounts)
 	if err := c.addOCIBindMounts(&g, mounts, mountLabel); err != nil {
 		return nil, errors.Wrapf(err, "failed to set OCI bind mounts %+v", mounts)
 	}
@@ -596,6 +597,10 @@ func setOCIDevicesPrivileged(g *generate.Generator) error {
 
 // addOCIBindMounts adds bind mounts.
 func (c *criService) addOCIBindMounts(g *generate.Generator, mounts []*runtime.Mount, mountLabel string) error {
+	// Sort mounts in number of parts. This ensures that high level mounts don't
+	// shadow other mounts.
+	sort.Sort(orderedMounts(mounts))
+
 	// Mount cgroup into the container as readonly, which inherits docker's behavior.
 	g.AddMount(runtimespec.Mount{
 		Source:      "cgroup",
@@ -603,6 +608,29 @@ func (c *criService) addOCIBindMounts(g *generate.Generator, mounts []*runtime.M
 		Type:        "cgroup",
 		Options:     []string{"nosuid", "noexec", "nodev", "relatime", "ro"},
 	})
+
+	// Copy all mounts from default mounts, except for
+	// - mounts overriden by supplied mount;
+	// - all mounts under /dev if a supplied /dev is present.
+	mountSet := make(map[string]struct{})
+	for _, m := range mounts {
+		mountSet[filepath.Clean(m.ContainerPath)] = struct{}{}
+	}
+	defaultMounts := g.Mounts()
+	g.ClearMounts()
+	for _, m := range defaultMounts {
+		dst := filepath.Clean(m.Destination)
+		if _, ok := mountSet[dst]; ok {
+			// filter out mount overridden by a supplied mount
+			continue
+		}
+		if _, mountDev := mountSet["/dev"]; mountDev && strings.HasPrefix(dst, "/dev/") {
+			// filter out everything under /dev if /dev is a supplied mount
+			continue
+		}
+		g.AddMount(m)
+	}
+
 	for _, mount := range mounts {
 		dst := mount.GetContainerPath()
 		src := mount.GetHostPath()
@@ -821,10 +849,6 @@ func defaultRuntimeSpec(id string) (*runtimespec.Spec, error) {
 		if mount.Destination == "/run" {
 			continue
 		}
-		// CRI plugin handles `/dev/shm` itself.
-		if mount.Destination == "/dev/shm" {
-			continue
-		}
 		mounts = append(mounts, mount)
 	}
 	spec.Mounts = mounts
@@ -967,4 +991,26 @@ func generateUserString(username string, uid, gid *runtime.Int64Value) (string, 
 		userstr = userstr + ":" + groupstr
 	}
 	return userstr, nil
+}
+
+// mergeMounts merge CRI mounts with extra mounts. If a mount destination
+// is mounted by both a CRI mount and an extra mount, the CRI mount will
+// be kept.
+func mergeMounts(criMounts, extraMounts []*runtime.Mount) []*runtime.Mount {
+	var mounts []*runtime.Mount
+	mounts = append(mounts, criMounts...)
+	// Copy all mounts from extra mounts, except for mounts overriden by CRI.
+	for _, e := range extraMounts {
+		found := false
+		for _, c := range criMounts {
+			if filepath.Clean(e.ContainerPath) == filepath.Clean(c.ContainerPath) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			mounts = append(mounts, e)
+		}
+	}
+	return mounts
 }

--- a/pkg/server/helpers_test.go
+++ b/pkg/server/helpers_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/containerd/containerd"
@@ -25,6 +26,7 @@ import (
 	imagedigest "github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
+	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
 	criconfig "github.com/containerd/cri/pkg/config"
 	"github.com/containerd/cri/pkg/util"
@@ -189,4 +191,25 @@ func TestGetRuntimeConfigFromContainerInfo(t *testing.T) {
 			assert.Equal(t, test.expectedRuntime, r)
 		})
 	}
+}
+
+func TestOrderedMounts(t *testing.T) {
+	mounts := []*runtime.Mount{
+		{ContainerPath: "/a/b/c"},
+		{ContainerPath: "/a/b"},
+		{ContainerPath: "/a/b/c/d"},
+		{ContainerPath: "/a"},
+		{ContainerPath: "/b"},
+		{ContainerPath: "/b/c"},
+	}
+	expected := []*runtime.Mount{
+		{ContainerPath: "/a"},
+		{ContainerPath: "/b"},
+		{ContainerPath: "/a/b"},
+		{ContainerPath: "/b/c"},
+		{ContainerPath: "/a/b/c"},
+		{ContainerPath: "/a/b/c/d"},
+	}
+	sort.Stable(orderedMounts(mounts))
+	assert.Equal(t, expected, mounts)
 }


### PR DESCRIPTION
Fixes https://github.com/containerd/containerd/issues/2596.

We should cherry-pick this fix into all supported branches.

This PR:
1) Makes sure volume mounts are sorted based by depth, so that parent directory mount won't override the sub directory mount. (Corresponding docker code: https://github.com/moby/moby/blob/a9bd60d674f85c2161bb702404b23501d6b746c3/daemon/volumes_unix.go#L97)
2) Skip default mount or cri plugin controlled mount if the destination is mounted by CRI already.
3) Skip all default `/dev` mounts if `/dev` is mounted in CRI. (Corresponding docker code: https://github.com/moby/moby/blob/a9bd60d674f85c2161bb702404b23501d6b746c3/daemon/oci_linux.go#L555)

Signed-off-by: Lantao Liu <lantaol@google.com>