### PR TITLE
Fix some typos in comment

### DIFF
--- a/pkg/server/streaming.go
+++ b/pkg/server/streaming.go
@@ -176,7 +176,7 @@ func handleResizing(resize <-chan remotecommand.TerminalSize, resizeFunc func(si
 
 // newTLSCert returns a self CA signed tls.certificate.
 // TODO (mikebrow): replace / rewrite this function to support using CA
-// signing of the cetificate. Requires a security plan for kubernetes regarding
+// signing of the certificate. Requires a security plan for kubernetes regarding
 // CRI connections / streaming, etc. For example, kubernetes could configure or
 // require a CA service and pass a configuration down through CRI.
 func newTLSCert() (tls.Certificate, error) {

--- a/pkg/store/snapshot/snapshot.go
+++ b/pkg/store/snapshot/snapshot.go
@@ -28,7 +28,7 @@ import (
 type Snapshot struct {
 	// Key is the key of the snapshot
 	Key string
-	// Kind is the kind of the snapshot (active, commited, view)
+	// Kind is the kind of the snapshot (active, committed, view)
 	Kind snapshot.Kind
 	// Size is the size of the snapshot in bytes.
 	Size uint64


### PR DESCRIPTION
1. "cetificate" to "certificate" in line 179.
2. "commited" to "committed" in line 31.