### PR TITLE
adds cni plugin config information for pod status, path and source data

### DIFF
--- a/pkg/server/sandbox_status.go
+++ b/pkg/server/sandbox_status.go
@@ -119,6 +119,7 @@ type SandboxInfo struct {
 	Config         *runtime.PodSandboxConfig `json:"config"`
 	RuntimeSpec    *runtimespec.Spec         `json:"runtimeSpec"`
 	CNIResult      *cni.CNIResult            `json:"cniResult"`
+	CNIConfig      *cni.ConfigResult         `json:"cniConfig"`
 }
 
 // toCRISandboxInfo converts internal container object information to CRI sandbox status response info map.
@@ -144,6 +145,7 @@ func toCRISandboxInfo(ctx context.Context, sandbox sandboxstore.Sandbox) (map[st
 		RuntimeHandler: sandbox.RuntimeHandler,
 		Status:         string(processStatus),
 		Config:         sandbox.Config,
+		CNIConfig:      sandbox.CNIConfig,
 		CNIResult:      sandbox.CNIResult,
 	}
 

--- a/pkg/server/testing/fake_cni_plugin.go
+++ b/pkg/server/testing/fake_cni_plugin.go
@@ -50,3 +50,8 @@ func (f *FakeCNIPlugin) Status() error {
 func (f *FakeCNIPlugin) Load(opts ...cni.CNIOpt) error {
 	return f.LoadErr
 }
+
+// GetConfig returns a copy of the CNI plugin configurations as parsed by CNI
+func (f *FakeCNIPlugin) GetConfig() *cni.ConfigResult {
+	return nil
+}

--- a/pkg/store/sandbox/metadata.go
+++ b/pkg/store/sandbox/metadata.go
@@ -57,8 +57,10 @@ type Metadata struct {
 	IP string
 	// RuntimeHandler is the runtime handler name of the pod.
 	RuntimeHandler string
-	// CNI result
+	// CNIResult resulting configuration for attached network namespace interfaces
 	CNIResult *cni.CNIResult
+	// CNIConfig paths and conflists for plugins used to create CNIResult
+	CNIConfig *cni.ConfigResult
 }
 
 // MarshalJSON encodes Metadata into bytes in json format.

--- a/vendor.conf
+++ b/vendor.conf
@@ -6,7 +6,7 @@ github.com/containerd/console c12b1e7919c14469339a5d38f2f8ed9b64a9de23
 github.com/containerd/containerd 6937c5a3ba8280edff9e9030767e3b0cb742581c
 github.com/containerd/continuity bd77b46c8352f74eb12c85bdc01f4b90f69d66b4
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
-github.com/containerd/go-cni 40bcf8ec8acd7372be1d77031d585d5d8e561c90
+github.com/containerd/go-cni c399b1539b8e2711704c2d011d54f20606f3f2b3
 github.com/containerd/go-runc 5a6d9f37cfa36b15efba46dc7ea349fa9b7143c3
 github.com/containerd/ttrpc 2a805f71863501300ae1976d29f0454ae003e85a
 github.com/containerd/typeurl a93fcdb778cd272c6e9b3028b2f42d813e785d40


### PR DESCRIPTION
Addressing the remaining content for issue #979 see comment https://github.com/containerd/cri/issues/979#issuecomment-443035615

Adds the CNI plugin path and config source information used to create the cni plugin results.

updates vndr for https://github.com/containerd/go-cni/pull/33.