### PR TITLE
adds cni results to verbose pod info

### DIFF
--- a/pkg/server/sandbox_status.go
+++ b/pkg/server/sandbox_status.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
+	cni "github.com/containerd/go-cni"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -117,6 +118,7 @@ type SandboxInfo struct {
 	RuntimeOptions interface{}               `json:"runtimeOptions"`
 	Config         *runtime.PodSandboxConfig `json:"config"`
 	RuntimeSpec    *runtimespec.Spec         `json:"runtimeSpec"`
+	CNIResult      *cni.CNIResult            `json:"cniResult"`
 }
 
 // toCRISandboxInfo converts internal container object information to CRI sandbox status response info map.
@@ -142,6 +144,7 @@ func toCRISandboxInfo(ctx context.Context, sandbox sandboxstore.Sandbox) (map[st
 		RuntimeHandler: sandbox.RuntimeHandler,
 		Status:         string(processStatus),
 		Config:         sandbox.Config,
+		CNIResult:      sandbox.CNIResult,
 	}
 
 	if si.Status == "" {

--- a/pkg/store/sandbox/metadata.go
+++ b/pkg/store/sandbox/metadata.go
@@ -19,6 +19,7 @@ package sandbox
 import (
 	"encoding/json"
 
+	cni "github.com/containerd/go-cni"
 	"github.com/pkg/errors"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 )
@@ -56,6 +57,8 @@ type Metadata struct {
 	IP string
 	// RuntimeHandler is the runtime handler name of the pod.
 	RuntimeHandler string
+	// CNI result
+	CNIResult *cni.CNIResult
 }
 
 // MarshalJSON encodes Metadata into bytes in json format.


### PR DESCRIPTION
Address issue #979 while we can ask them to re-run with debug logging turned on, it should be very useful to have the ability to inspect each pod's cni load results from users (clients) of containerd/cri. 

Signed-off-by: Mike Brown <brownwm@us.ibm.com>