### PR TITLE
Add unit test for DisableCgroup, RestrictOOMScoreAdj.

### DIFF
--- a/pkg/server/container_create_test.go
+++ b/pkg/server/container_create_test.go
@@ -1021,3 +1021,18 @@ func TestHostname(t *testing.T) {
 		assert.Contains(t, spec.Process.Env, test.expectedEnv)
 	}
 }
+
+func TestDisableCgroup(t *testing.T) {
+	config, sandboxConfig, imageConfig, _ := getCreateContainerTestData()
+	c := newTestCRIService()
+	c.config.DisableCgroup = true
+	spec, err := c.generateContainerSpec("test-id", "sandbox-id", 1234, config, sandboxConfig, imageConfig, nil)
+	require.NoError(t, err)
+
+	t.Log("resource limit should not be set")
+	assert.Nil(t, spec.Linux.Resources.Memory)
+	assert.Nil(t, spec.Linux.Resources.CPU)
+
+	t.Log("cgroup path should be empty")
+	assert.Empty(t, spec.Linux.CgroupsPath)
+}

--- a/pkg/server/helpers_test.go
+++ b/pkg/server/helpers_test.go
@@ -304,3 +304,20 @@ systemd_cgroup = true
 		})
 	}
 }
+
+func TestRestrictOOMScoreAdj(t *testing.T) {
+	current, err := getCurrentOOMScoreAdj()
+	require.NoError(t, err)
+
+	got, err := restrictOOMScoreAdj(current - 1)
+	require.NoError(t, err)
+	assert.Equal(t, got, current)
+
+	got, err = restrictOOMScoreAdj(current)
+	require.NoError(t, err)
+	assert.Equal(t, got, current)
+
+	got, err = restrictOOMScoreAdj(current + 1)
+	require.NoError(t, err)
+	assert.Equal(t, got, current+1)
+}

--- a/pkg/server/sandbox_run_test.go
+++ b/pkg/server/sandbox_run_test.go
@@ -691,5 +691,20 @@ func TestGetSandboxRuntime(t *testing.T) {
 	}
 }
 
+func TestSandboxDisableCgroup(t *testing.T) {
+	config, imageConfig, _ := getRunPodSandboxTestData()
+	c := newTestCRIService()
+	c.config.DisableCgroup = true
+	spec, err := c.generateSandboxContainerSpec("test-id", config, imageConfig, "test-cni")
+	require.NoError(t, err)
+
+	t.Log("resource limit should not be set")
+	assert.Nil(t, spec.Linux.Resources.Memory)
+	assert.Nil(t, spec.Linux.Resources.CPU)
+
+	t.Log("cgroup path should be empty")
+	assert.Empty(t, spec.Linux.CgroupsPath)
+}
+
 // TODO(random-liu): [P1] Add unit test for different error cases to make sure
 // the function cleans up on error properly.


### PR DESCRIPTION
OCI spec generation is the core logic, would like as much coverage as possible.

Signed-off-by: Lantao Liu <lantaol@google.com>