### PR TITLE
Add an OCI annotation for sandbox log directory.

### DIFF
--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -32,6 +32,15 @@ const (
 	// SandboxID is the sandbox ID annotation
 	SandboxID = "io.kubernetes.cri.sandbox-id"
 
+	// SandboxLogDir is the pod log directory annotation.
+	// If the sandbox needs to generate any log, it will put it into this directory.
+	// Kubelet will be responsible for:
+	// 1) Monitoring the disk usage of the log, and including it as part of the pod
+	// ephemeral storage usage.
+	// 2) Cleaning up the logs when the pod is deleted.
+	// NOTE: Kubelet is not responsible for rotating the logs.
+	SandboxLogDir = "io.kubernetes.cri.sandbox-log-directory"
+
 	// UntrustedWorkload is the sandbox annotation for untrusted workload. Untrusted
 	// workload can only run on dedicated runtime for untrusted workload.
 	UntrustedWorkload = "io.kubernetes.cri.untrusted-workload"

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -454,6 +454,7 @@ func (c *criService) generateSandboxContainerSpec(id string, config *runtime.Pod
 
 	g.AddAnnotation(annotations.ContainerType, annotations.ContainerTypeSandbox)
 	g.AddAnnotation(annotations.SandboxID, id)
+	g.AddAnnotation(annotations.SandboxLogDir, config.GetLogDirectory())
 
 	return g.Config, nil
 }

--- a/pkg/server/sandbox_run_test.go
+++ b/pkg/server/sandbox_run_test.go
@@ -75,6 +75,9 @@ func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConf
 
 		assert.Contains(t, spec.Annotations, annotations.ContainerType)
 		assert.EqualValues(t, spec.Annotations[annotations.ContainerType], annotations.ContainerTypeSandbox)
+
+		assert.Contains(t, spec.Annotations, annotations.SandboxLogDir)
+		assert.EqualValues(t, spec.Annotations[annotations.SandboxLogDir], "test-log-directory")
 	}
 	return config, imageConfig, specCheck
 }


### PR DESCRIPTION
Add an OCI annotation to pass down the pod log directory.

This is useful for sandbox runtime which has pod level logs, e.g. gvisor. Actually I chatted with @resouer about this, and he told me that kata used to have pod level logs as well.

Especially after https://github.com/kubernetes/kubernetes/pull/74441 lands, Kubelet will be responsible for monitoring the disk usage and cleanup these logs.

@mikebrow Are you ok with cherrypicking this to release/1.2? It doesn't break anyone. :)

Signed-off-by: Lantao Liu <lantaol@google.com>