### PR TITLE
Fix return error message

### DIFF
--- a/pkg/server/restart.go
+++ b/pkg/server/restart.go
@@ -146,7 +146,7 @@ func (c *criService) recover(ctx context.Context) error {
 // * ListContainerStats: Not in critical code path, a default timeout will
 // be applied at CRI level.
 // * Recovery logic: We should set a time for each container/sandbox recovery.
-// * Event montior: We should set a timeout for each container/sandbox event handling.
+// * Event monitor: We should set a timeout for each container/sandbox event handling.
 const loadContainerTimeout = 10 * time.Second
 
 // loadContainer loads container from containerd and status checkpoint.

--- a/pkg/server/sandbox_stop.go
+++ b/pkg/server/sandbox_stop.go
@@ -128,7 +128,7 @@ func (c *criService) waitSandboxStop(ctx context.Context, sandbox sandboxstore.S
 // teardownPod removes the network from the pod
 func (c *criService) teardownPod(id string, path string, config *runtime.PodSandboxConfig) error {
 	if c.netPlugin == nil {
-		return errors.New("cni config not intialized")
+		return errors.New("cni config not initialized")
 	}
 
 	labels := getPodCNILabels(id, config)


### PR DESCRIPTION
Fix some spelling errors:
1. "Event montior" to "Event monitor" in line 149.
2. "intialized" to "initialized" in line 131.