### PR TITLE
[release/1.0] Specify platform for image pull.

### DIFF
--- a/pkg/server/image_pull.go
+++ b/pkg/server/image_pull.go
@@ -24,6 +24,7 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
 	containerdimages "github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -104,6 +105,7 @@ func (c *criService) PullImage(ctx context.Context, r *runtime.PullImageRequest)
 	image, err := c.client.Pull(ctx, ref,
 		containerd.WithSchema1Conversion,
 		containerd.WithResolver(resolver),
+		containerd.WithPlatform(platforms.Default()),
 	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to pull image %q", ref)


### PR DESCRIPTION
Fixes https://github.com/containerd/cri/issues/1015.

Till now, the issue only happens to `docker.io/library/golang`. It seems that some platform of `docker.io/library/golang` is not pullable.

However, we shouldn't be pulling image for all platforms in the cri plugin anyway.

This is handled in containerd client in release/1.2.

However, we missed it in release/1.0.

Before the fix:
```
# crictl pull docker.io/library/golang:1.9
(stuck...)
```

After the fix:
```
# crictl pull docker.io/library/golang:1.9
Image is up to date for sha256:ef89ef5c42a90ec98bda7bbef0495c1ca6f43a31d059148c368b71858de463d2
```

