### PR TITLE
Remove invalid TODO comment.

### DIFF
--- a/pkg/server/events.go
+++ b/pkg/server/events.go
@@ -194,10 +194,6 @@ func (em *eventMonitor) handleEvent(any interface{}) error {
 	defer cancel()
 
 	switch any.(type) {
-	// If containerd-shim exits unexpectedly, there will be no corresponding event.
-	// However, containerd could not retrieve container state in that case, so it's
-	// fine to leave out that case for now.
-	// TODO(random-liu): [P2] Handle containerd-shim exit.
 	case *eventtypes.TaskExit:
 		e := any.(*eventtypes.TaskExit)
 		logrus.Infof("TaskExit event %+v", e)


### PR DESCRIPTION
Remove the TODO, because this has already been handled by containerd.

See https://github.com/containerd/containerd/blob/c95bb88fa3b6e6a37cdad6aad630203c80e4063f/runtime/v1/linux/runtime.go#L190 and https://github.com/containerd/containerd/blob/c95bb88fa3b6e6a37cdad6aad630203c80e4063f/runtime/v1/linux/runtime.go#L324.

Signed-off-by: Lantao Liu <lantaol@google.com>