### PR TITLE
Skip sctp protocol hostport mapping.

### DIFF
--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -558,6 +558,9 @@ func toCNIPortMappings(criPortMappings []*runtime.PortMapping) []cni.PortMapping
 		if mapping.HostPort <= 0 {
 			continue
 		}
+		if mapping.Protocol != runtime.Protocol_TCP && mapping.Protocol != runtime.Protocol_UDP {
+			continue
+		}
 		portMappings = append(portMappings, cni.PortMapping{
 			HostPort:      mapping.HostPort,
 			ContainerPort: mapping.ContainerPort,

--- a/pkg/server/sandbox_run_test.go
+++ b/pkg/server/sandbox_run_test.go
@@ -403,6 +403,30 @@ func TestToCNIPortMappings(t *testing.T) {
 				},
 			},
 		},
+		"CRI port mapping with unsupported protocol should be skipped": {
+			criPortMappings: []*runtime.PortMapping{
+				{
+					Protocol:      runtime.Protocol_SCTP,
+					ContainerPort: 1234,
+					HostPort:      5678,
+					HostIp:        "123.124.125.126",
+				},
+				{
+					Protocol:      runtime.Protocol_TCP,
+					ContainerPort: 4321,
+					HostPort:      8765,
+					HostIp:        "126.125.124.123",
+				},
+			},
+			cniPortMappings: []cni.PortMapping{
+				{
+					HostPort:      8765,
+					ContainerPort: 4321,
+					Protocol:      "tcp",
+					HostIP:        "126.125.124.123",
+				},
+			},
+		},
 	} {
 		t.Logf("TestCase %q", desc)
 		assert.Equal(t, test.cniPortMappings, toCNIPortMappings(test.criPortMappings))


### PR DESCRIPTION
Fixes https://github.com/containerd/cri/issues/907.

I asked Tim Hockin about this. He explains to me why we need to skip sctp hostport mapping. The reason is documented in the original KEP https://contributor.kubernetes.io/keps/sig-network/0015-20180614-sctp-support/#interworking-with-applications-that-use-a-user-space-sctp-stack:
```
As a user of Kubernetes I want to deploy and run my applications that use a userspace SCTP stack, and at the same time I want to define SCTP Services in the same cluster.
...
a userspace SCTP stack cannot co-exist with the SCTP kernel module (lksctp) on the same node.
...
On the Kubernetes side we solve this problem so, that we do not start listening on the SCTP ports defined for Servies with ClusterIP or NodePort or externalIP, neither in the case when containers with SCTP HostPort are defined. On this way we avoid the loading of the kernel module due to Kubernetes actions.
```

Basically we don't want to break users who are using user space SCTP, so we avoid doing SCTP in Kubernetes. And users can schedule their kernel SCTP application and userspace SCTP application onto different nodes.

Signed-off-by: Lantao Liu <lantaol@google.com>