### PR TITLE
adds golang 1.11.x to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,48 +2,48 @@ git:
   depth: 150
 
 language: go
+go:
+  - 1.11.x
+  - tip
+
+matrix:
+  allow_failures:
+    - go: tip
 
 sudo: required
 
 services:
-    - docker
+  - docker
 
 cache:
-    directories:
-        - "${HOME}/google-cloud-sdk/"
+  directories:
+    - "${HOME}/google-cloud-sdk/"
 
 before_install:
-    # libseccomp in trusty is not new enough, need backports version.
-    - sudo sh -c "echo 'deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse' > /etc/apt/sources.list.d/backports.list"
-    - sudo apt-get update
+  # libseccomp in trusty is not new enough, need backports version.
+  - sudo sh -c "echo 'deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse' > /etc/apt/sources.list.d/backports.list"
+  - sudo apt-get update
 
 install:
-    - sudo apt-get install btrfs-tools
-    - sudo apt-get install libseccomp2/trusty-backports
-    - sudo apt-get install libseccomp-dev/trusty-backports
-    - sudo apt-get install socat
+  - sudo apt-get install btrfs-tools
+  - sudo apt-get install libseccomp2/trusty-backports
+  - sudo apt-get install libseccomp-dev/trusty-backports
+  - sudo apt-get install socat
 
 before_script:
-    - export PATH=$HOME/gopath/bin:$PATH
+  - export PATH=$HOME/gopath/bin:$PATH
 
-jobs:
-  include:
-    - stage: Build
-      script:
-        - make install.tools
-        - make .gitvalidation
-        - make binaries
-      go: "1.10.x"
-    - stage: Test
-      script:
-        - make install.deps
-        - make containerd
-        - sudo PATH=$PATH GOPATH=$GOPATH make install-containerd
-        - make test
-        - make test-integration
-        - make test-cri
-      after_script:
-        # Abuse travis to preserve the log.
-        - cat /tmp/test-integration/containerd.log
-        - cat /tmp/test-cri/containerd.log
-      go: "1.10.x"
+script:
+  - make install.tools
+  - make .gitvalidation
+  - make binaries
+  - make install.deps
+  - make containerd
+  - sudo PATH=$PATH GOPATH=$GOPATH make install-containerd
+  - make test
+  - make test-integration
+  - make test-cri
+after_script:
+  # Abuse travis to preserve the log.
+  - cat /tmp/test-integration/containerd.log
+  - cat /tmp/test-cri/containerd.log

--- a/integration/container_update_resources_test.go
+++ b/integration/container_update_resources_test.go
@@ -51,7 +51,7 @@ func TestUpdateContainerResources(t *testing.T) {
 		"container",
 		pauseImage,
 		WithResources(&runtime.LinuxContainerResources{
-			MemoryLimitInBytes: 2 * 1024 * 1024,
+			MemoryLimitInBytes: 200 * 1024 * 1024,
 		}),
 	)
 	cn, err := runtimeService.CreateContainer(sb, cnConfig, sbConfig)
@@ -62,18 +62,18 @@ func TestUpdateContainerResources(t *testing.T) {
 	require.NoError(t, err)
 	spec, err := container.Spec(context.Background())
 	require.NoError(t, err)
-	checkMemoryLimit(t, spec, 2*1024*1024)
+	checkMemoryLimit(t, spec, 200*1024*1024)
 
 	t.Log("Update container memory limit after created")
 	err = runtimeService.UpdateContainerResources(cn, &runtime.LinuxContainerResources{
-		MemoryLimitInBytes: 4 * 1024 * 1024,
+		MemoryLimitInBytes: 400 * 1024 * 1024,
 	})
 	require.NoError(t, err)
 
 	t.Log("Check memory limit in container OCI spec")
 	spec, err = container.Spec(context.Background())
 	require.NoError(t, err)
-	checkMemoryLimit(t, spec, 4*1024*1024)
+	checkMemoryLimit(t, spec, 400*1024*1024)
 
 	t.Log("Start the container")
 	require.NoError(t, runtimeService.StartContainer(cn))
@@ -85,21 +85,21 @@ func TestUpdateContainerResources(t *testing.T) {
 	require.NoError(t, err)
 	stat, err := cgroup.Stat(cgroups.IgnoreNotExist)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(4*1024*1024), stat.Memory.Usage.Limit)
+	assert.Equal(t, uint64(400*1024*1024), stat.Memory.Usage.Limit)
 
 	t.Log("Update container memory limit after started")
 	err = runtimeService.UpdateContainerResources(cn, &runtime.LinuxContainerResources{
-		MemoryLimitInBytes: 8 * 1024 * 1024,
+		MemoryLimitInBytes: 800 * 1024 * 1024,
 	})
 	require.NoError(t, err)
 
 	t.Log("Check memory limit in container OCI spec")
 	spec, err = container.Spec(context.Background())
 	require.NoError(t, err)
-	checkMemoryLimit(t, spec, 8*1024*1024)
+	checkMemoryLimit(t, spec, 800*1024*1024)
 
 	t.Log("Check memory limit in cgroup")
 	stat, err = cgroup.Stat(cgroups.IgnoreNotExist)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(8*1024*1024), stat.Memory.Usage.Limit)
+	assert.Equal(t, uint64(800*1024*1024), stat.Memory.Usage.Limit)
 }


### PR DESCRIPTION
Never really liked the stages feature, switching back to clean and simple one run per go version implementation.

Setting 1.11.x to an allowed failure, temporarily, due to 
```
=== RUN   TestUpdateContainerResources
E1023 22:34:56.902537   21909 remote_runtime.go:213] StartContainer "70638def43d25a54024ccbb85b262beee83af18de47bb39fa6ddce1988749020" from runtime service failed: rpc error: code = Unknown desc = failed to create containerd task: OCI runtime create failed: container_linux.go:336: starting container process caused "process_linux.go:402: container init caused \"process_linux.go:367: setting cgroup config for procHooks process caused \\\"failed to write 4194304 to memory.limit_in_bytes: write /sys/fs/cgroup/memory/k8s.io/70638def43d25a54024ccbb85b262beee83af18de47bb39fa6ddce1988749020/memory.limit_in_bytes: device or resource busy\\\"\"": unknown
--- FAIL: TestUpdateContainerResources (0.63s)
    container_update_resources_test.go:40: Create a sandbox
    container_update_resources_test.go:49: Create a container with memory limit
    container_update_resources_test.go:60: Check memory limit in container OCI spec
    container_update_resources_test.go:67: Update container memory limit after created
    container_update_resources_test.go:73: Check memory limit in container OCI spec
    container_update_resources_test.go:78: Start the container
	Error Trace:	container_update_resources_test.go:79
	Error:		Received unexpected error rpc error: code = Unknown desc = failed to create containerd task: OCI runtime create failed: container_linux.go:336: starting container process caused "process_linux.go:402: container init caused \"process_linux.go:367: setting cgroup config for procHooks process caused \\\"failed to write 4194304 to memory.limit_in_bytes: write /sys/fs/cgroup/memory/k8s.io/70638def43d25a54024ccbb85b262beee83af18de47bb39fa6ddce1988749020/memory.limit_in_bytes: device or resource busy\\\"\"": unknown
```
We have a couple cgroup prs in the works... will need to get those vendored over and see what's what. 

Suggest merging this, and tracking 1.11.x results with issues.
 
Signed-off-by: Mike Brown <brownwm@us.ibm.com>