### PR TITLE
Use the correct sandbox config.

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -195,7 +195,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 
 	// Get container log path.
 	if config.GetLogPath() != "" {
-		meta.LogPath = filepath.Join(sandbox.Config.GetLogDirectory(), config.GetLogPath())
+		meta.LogPath = filepath.Join(sandboxConfig.GetLogDirectory(), config.GetLogPath())
 	}
 
 	containerIO, err := cio.NewContainerIO(id,


### PR DESCRIPTION
This is to work with https://github.com/kubernetes/kubernetes/pull/74441.

Usually the sandbox config passed in by `RunPodSandbox` and `CreateContainer` should be the same. However, it may not be the case when there is a version skew (sandbox is created before upgrade, container is created after upgrade).

Use the `sandboxConfig` passed in `CreateContainer` to keep the same behavior with dockershim.

Signed-off-by: Lantao Liu <lantaol@google.com>