### PR TITLE
Fix the issue that pod or container config file without metadata will…

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -92,7 +92,11 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	// Reserve the container name to avoid concurrent `CreateContainer` request creating
 	// the same container.
 	id := util.GenerateID()
-	name := makeContainerName(config.GetMetadata(), sandboxConfig.GetMetadata())
+	metadata := config.GetMetadata()
+	if metadata == nil {
+		return nil, errors.New("container config must include metadata")
+	}
+	name := makeContainerName(metadata, sandboxConfig.GetMetadata())
 	logrus.Debugf("Generated id %q for container %q", id, name)
 	if err = c.containerNameIndex.Reserve(name, id); err != nil {
 		return nil, errors.Wrapf(err, "failed to reserve container name %q", name)

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -58,7 +58,11 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 
 	// Generate unique id and name for the sandbox and reserve the name.
 	id := util.GenerateID()
-	name := makeSandboxName(config.GetMetadata())
+	metadata := config.GetMetadata()
+	if metadata == nil {
+		return nil, errors.New("sandbox config must include metadata")
+	}
+	name := makeSandboxName(metadata)
 	logrus.Debugf("Generated id %q for sandbox %q", id, name)
 	// Reserve the sandbox name to avoid concurrent `RunPodSandbox` request starting the
 	// same sandbox.


### PR DESCRIPTION
… crash containerd

Because RunPodSandbox and CreateContainer will access metadata
without check, pod or container config file without metadata will
crash containerd.

This patch add checks to handle the issue.

Fixes: #1009

Signed-off-by: Hui Zhu <teawater@hyper.sh>