### PR TITLE
Cherrypick #984 release 1.0

### DIFF
--- a/pkg/server/events.go
+++ b/pkg/server/events.go
@@ -31,6 +31,7 @@ import (
 	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/util/clock"
 
+	"github.com/containerd/cri/pkg/constants"
 	ctrdutil "github.com/containerd/cri/pkg/containerd/util"
 	"github.com/containerd/cri/pkg/store"
 	containerstore "github.com/containerd/cri/pkg/store/container"
@@ -77,7 +78,6 @@ type backOffQueue struct {
 // Create new event monitor. New event monitor will start subscribing containerd event. All events
 // happen after it should be monitored.
 func newEventMonitor(c *containerstore.Store, s *sandboxstore.Store) *eventMonitor {
-	// event subscribe doesn't need namespace.
 	ctx, cancel := context.WithCancel(context.Background())
 	return &eventMonitor{
 		containerStore: c,
@@ -90,6 +90,8 @@ func newEventMonitor(c *containerstore.Store, s *sandboxstore.Store) *eventMonit
 
 // subscribe starts to subscribe containerd events.
 func (em *eventMonitor) subscribe(subscriber events.Subscriber) {
+	// note: filters are any match, if you want any match but not in namespace foo
+	// then you have to manually filter namespace foo
 	filters := []string{
 		`topic=="/tasks/exit"`,
 		`topic=="/tasks/oom"`,
@@ -130,6 +132,10 @@ func (em *eventMonitor) start() <-chan error {
 			select {
 			case e := <-em.ch:
 				logrus.Debugf("Received containerd event timestamp - %v, namespace - %q, topic - %q", e.Timestamp, e.Namespace, e.Topic)
+				if e.Namespace != constants.K8sContainerdNamespace {
+					logrus.Debugf("Ignoring events in namespace - %q", e.Namespace)
+					break
+				}
 				cID, evt, err := convertEvent(e.Event)
 				if err != nil {
 					logrus.WithError(err).Errorf("Failed to convert event %+v", e)


### PR DESCRIPTION
This PR:
- Cherrypick #984 into release/1.0 branch;
- Resolves issue firecracker-microvm/firecracker-containerd#35
 
Signed-off-by: Mike Brown <brownwm@us.ibm.com>