### PR TITLE
corrects syntax error in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ help:
 	@echo " * 'verify'           	- Execute the source code verification tools"
 	@echo " * 'proto'            	- Update protobuf of the cri plugin api"
 	@echo " * 'install.tools'    	- Install tools used by verify"
-	@echo " * 'install.deps'     	- Install dependencies of cri (Note: BUILDTAGS defaults to 'seccomp apparmor' for runc build")
+	@echo " * 'install.deps'     	- Install dependencies of cri (Note: BUILDTAGS defaults to 'seccomp apparmor' for runc build)"
 	@echo " * 'uninstall'        	- Remove installed binaries from system locations"
 	@echo " * 'version'          	- Print current cri plugin release version"
 	@echo " * 'update-vendor'    	- Syncs containerd/vendor.conf -> vendor.conf and sorts vendor.conf"


### PR DESCRIPTION
fixes syntax issue with "make help" command 

before:  
```
 * 'install.tools'    	- Install tools used by verify
/bin/sh: 1: Syntax error: ")" unexpected
Makefile:41: recipe for target 'help' failed
make: *** [help] Error 2
```
after:
```
 * 'install.tools'    	- Install tools used by verify
 * 'install.deps'     	- Install dependencies of cri (Note: BUILDTAGS defaults to 'seccomp apparmor' for runc build)
 * 'uninstall'        	- Remove installed binaries from system locations
 * 'version'          	- Print current cri plugin release version
 * 'update-vendor'    	- Syncs containerd/vendor.conf -> vendor.conf and sorts vendor.conf
```


Signed-off-by: Mike Brown <brownwm@us.ibm.com>