### PR TITLE
Add HOSTNAME to env by default for pod containers

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -341,6 +341,8 @@ func (c *criService) generateContainerSpec(id string, sandboxID string, sandboxP
 	for _, e := range config.GetEnvs() {
 		g.AddProcessEnv(e.GetKey(), e.GetValue())
 	}
+	// add the HOSTNAME variable to the environment to match Docker runtime default
+	g.AddProcessEnv("HOSTNAME", sandboxConfig.GetHostname())
 
 	securityContext := config.GetLinux().GetSecurityContext()
 	selinuxOpt := securityContext.GetSelinuxOptions()


### PR DESCRIPTION
To match expectations of users coming from Docker engine runtime, add
the HOSTNAME to the environment of new containers in a pod.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>