### PR TITLE
support DisableCgroup, DisableApparmor, RestrictOOMScoreAdj

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -44,6 +44,19 @@ The explanation and default value of each configuration item are as follows:
   # limit.
   max_container_log_line_size = 16384
 
+  # disable_cgroup indicates to disable the cgroup support.
+  # This is useful when the daemon does not have permission to access cgroup.
+  disable_cgroup = false
+
+  # disable_apparmor indicates to disable the apparmor support.
+  # This is useful when the daemon does not have permission to access apparmor.
+  disable_apparmor = false
+
+  # restrict_oom_score_adj indicates to limit the lower bound of OOMScoreAdj to
+  # the containerd's current OOMScoreAdj.
+  # This is useful when the containerd does not have permission to decrease OOMScoreAdj.
+  restrict_oom_score_adj = false
+
   # "plugins.cri.containerd" contains config related to containerd
   [plugins.cri.containerd]
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -142,6 +142,16 @@ type PluginConfig struct {
 	// Log line longer than the limit will be split into multiple lines. Non-positive
 	// value means no limit.
 	MaxContainerLogLineSize int `toml:"max_container_log_line_size" json:"maxContainerLogSize"`
+	// DisableCgroup indicates to disable the cgroup support.
+	// This is useful when the containerd does not have permission to access cgroup.
+	DisableCgroup bool `toml:"disable_cgroup" json:"disableCgroup"`
+	// DisableApparmor indicates to disable the apparmor support.
+	// This is useful when the containerd does not have permission to access Apparmor.
+	DisableApparmor bool `toml:"disable_apparmor" json:"disableApparmor"`
+	// RestrictOOMScoreAdj indicates to limit the lower bound of OOMScoreAdj to the containerd's
+	// current OOMScoreADj.
+	// This is useful when the containerd does not have permission to decrease OOMScoreAdj.
+	RestrictOOMScoreAdj bool `toml:"restrict_oom_score_adj" json:"restrictOOMScoreAdj"`
 }
 
 // X509KeyPairStreaming contains the x509 configuration for streaming

--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -417,12 +417,18 @@ func (c *criService) generateContainerSpec(id string, sandboxID string, sandboxP
 
 	g.SetRootReadonly(securityContext.GetReadonlyRootfs())
 
-	setOCILinuxResource(&g, config.GetLinux().GetResources())
-
-	if sandboxConfig.GetLinux().GetCgroupParent() != "" {
-		cgroupsPath := getCgroupsPath(sandboxConfig.GetLinux().GetCgroupParent(), id,
-			c.config.SystemdCgroup)
-		g.SetLinuxCgroupsPath(cgroupsPath)
+	if c.config.DisableCgroup {
+		g.SetLinuxCgroupsPath("")
+	} else {
+		setOCILinuxResourceCgroup(&g, config.GetLinux().GetResources())
+		if sandboxConfig.GetLinux().GetCgroupParent() != "" {
+			cgroupsPath := getCgroupsPath(sandboxConfig.GetLinux().GetCgroupParent(), id,
+				c.config.SystemdCgroup)
+			g.SetLinuxCgroupsPath(cgroupsPath)
+		}
+	}
+	if err := setOCILinuxResourceOOMScoreAdj(&g, config.GetLinux().GetResources(), c.config.RestrictOOMScoreAdj); err != nil {
+		return nil, err
 	}
 
 	// Set namespaces, share namespace with sandbox container.
@@ -744,8 +750,8 @@ func setOCIBindMountsPrivileged(g *generate.Generator) {
 	spec.Linux.MaskedPaths = nil
 }
 
-// setOCILinuxResource set container resource limit.
-func setOCILinuxResource(g *generate.Generator, resources *runtime.LinuxContainerResources) {
+// setOCILinuxResourceCgroup set container cgroup resource limit.
+func setOCILinuxResourceCgroup(g *generate.Generator, resources *runtime.LinuxContainerResources) {
 	if resources == nil {
 		return
 	}
@@ -753,9 +759,26 @@ func setOCILinuxResource(g *generate.Generator, resources *runtime.LinuxContaine
 	g.SetLinuxResourcesCPUQuota(resources.GetCpuQuota())
 	g.SetLinuxResourcesCPUShares(uint64(resources.GetCpuShares()))
 	g.SetLinuxResourcesMemoryLimit(resources.GetMemoryLimitInBytes())
-	g.SetProcessOOMScoreAdj(int(resources.GetOomScoreAdj()))
 	g.SetLinuxResourcesCPUCpus(resources.GetCpusetCpus())
 	g.SetLinuxResourcesCPUMems(resources.GetCpusetMems())
+}
+
+// setOCILinuxResourceOOMScoreAdj set container OOMScoreAdj resource limit.
+func setOCILinuxResourceOOMScoreAdj(g *generate.Generator, resources *runtime.LinuxContainerResources, restrictOOMScoreAdjFlag bool) error {
+	if resources == nil {
+		return nil
+	}
+	adj := int(resources.GetOomScoreAdj())
+	if restrictOOMScoreAdjFlag {
+		var err error
+		adj, err = restrictOOMScoreAdj(adj)
+		if err != nil {
+			return err
+		}
+	}
+	g.SetProcessOOMScoreAdj(adj)
+
+	return nil
 }
 
 // getOCICapabilitiesList returns a list of all available capabilities.

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -371,10 +371,14 @@ func (c *criService) generateSandboxContainerSpec(id string, config *runtime.Pod
 	// TODO(random-liu): [P2] Consider whether to add labels and annotations to the container.
 
 	// Set cgroups parent.
-	if config.GetLinux().GetCgroupParent() != "" {
-		cgroupsPath := getCgroupsPath(config.GetLinux().GetCgroupParent(), id,
-			c.config.SystemdCgroup)
-		g.SetLinuxCgroupsPath(cgroupsPath)
+	if c.config.DisableCgroup {
+		g.SetLinuxCgroupsPath("")
+	} else {
+		if config.GetLinux().GetCgroupParent() != "" {
+			cgroupsPath := getCgroupsPath(config.GetLinux().GetCgroupParent(), id,
+				c.config.SystemdCgroup)
+			g.SetLinuxCgroupsPath(cgroupsPath)
+		}
 	}
 	// When cgroup parent is not set, containerd-shim will create container in a child cgroup
 	// of the cgroup itself is in.
@@ -430,8 +434,17 @@ func (c *criService) generateSandboxContainerSpec(id string, config *runtime.Pod
 
 	// Note: LinuxSandboxSecurityContext does not currently provide an apparmor profile
 
-	g.SetLinuxResourcesCPUShares(uint64(defaultSandboxCPUshares))
-	g.SetProcessOOMScoreAdj(int(defaultSandboxOOMAdj))
+	if !c.config.DisableCgroup {
+		g.SetLinuxResourcesCPUShares(uint64(defaultSandboxCPUshares))
+	}
+	adj := int(defaultSandboxOOMAdj)
+	if c.config.RestrictOOMScoreAdj {
+		adj, err = restrictOOMScoreAdj(adj)
+		if err != nil {
+			return nil, err
+		}
+	}
+	g.SetProcessOOMScoreAdj(adj)
 
 	g.AddAnnotation(annotations.ContainerType, annotations.ContainerTypeSandbox)
 	g.AddAnnotation(annotations.SandboxID, id)


### PR DESCRIPTION
Add following config for supporting "rootless" mode

* DisableCgroup: disable cgroup
* DisableApparmor: disable Apparmor
* RestrictOOMScoreAdj: restrict the lower bound of OOMScoreAdj

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

---

A quick way to test this PR is to use Usernetes v20181109.0 ( https://github.com/rootless-containers/usernetes )

```console
$ ./run.sh default-containerd
$ ./kubectl.sh run -it --rm --image alpine foo
```

cc @giuseppe for consistency with CRI-O implementation (https://github.com/kubernetes-sigs/cri-o/blob/2accad9fab352c445bb4c414d9d3c8cdf351c524/server/rootless.go could be simplified as in this PR with the latest runc IIUC)
