### PR TITLE
Show runtime handler in sandbox debug info.

### DIFF
--- a/pkg/server/container_status.go
+++ b/pkg/server/container_status.go
@@ -113,7 +113,6 @@ type containerInfo struct {
 }
 
 // toCRIContainerInfo converts internal container object information to CRI container status response info map.
-// TODO(random-liu): Return error instead of logging.
 func toCRIContainerInfo(ctx context.Context, container containerstore.Container, verbose bool) (map[string]string, error) {
 	if !verbose {
 		return nil, nil

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -74,9 +74,10 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	// Create initial internal sandbox object.
 	sandbox := sandboxstore.NewSandbox(
 		sandboxstore.Metadata{
-			ID:     id,
-			Name:   name,
-			Config: config,
+			ID:             id,
+			Name:           name,
+			Config:         config,
+			RuntimeHandler: r.GetRuntimeHandler(),
 		},
 		sandboxstore.Status{
 			State: sandboxstore.StateUnknown,

--- a/pkg/server/sandbox_status.go
+++ b/pkg/server/sandbox_status.go
@@ -102,15 +102,16 @@ func toCRISandboxStatus(meta sandboxstore.Metadata, status sandboxstore.Status, 
 
 // TODO (mikebrow): discuss predefining constants structures for some or all of these field names in CRI
 type sandboxInfo struct {
-	Pid         uint32                    `json:"pid"`
-	Status      string                    `json:"processStatus"`
-	NetNSClosed bool                      `json:"netNamespaceClosed"`
-	Image       string                    `json:"image"`
-	SnapshotKey string                    `json:"snapshotKey"`
-	Snapshotter string                    `json:"snapshotter"`
-	Runtime     *criconfig.Runtime        `json:"runtime"`
-	Config      *runtime.PodSandboxConfig `json:"config"`
-	RuntimeSpec *runtimespec.Spec         `json:"runtimeSpec"`
+	Pid            uint32                    `json:"pid"`
+	Status         string                    `json:"processStatus"`
+	NetNSClosed    bool                      `json:"netNamespaceClosed"`
+	Image          string                    `json:"image"`
+	SnapshotKey    string                    `json:"snapshotKey"`
+	Snapshotter    string                    `json:"snapshotter"`
+	RuntimeHandler string                    `json:"runtimeHandler"`
+	Runtime        *criconfig.Runtime        `json:"runtime"`
+	Config         *runtime.PodSandboxConfig `json:"config"`
+	RuntimeSpec    *runtimespec.Spec         `json:"runtimeSpec"`
 }
 
 // toCRISandboxInfo converts internal container object information to CRI sandbox status response info map.
@@ -132,9 +133,10 @@ func toCRISandboxInfo(ctx context.Context, sandbox sandboxstore.Sandbox) (map[st
 	}
 
 	si := &sandboxInfo{
-		Pid:    sandbox.Status.Get().Pid,
-		Status: string(processStatus),
-		Config: sandbox.Config,
+		Pid:            sandbox.Status.Get().Pid,
+		RuntimeHandler: sandbox.RuntimeHandler,
+		Status:         string(processStatus),
+		Config:         sandbox.Config,
 	}
 
 	if si.Status == "" {

--- a/pkg/store/sandbox/metadata.go
+++ b/pkg/store/sandbox/metadata.go
@@ -54,6 +54,8 @@ type Metadata struct {
 	NetNSPath string
 	// IP of Pod if it is attached to non host network
 	IP string
+	// RuntimeHandler is the runtime handler name of the pod.
+	RuntimeHandler string
 }
 
 // MarshalJSON encodes Metadata into bytes in json format.


### PR DESCRIPTION
Fixes https://github.com/containerd/cri/issues/915.

Added `runtimeHandler` in sandbox debug info. Not sure whether we should add it to container debug info, given that runtime handler is a sandbox level configuration. Only add to sandbox debug info for now.

Signed-off-by: Lantao Liu <lantaol@google.com>