### PR TITLE
test: Fix compile error with go1.10.2

### DIFF
--- a/integration/image_load_test.go
+++ b/integration/image_load_test.go
@@ -36,7 +36,7 @@ func TestImageLoad(t *testing.T) {
 	loadedImage := "docker.io/library/" + testImage
 	_, err := exec.LookPath("docker")
 	if err != nil {
-		t.Skip("Docker is not available: %v", err)
+		t.Skipf("Docker is not available: %v", err)
 	}
 	t.Logf("docker save image into tarball")
 	output, err := exec.Command("docker", "pull", testImage).CombinedOutput()


### PR DESCRIPTION
Replace Skip with Skipf in the intergration test.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>