### PR TITLE
Fix the log ending newline handling.

### DIFF
--- a/integration/container_log_test.go
+++ b/integration/container_log_test.go
@@ -30,6 +30,66 @@ import (
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 )
 
+func TestContainerLogWithoutTailingNewLine(t *testing.T) {
+	testPodLogDir, err := ioutil.TempDir("/tmp", "container-log-without-tailing-newline")
+	require.NoError(t, err)
+	defer os.RemoveAll(testPodLogDir)
+
+	t.Log("Create a sandbox with log directory")
+	sbConfig := PodSandboxConfig("sandbox", "container-log-without-tailing-newline",
+		WithPodLogDirectory(testPodLogDir),
+	)
+	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, runtimeService.StopPodSandbox(sb))
+		assert.NoError(t, runtimeService.RemovePodSandbox(sb))
+	}()
+
+	const (
+		testImage     = "busybox"
+		containerName = "test-container"
+	)
+	t.Logf("Pull test image %q", testImage)
+	img, err := imageService.PullImage(&runtime.ImageSpec{Image: testImage}, nil)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, imageService.RemoveImage(&runtime.ImageSpec{Image: img}))
+	}()
+
+	t.Log("Create a container with log path")
+	cnConfig := ContainerConfig(
+		containerName,
+		testImage,
+		WithCommand("sh", "-c", "printf abcd"),
+		WithLogPath(containerName),
+	)
+	cn, err := runtimeService.CreateContainer(sb, cnConfig, sbConfig)
+	require.NoError(t, err)
+
+	t.Log("Start the container")
+	require.NoError(t, runtimeService.StartContainer(cn))
+
+	t.Log("Wait for container to finish running")
+	require.NoError(t, Eventually(func() (bool, error) {
+		s, err := runtimeService.ContainerStatus(cn)
+		if err != nil {
+			return false, err
+		}
+		if s.GetState() == runtime.ContainerState_CONTAINER_EXITED {
+			return true, nil
+		}
+		return false, nil
+	}, time.Second, 30*time.Second))
+
+	t.Log("Check container log")
+	content, err := ioutil.ReadFile(filepath.Join(testPodLogDir, containerName))
+	assert.NoError(t, err)
+	checkContainerLog(t, string(content), []string{
+		fmt.Sprintf("%s %s %s", runtime.Stdout, runtime.LogTagPartial, "abcd"),
+	})
+}
+
 func TestLongContainerLog(t *testing.T) {
 	testPodLogDir, err := ioutil.TempDir("/tmp", "long-container-log")
 	require.NoError(t, err)
@@ -66,9 +126,9 @@ func TestLongContainerLog(t *testing.T) {
 	longLineCmd := fmt.Sprintf("i=0; while [ $i -lt %d ]; do printf %s; i=$((i+1)); done", maxSize+1, "c")
 	cnConfig := ContainerConfig(
 		containerName,
-		"busybox",
+		testImage,
 		WithCommand("sh", "-c",
-			fmt.Sprintf("%s; echo; %s; echo; %s", shortLineCmd, maxLenLineCmd, longLineCmd)),
+			fmt.Sprintf("%s; echo; %s; echo; %s; echo", shortLineCmd, maxLenLineCmd, longLineCmd)),
 		WithLogPath(containerName),
 	)
 	cn, err := runtimeService.CreateContainer(sb, cnConfig, sbConfig)

--- a/pkg/server/io/logger_test.go
+++ b/pkg/server/io/logger_test.go
@@ -72,7 +72,7 @@ func TestRedirectLogs(t *testing.T) {
 			maxLen: maxLen,
 			tag: []runtime.LogTag{
 				runtime.LogTagFull,
-				runtime.LogTagFull,
+				runtime.LogTagPartial,
 			},
 			content: []string{
 				"test stderr log 1",
@@ -220,6 +220,19 @@ func TestRedirectLogs(t *testing.T) {
 			content: []string{
 				strings.Repeat("a", defaultBufSize*10+10),
 				strings.Repeat("a", defaultBufSize*10+20),
+			},
+		},
+		"log length longer than buffer size with tailing \\r\\n": {
+			input:  strings.Repeat("a", defaultBufSize-1) + "\r\n" + strings.Repeat("a", defaultBufSize-1) + "\r\n",
+			stream: Stdout,
+			maxLen: -1,
+			tag: []runtime.LogTag{
+				runtime.LogTagFull,
+				runtime.LogTagFull,
+			},
+			content: []string{
+				strings.Repeat("a", defaultBufSize-1),
+				strings.Repeat("a", defaultBufSize-1),
 			},
 		},
 	} {

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -22,7 +22,7 @@ import "strings"
 // Comparison is case insensitive.
 func InStringSlice(ss []string, str string) bool {
 	for _, s := range ss {
-		if strings.ToLower(s) == strings.ToLower(str) {
+		if strings.EqualFold(s, str) {
 			return true
 		}
 	}
@@ -34,7 +34,7 @@ func InStringSlice(ss []string, str string) bool {
 func SubtractStringSlice(ss []string, str string) []string {
 	var res []string
 	for _, s := range ss {
-		if strings.ToLower(s) == strings.ToLower(str) {
+		if strings.EqualFold(s, str) {
 			continue
 		}
 		res = append(res, s)


### PR DESCRIPTION
Fixes https://github.com/containerd/cri/issues/1026.

Basically we need our own `ReadLine` to return errors instead of hiding it.

We should cherry-pick this change to release/1.0 and release/1.2.

Signed-off-by: Lantao Liu <lantaol@google.com>