### PR TITLE
Remove container lifecycle image dependency

### DIFF
--- a/integration/container_without_image_ref_test.go
+++ b/integration/container_without_image_ref_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2018 The containerd Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
+)
+
+// Test container lifecycle can work without image references.
+func TestContainerLifecycleWithoutImageRef(t *testing.T) {
+	t.Log("Create a sandbox")
+	sbConfig := PodSandboxConfig("sandbox", "container-lifecycle-without-image-ref")
+	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, runtimeService.StopPodSandbox(sb))
+		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
+	}()
+
+	const (
+		testImage     = "busybox"
+		containerName = "test-container"
+	)
+	t.Log("Pull test image")
+	img, err := imageService.PullImage(&runtime.ImageSpec{Image: testImage}, nil)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, imageService.RemoveImage(&runtime.ImageSpec{Image: img}))
+	}()
+
+	t.Log("Create test container")
+	cnConfig := ContainerConfig(
+		containerName,
+		testImage,
+		WithCommand("sleep", "1000"),
+	)
+	cn, err := runtimeService.CreateContainer(sb, cnConfig, sbConfig)
+	require.NoError(t, err)
+	require.NoError(t, runtimeService.StartContainer(cn))
+
+	t.Log("Remove test image")
+	assert.NoError(t, imageService.RemoveImage(&runtime.ImageSpec{Image: img}))
+
+	t.Log("Container status should be running")
+	status, err := runtimeService.ContainerStatus(cn)
+	require.NoError(t, err)
+	assert.Equal(t, status.GetState(), runtime.ContainerState_CONTAINER_RUNNING)
+
+	t.Logf("Stop container")
+	err = runtimeService.StopContainer(cn, 1)
+	assert.NoError(t, err)
+
+	t.Log("Container status should be exited")
+	status, err = runtimeService.ContainerStatus(cn)
+	require.NoError(t, err)
+	assert.Equal(t, status.GetState(), runtime.ContainerState_CONTAINER_EXITED)
+}

--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -187,6 +187,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 		opts = append(opts, customopts.WithVolumes(mountMap))
 	}
 	meta.ImageRef = image.ID
+	meta.StopSignal = image.ImageSpec.Config.StopSignal
 
 	// Get container log path.
 	if config.GetLogPath() != "" {

--- a/pkg/store/container/container_test.go
+++ b/pkg/store/container/container_test.go
@@ -39,8 +39,9 @@ func TestContainerStore(t *testing.T) {
 					Attempt: 1,
 				},
 			},
-			ImageRef: "TestImage-1",
-			LogPath:  "/test/log/path/1",
+			ImageRef:   "TestImage-1",
+			StopSignal: "SIGTERM",
+			LogPath:    "/test/log/path/1",
 		},
 		"2abcd": {
 			ID:        "2abcd",
@@ -52,8 +53,9 @@ func TestContainerStore(t *testing.T) {
 					Attempt: 2,
 				},
 			},
-			ImageRef: "TestImage-2",
-			LogPath:  "/test/log/path/2",
+			StopSignal: "SIGTERM",
+			ImageRef:   "TestImage-2",
+			LogPath:    "/test/log/path/2",
 		},
 		"4a333": {
 			ID:        "4a333",
@@ -65,8 +67,9 @@ func TestContainerStore(t *testing.T) {
 					Attempt: 3,
 				},
 			},
-			ImageRef: "TestImage-3",
-			LogPath:  "/test/log/path/3",
+			StopSignal: "SIGTERM",
+			ImageRef:   "TestImage-3",
+			LogPath:    "/test/log/path/3",
 		},
 		"4abcd": {
 			ID:        "4abcd",
@@ -78,7 +81,8 @@ func TestContainerStore(t *testing.T) {
 					Attempt: 1,
 				},
 			},
-			ImageRef: "TestImage-4abcd",
+			StopSignal: "SIGTERM",
+			ImageRef:   "TestImage-4abcd",
 		},
 	}
 	statuses := map[string]Status{
@@ -182,8 +186,9 @@ func TestWithContainerIO(t *testing.T) {
 				Attempt: 1,
 			},
 		},
-		ImageRef: "TestImage-1",
-		LogPath:  "/test/log/path",
+		ImageRef:   "TestImage-1",
+		StopSignal: "SIGTERM",
+		LogPath:    "/test/log/path",
 	}
 	status := Status{
 		Pid:        1,

--- a/pkg/store/container/metadata.go
+++ b/pkg/store/container/metadata.go
@@ -27,7 +27,7 @@ import (
 // 1) Metadata is immutable after created.
 // 2) Metadata is checkpointed as containerd container label.
 
-// metadataVersion  is current version of container metadata.
+// metadataVersion is current version of container metadata.
 const metadataVersion = "v1" // nolint
 
 // versionedMetadata is the internal versioned container metadata.
@@ -58,6 +58,9 @@ type Metadata struct {
 	ImageRef string
 	// LogPath is the container log path.
 	LogPath string
+	// StopSignal is the system call signal that will be sent to the container to exit.
+	// TODO(random-liu): Add integration test for stop signal.
+	StopSignal string
 }
 
 // MarshalJSON encodes Metadata into bytes in json format.


### PR DESCRIPTION
Fixes https://github.com/containerd/cri/issues/990.

Test result without the fix:
```
--- FAIL: TestContainerLifecycleWithoutImageRef (1.66s)
    container_without_image_ref_test.go:29: Create a sandbox
    container_without_image_ref_test.go:42: Pull test image
    container_without_image_ref_test.go:49: Create test container
    container_without_image_ref_test.go:59: Remove test image
    container_without_image_ref_test.go:62: Container status should be running
        Error Trace:    container_without_image_ref_test.go:64
        Error:		Received unexpected error rpc error: code = Unknown desc = failed to get image "sha256:59788edf1f3e78cd0ebe6ce1446e9d10788225db3dedcfd1a59f764bad2b2690": does not exist
```

Test result with the fix:
```
=== RUN   TestContainerLifecycleWithoutImageRef
--- PASS: TestContainerLifecycleWithoutImageRef (1.74s)
    container_without_image_ref_test.go:29: Create a sandbox
    container_without_image_ref_test.go:42: Pull test image
    container_without_image_ref_test.go:49: Create test container
    container_without_image_ref_test.go:59: Remove test image
    container_without_image_ref_test.go:62: Container status should be running
    container_without_image_ref_test.go:67: Stop container
    container_without_image_ref_test.go:71: Container status should be exited
PASS
```