### PR TITLE
Support runtime specific configurations.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package config
 
-import "github.com/containerd/containerd"
+import (
+	"github.com/BurntSushi/toml"
+	"github.com/containerd/containerd"
+)
 
 // Runtime struct to contain the type(ID), engine, and root variables for a default runtime
 // and a runtime for untrusted worload.
@@ -24,9 +27,16 @@ type Runtime struct {
 	// Type is the runtime type to use in containerd e.g. io.containerd.runtime.v1.linux
 	Type string `toml:"runtime_type" json:"runtimeType"`
 	// Engine is the name of the runtime engine used by containerd.
+	// This only works for runtime type "io.containerd.runtime.v1.linux".
+	// DEPRECATED: use Options instead. Remove when shim v1 is deprecated.
 	Engine string `toml:"runtime_engine" json:"runtimeEngine"`
 	// Root is the directory used by containerd for runtime state.
+	// DEPRECATED: use Options instead. Remove when shim v1 is deprecated.
+	// This only works for runtime type "io.containerd.runtime.v1.linux".
 	Root string `toml:"runtime_root" json:"runtimeRoot"`
+	// Options are config options for the runtime. If options is loaded
+	// from toml config, it will be toml.Primitive.
+	Options *toml.Primitive `toml:"options" json:"options"`
 }
 
 // ContainerdConfig contains toml config related to containerd
@@ -46,6 +56,8 @@ type ContainerdConfig struct {
 	// configurations, to the matching configurations.
 	Runtimes map[string]Runtime `toml:"runtimes" json:"runtimes"`
 	// NoPivot disables pivot-root (linux only), required when running a container in a RamDisk with runc
+	// This only works for runtime type "io.containerd.runtime.v1.linux".
+	// DEPRECATED: use Runtime.Options instead. Remove when shim v1 is deprecated.
 	NoPivot bool `toml:"no_pivot" json:"noPivot"`
 }
 
@@ -119,6 +131,8 @@ type PluginConfig struct {
 	// StatsCollectPeriod is the period (in seconds) of snapshots stats collection.
 	StatsCollectPeriod int `toml:"stats_collect_period" json:"statsCollectPeriod"`
 	// SystemdCgroup enables systemd cgroup support.
+	// This only works for runtime type "io.containerd.runtime.v1.linux".
+	// DEPRECATED: config runc runtime handler instead. Remove when shim v1 is deprecated.
 	SystemdCgroup bool `toml:"systemd_cgroup" json:"systemdCgroup"`
 	// EnableTLSStreaming indicates to enable the TLS streaming support.
 	EnableTLSStreaming bool `toml:"enable_tls_streaming" json:"enableTLSStreaming"`

--- a/pkg/server/container_start.go
+++ b/pkg/server/container_start.go
@@ -108,8 +108,14 @@ func (c *criService) startContainer(ctx context.Context,
 		return cntr.IO, nil
 	}
 
+	ctrInfo, err := container.Info(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get container info")
+	}
+
 	var taskOpts []containerd.NewTaskOpts
-	if c.config.NoPivot {
+	// TODO(random-liu): Remove this after shim v1 is deprecated.
+	if c.config.NoPivot && ctrInfo.Runtime.Name == linuxRuntime {
 		taskOpts = append(taskOpts, containerd.WithNoPivotRoot)
 	}
 	task, err := container.NewTask(ctx, ioCreation, taskOpts...)

--- a/pkg/server/container_status.go
+++ b/pkg/server/container_status.go
@@ -24,7 +24,6 @@ import (
 	"golang.org/x/net/context"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
-	criconfig "github.com/containerd/cri/pkg/config"
 	containerstore "github.com/containerd/cri/pkg/store/container"
 )
 
@@ -102,14 +101,15 @@ func toCRIContainerStatus(container containerstore.Container, spec *runtime.Imag
 
 type containerInfo struct {
 	// TODO(random-liu): Add sandboxID in CRI container status.
-	SandboxID   string                   `json:"sandboxID"`
-	Pid         uint32                   `json:"pid"`
-	Removing    bool                     `json:"removing"`
-	SnapshotKey string                   `json:"snapshotKey"`
-	Snapshotter string                   `json:"snapshotter"`
-	Runtime     *criconfig.Runtime       `json:"runtime"`
-	Config      *runtime.ContainerConfig `json:"config"`
-	RuntimeSpec *runtimespec.Spec        `json:"runtimeSpec"`
+	SandboxID      string                   `json:"sandboxID"`
+	Pid            uint32                   `json:"pid"`
+	Removing       bool                     `json:"removing"`
+	SnapshotKey    string                   `json:"snapshotKey"`
+	Snapshotter    string                   `json:"snapshotter"`
+	RuntimeType    string                   `json:"runtimeType"`
+	RuntimeOptions interface{}              `json:"runtimeOptions"`
+	Config         *runtime.ContainerConfig `json:"config"`
+	RuntimeSpec    *runtimespec.Spec        `json:"runtimeSpec"`
 }
 
 // toCRIContainerInfo converts internal container object information to CRI container status response info map.
@@ -142,11 +142,12 @@ func toCRIContainerInfo(ctx context.Context, container containerstore.Container,
 	ci.SnapshotKey = ctrInfo.SnapshotKey
 	ci.Snapshotter = ctrInfo.Snapshotter
 
-	ociRuntime, err := getRuntimeConfigFromContainerInfo(ctrInfo)
+	runtimeOptions, err := getRuntimeOptions(ctrInfo)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get container runtime config")
+		return nil, errors.Wrap(err, "failed to get runtime options")
 	}
-	ci.Runtime = &ociRuntime
+	ci.RuntimeType = ctrInfo.Runtime.Name
+	ci.RuntimeOptions = runtimeOptions
 
 	infoBytes, err := json.Marshal(ci)
 	if err != nil {

--- a/pkg/server/helpers.go
+++ b/pkg/server/helpers.go
@@ -25,8 +25,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/BurntSushi/toml"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/runtime/linux/runctypes"
+	runcoptions "github.com/containerd/containerd/runtime/v2/runc/options"
 	"github.com/containerd/typeurl"
 	"github.com/docker/distribution/reference"
 	imagedigest "github.com/opencontainers/go-digest"
@@ -121,6 +123,14 @@ const (
 	// networkAttachCount is the minimum number of networks the PodSandbox
 	// attaches to
 	networkAttachCount = 2
+)
+
+// Runtime type strings for various runtimes.
+const (
+	// linuxRuntime is the legacy linux runtime for shim v1.
+	linuxRuntime = "io.containerd.runtime.v1.linux"
+	// runcRuntime is the runc runtime for shim v2.
+	runcRuntime = "io.containerd.runc.v1"
 )
 
 // makeSandboxName generates sandbox name from sandbox metadata. The name
@@ -390,26 +400,6 @@ func getPodCNILabels(id string, config *runtime.PodSandboxConfig) map[string]str
 	}
 }
 
-// getRuntimeConfigFromContainerInfo gets runtime configuration from containerd
-// container info.
-func getRuntimeConfigFromContainerInfo(c containers.Container) (criconfig.Runtime, error) {
-	r := criconfig.Runtime{
-		Type: c.Runtime.Name,
-	}
-	if c.Runtime.Options == nil {
-		// CRI plugin makes sure that runtime option is always set.
-		return criconfig.Runtime{}, errors.New("runtime options is nil")
-	}
-	data, err := typeurl.UnmarshalAny(c.Runtime.Options)
-	if err != nil {
-		return criconfig.Runtime{}, errors.Wrap(err, "failed to unmarshal runtime options")
-	}
-	runtimeOpts := data.(*runctypes.RuncOptions)
-	r.Engine = runtimeOpts.Runtime
-	r.Root = runtimeOpts.RuntimeRoot
-	return r, nil
-}
-
 // toRuntimeAuthConfig converts cri plugin auth config to runtime auth config.
 func toRuntimeAuthConfig(a criconfig.AuthConfig) *runtime.AuthConfig {
 	return &runtime.AuthConfig{
@@ -463,4 +453,46 @@ func parseImageReferences(refs []string) ([]string, []string) {
 		}
 	}
 	return tags, digests
+}
+
+// generateRuntimeOptions generates runtime options from cri plugin config.
+func generateRuntimeOptions(r criconfig.Runtime, c criconfig.Config) (interface{}, error) {
+	if r.Options == nil {
+		if r.Type != linuxRuntime {
+			return nil, nil
+		}
+		// This is a legacy config, generate runctypes.RuncOptions.
+		return &runctypes.RuncOptions{
+			Runtime:       r.Engine,
+			RuntimeRoot:   r.Root,
+			SystemdCgroup: c.SystemdCgroup,
+		}, nil
+	}
+	options := getRuntimeOptionsType(r.Type)
+	if err := toml.PrimitiveDecode(*r.Options, options); err != nil {
+		return nil, err
+	}
+	return options, nil
+}
+
+// getRuntimeOptionsType gets empty runtime options by the runtime type name.
+func getRuntimeOptionsType(t string) interface{} {
+	switch t {
+	case runcRuntime:
+		return &runcoptions.Options{}
+	default:
+		return &runctypes.RuncOptions{}
+	}
+}
+
+// getRuntimeOptions get runtime options from container metadata.
+func getRuntimeOptions(c containers.Container) (interface{}, error) {
+	if c.Runtime.Options == nil {
+		return nil, nil
+	}
+	opts, err := typeurl.UnmarshalAny(c.Runtime.Options)
+	if err != nil {
+		return nil, err
+	}
+	return opts, nil
 }

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -26,8 +26,7 @@ import (
 	containerdio "github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/oci"
-	"github.com/containerd/containerd/runtime/linux/runctypes"
-	"github.com/containerd/go-cni"
+	cni "github.com/containerd/go-cni"
 	"github.com/containerd/typeurl"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
@@ -172,18 +171,17 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 
 	sandboxLabels := buildLabels(config.Labels, containerKindSandbox)
 
+	runtimeOpts, err := generateRuntimeOptions(ociRuntime, c.config)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to generate runtime options")
+	}
 	opts := []containerd.NewContainerOpts{
 		containerd.WithSnapshotter(c.config.ContainerdConfig.Snapshotter),
 		customopts.WithNewSnapshot(id, image.Image),
 		containerd.WithSpec(spec, specOpts...),
 		containerd.WithContainerLabels(sandboxLabels),
 		containerd.WithContainerExtension(sandboxMetadataExtension, &sandbox.Metadata),
-		containerd.WithRuntime(
-			ociRuntime.Type,
-			&runctypes.RuncOptions{
-				Runtime:       ociRuntime.Engine,
-				RuntimeRoot:   ociRuntime.Root,
-				SystemdCgroup: c.config.SystemdCgroup})} // TODO (mikebrow): add CriuPath when we add support for pause
+		containerd.WithRuntime(ociRuntime.Type, runtimeOpts)}
 
 	container, err := c.client.NewContainer(ctx, id, opts...)
 	if err != nil {
@@ -297,7 +295,8 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 			id, name)
 
 		var taskOpts []containerd.NewTaskOpts
-		if c.config.NoPivot {
+		// TODO(random-liu): Remove this after shim v1 is deprecated.
+		if c.config.NoPivot && ociRuntime.Type == linuxRuntime {
 			taskOpts = append(taskOpts, containerd.WithNoPivotRoot)
 		}
 		// We don't need stdio for sandbox container.


### PR DESCRIPTION
Fixes https://github.com/containerd/containerd/issues/2701.

Support per-runtime configuration in the `cri` config file. The newly introduced `Options` field can be any type. Currently, only supported types are [`options.Options`](https://github.com/containerd/containerd/blob/master/runtime/v2/runc/options/oci.pb.go#L39) for shim v2, and [`runctypes.RuncOptions`](https://github.com/containerd/containerd/blob/master/runtime/linux/runctypes/runc.pb.go#L40). `runctypes.RuncOptions` is the fallback for unknown runtime types.

Change [`getRuntimeType`](https://github.com/containerd/cri/pull/943/files#diff-f41a864ccb9e17c8853f725df14b8e3eR479) to support new option types.

Here is an example config which uses runc with shim v1 as the default runtime, runc with shim v2 as the `runc` runtime, and kata as the `kata` runtime:
```toml
[plugins.cri.containerd.default_runtime]                                                                                           
  runtime_type = "io.containerd.runtime.v1.linux"
# https://github.com/containerd/containerd/blob/v1.2.0-rc.1/runtime/linux/runctypes/runc.pb.go#L40
[plugins.cri.containerd.default_runtime.options]
  Runtime = "runc"
  RuntimeRoot = "/run/containerd/default"

[plugins.cri.containerd.runtimes.runc]
  runtime_type = "io.containerd.runc.v1"
# https://github.com/containerd/containerd/blob/v1.2.0-rc.1/runtime/v2/runc/options/oci.pb.go#L39
[plugins.cri.containerd.runtimes.runc.options]
  BinaryName = "runc"
  Root = "/run/containerd/runc"

[plugins.cri.containerd.runtimes.kata]
  runtime_type = "io.containerd.runtime.kata.v2"
```

Note that the deprecated daemon level config `systemd_cgroup`, `no_pivot`, and runtime level config `runtime_engine`, `runtime_root` still work for the legacy runtime `io.containerd.runtime.v1.linux`. However, 1) they won't work for shim v2 runtimes; 2) they'll be deprecated when shim v1 is deprecated.

It is recommended to use the new `Options` field for all runtimes.

/cc @yujuhong @crosbymichael @tallclair 
Signed-off-by: Lantao Liu <lantaol@google.com>