### PR TITLE
Update containerd to 4543e32a8b29e691e523ddc142f0c9068917df54

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -3,7 +3,7 @@ github.com/blang/semver v3.1.0
 github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
 github.com/containerd/cgroups 1152b960fcee041f50df15cdc67c29dbccf801ef
 github.com/containerd/console c12b1e7919c14469339a5d38f2f8ed9b64a9de23
-github.com/containerd/containerd 5ba368748b0275d8f45f909413d94738992f0050
+github.com/containerd/containerd 4543e32a8b29e691e523ddc142f0c9068917df54
 github.com/containerd/continuity bd77b46c8352f74eb12c85bdc01f4b90f69d66b4
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
 github.com/containerd/go-cni 40bcf8ec8acd7372be1d77031d585d5d8e561c90

--- a/vendor/github.com/containerd/containerd/cmd/ctr/commands/run/run_windows.go
+++ b/vendor/github.com/containerd/containerd/cmd/ctr/commands/run/run_windows.go
@@ -64,6 +64,8 @@ func NewContainer(ctx gocontext.Context, client *containerd.Client, context *cli
 			opts = append(opts, oci.WithRootFSPath(""))
 		} else {
 			opts = append(opts, oci.WithDefaultSpec())
+			opts = append(opts, oci.WithWindowNetworksAllowUnqualifiedDNSQuery())
+			opts = append(opts, oci.WithWindowsIgnoreFlushesDuringBoot())
 		}
 		opts = append(opts, oci.WithEnv(context.StringSlice("env")))
 		opts = append(opts, withMounts(context))

--- a/vendor/github.com/containerd/containerd/images/archive/reference.go
+++ b/vendor/github.com/containerd/containerd/images/archive/reference.go
@@ -19,8 +19,8 @@ package archive
 import (
 	"strings"
 
-	"github.com/containerd/cri/pkg/util"
-	digest "github.com/opencontainers/go-digest"
+	"github.com/docker/distribution/reference"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
 
@@ -69,7 +69,7 @@ func isImagePrefix(s, prefix string) bool {
 
 func normalizeReference(ref string) (string, error) {
 	// TODO: Replace this function to not depend on reference package
-	normalized, err := util.NormalizeImageRef(ref)
+	normalized, err := reference.ParseDockerRef(ref)
 	if err != nil {
 		return "", errors.Wrapf(err, "normalize image ref %q", ref)
 	}

--- a/vendor/github.com/containerd/containerd/oci/spec.go
+++ b/vendor/github.com/containerd/containerd/oci/spec.go
@@ -247,17 +247,8 @@ func populateDefaultWindowsSpec(ctx context.Context, s *Spec, id string) error {
 		Root:    &specs.Root{},
 		Process: &specs.Process{
 			Cwd: `C:\`,
-			ConsoleSize: &specs.Box{
-				Width:  80,
-				Height: 20,
-			},
 		},
-		Windows: &specs.Windows{
-			IgnoreFlushesDuringBoot: true,
-			Network: &specs.WindowsNetwork{
-				AllowUnqualifiedDNSQuery: true,
-			},
-		},
+		Windows: &specs.Windows{},
 	}
 	return nil
 }

--- a/vendor/github.com/containerd/containerd/oci/spec_opts_windows.go
+++ b/vendor/github.com/containerd/containerd/oci/spec_opts_windows.go
@@ -39,3 +39,29 @@ func WithWindowsCPUCount(count uint64) SpecOpts {
 		return nil
 	}
 }
+
+// WithWindowsIgnoreFlushesDuringBoot sets `Windows.IgnoreFlushesDuringBoot`.
+func WithWindowsIgnoreFlushesDuringBoot() SpecOpts {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
+		if s.Windows == nil {
+			s.Windows = &specs.Windows{}
+		}
+		s.Windows.IgnoreFlushesDuringBoot = true
+		return nil
+	}
+}
+
+// WithWindowNetworksAllowUnqualifiedDNSQuery sets `Windows.IgnoreFlushesDuringBoot`.
+func WithWindowNetworksAllowUnqualifiedDNSQuery() SpecOpts {
+	return func(_ context.Context, _ Client, _ *containers.Container, s *Spec) error {
+		if s.Windows == nil {
+			s.Windows = &specs.Windows{}
+		}
+		if s.Windows.Network == nil {
+			s.Windows.Network = &specs.WindowsNetwork{}
+		}
+
+		s.Windows.Network.AllowUnqualifiedDNSQuery = true
+		return nil
+	}
+}

--- a/vendor/github.com/containerd/containerd/vendor.conf
+++ b/vendor/github.com/containerd/containerd/vendor.conf
@@ -49,7 +49,7 @@ github.com/blang/semver v3.1.0
 github.com/containernetworking/cni v0.6.0
 github.com/containernetworking/plugins v0.7.0
 github.com/davecgh/go-spew v1.1.0
-github.com/docker/distribution b38e5838b7b2f2ad48e06ec4b500011976080621
+github.com/docker/distribution 0d3efadf0154c2b8a4e7b6621fff9809655cc580
 github.com/docker/docker 86f080cff0914e9694068ed78d503701667c4c00
 github.com/docker/spdystream 449fdfce4d962303d702fec724ef0ad181c92528
 github.com/emicklei/go-restful v2.2.1


### PR DESCRIPTION
This removes the last use of `util.NormalizeImageRef`

Let me know if you want to have this utility removed, or to keep it for backward compatibility (not sure if this repository is vendored elsewhere, and the utility used by other projects)