### PR TITLE
Add RUNTIME env in integration and cri test.

### DIFF
--- a/hack/test-cri.sh
+++ b/hack/test-cri.sh
@@ -25,6 +25,8 @@ FOCUS=${FOCUS:-}
 SKIP=${SKIP:-""}
 # REPORT_DIR is the the directory to store test logs.
 REPORT_DIR=${REPORT_DIR:-"/tmp/test-cri"}
+# RUNTIME is the runtime handler to use in the test.
+RUNTIME=${RUNTIME:-""}
 
 # Check GOPATH
 if [[ -z "${GOPATH}" ]]; then
@@ -58,7 +60,7 @@ mkdir -p ${REPORT_DIR}
 test_setup ${REPORT_DIR}
 
 # Run cri validation test
-sudo env PATH=${PATH} GOPATH=${GOPATH} ${CRITEST} --runtime-endpoint=${CONTAINERD_SOCK} --ginkgo.focus="${FOCUS}" --ginkgo.skip="${SKIP}" --parallel=8
+sudo env PATH=${PATH} GOPATH=${GOPATH} ${CRITEST} --runtime-endpoint=${CONTAINERD_SOCK} --ginkgo.focus="${FOCUS}" --ginkgo.skip="${SKIP}" --parallel=8 --runtime-handler=${RUNTIME}
 test_exit_code=$?
 
 test_teardown

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -24,6 +24,8 @@ cd ${ROOT}
 FOCUS=${FOCUS:-""}
 # REPORT_DIR is the the directory to store test logs.
 REPORT_DIR=${REPORT_DIR:-"/tmp/test-integration"}
+# RUNTIME is the runtime handler to use in the test.
+RUNTIME=${RUNTIME:-""}
 
 CRI_ROOT="/var/lib/containerd/io.containerd.grpc.v1.cri"
 
@@ -33,7 +35,8 @@ test_setup ${REPORT_DIR}
 # Run integration test.
 sudo ${ROOT}/_output/integration.test --test.run="${FOCUS}" --test.v \
   --cri-endpoint=${CONTAINERD_SOCK} \
-  --cri-root=${CRI_ROOT}
+  --cri-root=${CRI_ROOT} \
+  --runtime-handler=${RUNTIME}
 
 test_exit_code=$?
 


### PR DESCRIPTION
Add `RUNTIME` env in the integration and cri test.
This can be used to test different runtimes.

Signed-off-by: Lantao Liu <lantaol@google.com>