### PR TITLE
Do not remove image when it is being used by a container

### DIFF
--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -36,7 +36,8 @@ test_setup ${REPORT_DIR}
 sudo PATH=${PATH} ${ROOT}/_output/integration.test --test.run="${FOCUS}" --test.v \
   --cri-endpoint=${CONTAINERD_SOCK} \
   --cri-root=${CRI_ROOT} \
-  --runtime-handler=${RUNTIME}
+  --runtime-handler=${RUNTIME} \
+  --containerd-bin=${CONTAINERD_BIN}
 
 test_exit_code=$?
 

--- a/hack/test-utils.sh
+++ b/hack/test-utils.sh
@@ -32,6 +32,8 @@ CONTAINERD_ROOT=${CONTAINERD_ROOT:-"/var/lib/containerd${CONTAINERD_TEST_SUFFIX}
 CONTAINERD_STATE=${CONTAINERD_STATE:-"/run/containerd${CONTAINERD_TEST_SUFFIX}"}
 # The containerd socket address.
 CONTAINERD_SOCK=${CONTAINERD_SOCK:-unix://${CONTAINERD_STATE}/containerd.sock}
+# The containerd binary name.
+CONTAINERD_BIN=${CONTAINERD_BIN:-"containerd${CONTAINERD_TEST_SUFFIX}"}
 if [ -f "${CONTAINERD_CONFIG_FILE}" ]; then
   CONTAINERD_FLAGS+="--config ${CONTAINERD_CONFIG_FILE} "
 fi
@@ -49,10 +51,13 @@ test_setup() {
     echo "containerd is not built"
     exit 1
   fi
+  # rename the test containerd binary, so that we can easily
+  # distinguish it.
+  mv ${ROOT}/_output/containerd ${ROOT}/_output/${CONTAINERD_BIN}
   set -m
   # Create containerd in a different process group
   # so that we can easily clean them up.
-  keepalive "sudo PATH=${PATH} ${ROOT}/_output/containerd ${CONTAINERD_FLAGS}" \
+  keepalive "sudo PATH=${PATH} ${ROOT}/_output/${CONTAINERD_BIN} ${CONTAINERD_FLAGS}" \
     ${RESTART_WAIT_PERIOD} &> ${report_dir}/containerd.log &
   pid=$!
   set +m

--- a/integration/container_log_test.go
+++ b/integration/container_log_test.go
@@ -35,26 +35,27 @@ func TestContainerLogWithoutTailingNewLine(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(testPodLogDir)
 
-	t.Log("Create a sandbox with log directory")
-	sbConfig := PodSandboxConfig("sandbox", "container-log-without-tailing-newline",
-		WithPodLogDirectory(testPodLogDir),
-	)
-	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
-
 	const (
 		testImage     = "busybox"
 		containerName = "test-container"
 	)
+	var sbConfig = PodSandboxConfig("sandbox", "container-log-without-tailing-newline",
+		WithPodLogDirectory(testPodLogDir),
+	)
+
 	t.Logf("Pull test image %q", testImage)
 	img, err := imageService.PullImage(&runtime.ImageSpec{Image: testImage}, nil, sbConfig)
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, imageService.RemoveImage(&runtime.ImageSpec{Image: img}))
+	}()
+
+	t.Log("Create a sandbox with log directory")
+	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, runtimeService.StopPodSandbox(sb))
+		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
 	}()
 
 	t.Log("Create a container with log path")
@@ -95,26 +96,27 @@ func TestLongContainerLog(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(testPodLogDir)
 
-	t.Log("Create a sandbox with log directory")
-	sbConfig := PodSandboxConfig("sandbox", "long-container-log",
-		WithPodLogDirectory(testPodLogDir),
-	)
-	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
-
 	const (
 		testImage     = "busybox"
 		containerName = "test-container"
 	)
+	var sbConfig = PodSandboxConfig("sandbox", "long-container-log",
+		WithPodLogDirectory(testPodLogDir),
+	)
+
 	t.Logf("Pull test image %q", testImage)
 	img, err := imageService.PullImage(&runtime.ImageSpec{Image: testImage}, nil, sbConfig)
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, imageService.RemoveImage(&runtime.ImageSpec{Image: img}))
+	}()
+
+	t.Log("Create a sandbox with log directory")
+	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, runtimeService.StopPodSandbox(sb))
+		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
 	}()
 
 	t.Log("Create a container with log path")

--- a/integration/container_stop_test.go
+++ b/integration/container_stop_test.go
@@ -32,14 +32,6 @@ func TestSharedPidMultiProcessContainerStop(t *testing.T) {
 		"podpid":  PodSandboxConfig("sandbox", "pod-pid-container-stop", WithPodPid),
 	} {
 		t.Run(name, func(t *testing.T) {
-			t.Log("Create a shared pid sandbox")
-			sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
-			require.NoError(t, err)
-			defer func() {
-				assert.NoError(t, runtimeService.StopPodSandbox(sb))
-				assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-			}()
-
 			const (
 				testImage     = "busybox"
 				containerName = "test-container"
@@ -49,6 +41,14 @@ func TestSharedPidMultiProcessContainerStop(t *testing.T) {
 			require.NoError(t, err)
 			defer func() {
 				assert.NoError(t, imageService.RemoveImage(&runtime.ImageSpec{Image: img}))
+			}()
+
+			t.Log("Create a shared pid sandbox")
+			sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
+			require.NoError(t, err)
+			defer func() {
+				assert.NoError(t, runtimeService.StopPodSandbox(sb))
+				assert.NoError(t, runtimeService.RemovePodSandbox(sb))
 			}()
 
 			t.Log("Create a multi-process container")
@@ -75,24 +75,25 @@ func TestSharedPidMultiProcessContainerStop(t *testing.T) {
 }
 
 func TestContainerStopCancellation(t *testing.T) {
-	t.Log("Create a pod sandbox")
-	sbConfig := PodSandboxConfig("sandbox", "cancel-container-stop")
-	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, runtimeService.StopPodSandbox(sb))
-		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
-	}()
-
 	const (
 		testImage     = "busybox"
 		containerName = "test-container"
 	)
+	var sbConfig = PodSandboxConfig("sandbox", "cancel-container-stop")
+
 	t.Logf("Pull test image %q", testImage)
 	img, err := imageService.PullImage(&runtime.ImageSpec{Image: testImage}, nil, sbConfig)
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, imageService.RemoveImage(&runtime.ImageSpec{Image: img}))
+	}()
+
+	t.Log("Create a pod sandbox")
+	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, runtimeService.StopPodSandbox(sb))
+		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
 	}()
 
 	t.Log("Create a container which traps sigterm")

--- a/integration/image_remove_test.go
+++ b/integration/image_remove_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright The containerd Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+// Test to test that an image can't be removed when it is being used by a containerd.
+func TestImageRemove(t *testing.T) {
+	const testImage = "busybox:latest"
+
+	t.Logf("Make sure no such image in cri")
+	img, err := imageService.ImageStatus(&runtime.ImageSpec{Image: testImage})
+	require.NoError(t, err)
+	if img != nil {
+		require.NoError(t, imageService.RemoveImage(&runtime.ImageSpec{Image: testImage}))
+	}
+
+	t.Logf("Create a container with the test image")
+	sbConfig := PodSandboxConfig("sandbox", "image-remove")
+	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, runtimeService.StopPodSandbox(sb))
+		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
+	}()
+
+	t.Logf("Pull the test image")
+	i, err := imageService.PullImage(&runtime.ImageSpec{Image: testImage}, nil, sbConfig)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, imageService.RemoveImage(&runtime.ImageSpec{Image: i}))
+	}()
+
+	cnConfig := ContainerConfig(
+		"test-container",
+		testImage,
+		WithCommand("echo", "hello"),
+	)
+	cn, err := runtimeService.CreateContainer(sb, cnConfig, sbConfig)
+	require.NoError(t, err)
+
+	t.Logf("The image can't be removed when a container is using it")
+	assert.Error(t, imageService.RemoveImage(&runtime.ImageSpec{Image: i}))
+
+	t.Logf("The image can be removed when the container using it is removed")
+	require.NoError(t, runtimeService.RemoveContainer(cn))
+	assert.NoError(t, imageService.RemoveImage(&runtime.ImageSpec{Image: i}))
+}
+
+// Test to test that there is no race condition between image removal and container creation.
+func TestImageRemoveRaceCondition(t *testing.T) {
+	const (
+		testImage = "busybox:latest"
+		times     = 10
+	)
+
+	t.Logf("Make sure no such image in cri")
+	img, err := imageService.ImageStatus(&runtime.ImageSpec{Image: testImage})
+	require.NoError(t, err)
+	if img != nil {
+		require.NoError(t, imageService.RemoveImage(&runtime.ImageSpec{Image: testImage}))
+	}
+
+	f := func() {
+		t.Logf("Create a container with the test image")
+		sbConfig := PodSandboxConfig("sandbox", "image-remove")
+		sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
+		require.NoError(t, err)
+		defer func() {
+			assert.NoError(t, runtimeService.StopPodSandbox(sb))
+			assert.NoError(t, runtimeService.RemovePodSandbox(sb))
+		}()
+
+		t.Logf("Pull the test image")
+		i, err := imageService.PullImage(&runtime.ImageSpec{Image: testImage}, nil, sbConfig)
+		require.NoError(t, err)
+		defer func() {
+			assert.NoError(t, imageService.RemoveImage(&runtime.ImageSpec{Image: i}))
+		}()
+
+		var wg sync.WaitGroup
+		var containerCreateErr, imageRemoveErr error
+		wg.Add(1)
+		go func() {
+			cnConfig := ContainerConfig(
+				"test-container",
+				testImage,
+				WithCommand("echo", "hello"),
+			)
+			_, containerCreateErr = runtimeService.CreateContainer(sb, cnConfig, sbConfig)
+			wg.Done()
+		}()
+
+		t.Logf("Remove the image")
+		wg.Add(1)
+		go func() {
+			imageRemoveErr = imageService.RemoveImage(&runtime.ImageSpec{Image: i})
+			wg.Done()
+		}()
+
+		wg.Wait()
+		t.Logf("Either image remove or container create should fail")
+		assert.NotEqual(t, containerCreateErr != nil, imageRemoveErr != nil,
+			"container create err: %v, image remove err: %v", containerCreateErr, imageRemoveErr)
+	}
+
+	for i := 1; i <= times; i++ {
+		t.Logf("%d test run", i)
+		f()
+	}
+}

--- a/integration/restart_test.go
+++ b/integration/restart_test.go
@@ -209,7 +209,7 @@ func TestUnknownStateAfterContainerdRestart(t *testing.T) {
 		t.Skip("unsupported config: runc not in PATH")
 	}
 
-	sbConfig := PodSandboxConfig("sandbox", "sandbox-unknown-state")
+	var sbConfig = PodSandboxConfig("sandbox", "sandbox-unknown-state")
 
 	const testImage = "busybox"
 	t.Logf("Pull test image %q", testImage)

--- a/integration/test_utils.go
+++ b/integration/test_utils.go
@@ -60,6 +60,7 @@ var (
 var criEndpoint = flag.String("cri-endpoint", "unix:///run/containerd/containerd.sock", "The endpoint of cri plugin.")
 var criRoot = flag.String("cri-root", "/var/lib/containerd/io.containerd.grpc.v1.cri", "The root directory of cri plugin.")
 var runtimeHandler = flag.String("runtime-handler", "", "The runtime handler to use in the test.")
+var containerdBin = flag.String("containerd-bin", "containerd", "The containerd binary name. The name is used to restart containerd during test.")
 
 func init() {
 	flag.Parse()
@@ -395,12 +396,12 @@ func SandboxInfo(id string) (*runtime.PodSandboxStatus, *server.SandboxInfo, err
 }
 
 func RestartContainerd(t *testing.T) {
-	require.NoError(t, KillProcess("containerd"))
+	require.NoError(t, KillProcess(*containerdBin))
 
 	// Use assert so that the 3rd wait always runs, this makes sure
 	// containerd is running before this function returns.
 	assert.NoError(t, Eventually(func() (bool, error) {
-		pid, err := PidOf("containerd")
+		pid, err := PidOf(*containerdBin)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -114,6 +114,13 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to resolve image %q", config.GetImage().GetImage())
 	}
+	// Lease the image, so that the image won't be removed when the container
+	// is being created.
+	if err := image.Lease(); err != nil {
+		return nil, errors.Wrapf(err, "lease image %q", config.GetImage().GetImage())
+	}
+	defer image.Unlease() // nolint: errcheck
+
 	containerdImage, err := c.toContainerdImage(ctx, image)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get image from containerd %q", image.ID)

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -99,6 +99,13 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get sandbox image %q", c.config.SandboxImage)
 	}
+	// Lease the image, so that the image won't be removed when the sandbox container
+	// is being created.
+	if err := image.Lease(); err != nil {
+		return nil, errors.Wrapf(err, "lease image %q", c.config.SandboxImage)
+	}
+	defer image.Unlease() // nolint: errcheck
+
 	containerdImage, err := c.toContainerdImage(ctx, *image)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get image from containerd %q", image.ID)

--- a/pkg/store/image/image.go
+++ b/pkg/store/image/image.go
@@ -47,6 +47,10 @@ type Image struct {
 	Size int64
 	// ImageSpec is the oci image structure which describes basic information about the image.
 	ImageSpec imagespec.Image
+	// leases tracks all leases of the image. Image with non-zero lease
+	// can't be removed. Unleasable image can't be used for new container
+	// creation.
+	*leases
 }
 
 // Store stores all images.
@@ -150,6 +154,7 @@ func getImage(ctx context.Context, i containerd.Image) (*Image, error) {
 		ChainID:    chainID.String(),
 		Size:       size,
 		ImageSpec:  ociimage,
+		leases:     newLeases(),
 	}, nil
 }
 

--- a/pkg/store/image/leases.go
+++ b/pkg/store/image/leases.go
@@ -1,0 +1,72 @@
+/*
+Copyright The containerd Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package image
+
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+// leases manages all leases of an image.
+// * Leases can be used for many times;
+// * Leases with non-zero lease count can't be set nonleasable.
+// * Nonleasable leases can't be used.
+type leases struct {
+	sync.Mutex
+	count       int
+	nonleasable bool
+}
+
+func newLeases() *leases {
+	return &leases{}
+}
+
+// Lease leases the image.
+func (l *leases) Lease() error {
+	l.Lock()
+	defer l.Unlock()
+	if l.nonleasable {
+		return errors.New("not leasable")
+	}
+	l.count++
+	return nil
+}
+
+// Unlease unleases the image.
+func (l *leases) Unlease() error {
+	l.Lock()
+	defer l.Unlock()
+	if l.count <= 0 {
+		return errors.New("not leased")
+	}
+	l.count--
+	return nil
+}
+
+// SetNonleasable sets the image nonleasable.
+func (l *leases) SetNonleasable(nonleasable bool) error {
+	l.Lock()
+	defer l.Unlock()
+	if nonleasable {
+		if l.count > 0 {
+			return errors.New("leased")
+		}
+	}
+	l.nonleasable = nonleasable
+	return nil
+}

--- a/pkg/store/image/leases_test.go
+++ b/pkg/store/image/leases_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2018 The containerd Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package image
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLeases(t *testing.T) {
+	l := newLeases()
+
+	t.Logf("Leases can be leased for multiple times")
+	assert.NoError(t, l.Lease())
+	assert.NoError(t, l.Lease())
+	assert.NoError(t, l.Lease())
+
+	t.Logf("Leases with non-zero lease count can't be set nonleasable")
+	assert.Error(t, l.SetNonleasable(true))
+
+	t.Logf("Leases with non-zero lease count can be unleased")
+	assert.NoError(t, l.Unlease())
+	assert.NoError(t, l.Unlease())
+	assert.NoError(t, l.Unlease())
+
+	t.Logf("Leases with zero lease count can't be unleased")
+	assert.Error(t, l.Unlease())
+
+	t.Logf("Leases with zero lease count can be set nonleasable")
+	assert.NoError(t, l.SetNonleasable(true))
+
+	t.Logf("Nonleasable leases can't be leased any more")
+	assert.Error(t, l.Lease())
+
+	t.Logf("Nonleasable leases can be set back to leasable")
+	assert.NoError(t, l.SetNonleasable(false))
+
+	t.Logf("Leases can be leased after being set back to leasable")
+	assert.NoError(t, l.Lease())
+}


### PR DESCRIPTION
For https://github.com/containerd/cri/issues/990.

This PR:
1) Added a check in image_remove.go to make sure image can only be removed when it is not used by a container;
2) Added a `leases` field in `Image` to avoid the race condition between the check and container creation.