### PR TITLE
Add RuntimeHandler into PodSandbox and PodSandboxStatus

### DIFF
--- a/integration/runtime_handler_test.go
+++ b/integration/runtime_handler_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
+)
+
+func TestRuntimeHandler(t *testing.T) {
+	t.Logf("Create a sandbox")
+	sbConfig := PodSandboxConfig("sandbox", "test-runtime-handler")
+	t.Logf("the --runtime-handler flag value is: %s", *runtimeHandler)
+	sb, err := runtimeService.RunPodSandbox(sbConfig, *runtimeHandler)
+	require.NoError(t, err)
+	defer func() {
+		// Make sure the sandbox is cleaned up in any case.
+		runtimeService.StopPodSandbox(sb)
+		runtimeService.RemovePodSandbox(sb)
+	}()
+
+	t.Logf("Verify runtimeService.PodSandboxStatus sets RuntimeHandler")
+	sbStatus, err := runtimeService.PodSandboxStatus(sb)
+	require.NoError(t, err)
+	t.Logf("runtimeService.PodSandboxStatus sets RuntimeHandler to %s", sbStatus.RuntimeHandler)
+	assert.Equal(t, *runtimeHandler, sbStatus.RuntimeHandler)
+
+	t.Logf("Verify runtimeService.ListPodSandbox sets RuntimeHandler")
+	sandboxes, err := runtimeService.ListPodSandbox(&runtime.PodSandboxFilter{})
+	require.NoError(t, err)
+	t.Logf("runtimeService.ListPodSandbox sets RuntimeHandler to %s", sbStatus.RuntimeHandler)
+	assert.Equal(t, *runtimeHandler, sandboxes[0].RuntimeHandler)
+}

--- a/pkg/server/sandbox_list.go
+++ b/pkg/server/sandbox_list.go
@@ -47,12 +47,13 @@ func toCRISandbox(meta sandboxstore.Metadata, status sandboxstore.Status) *runti
 		state = runtime.PodSandboxState_SANDBOX_READY
 	}
 	return &runtime.PodSandbox{
-		Id:          meta.ID,
-		Metadata:    meta.Config.GetMetadata(),
-		State:       state,
-		CreatedAt:   status.CreatedAt.UnixNano(),
-		Labels:      meta.Config.GetLabels(),
-		Annotations: meta.Config.GetAnnotations(),
+		Id:             meta.ID,
+		Metadata:       meta.Config.GetMetadata(),
+		State:          state,
+		CreatedAt:      status.CreatedAt.UnixNano(),
+		Labels:         meta.Config.GetLabels(),
+		Annotations:    meta.Config.GetAnnotations(),
+		RuntimeHandler: meta.RuntimeHandler,
 	}
 }
 

--- a/pkg/server/sandbox_list_test.go
+++ b/pkg/server/sandbox_list_test.go
@@ -39,17 +39,19 @@ func TestToCRISandbox(t *testing.T) {
 	}
 	createdAt := time.Now()
 	meta := sandboxstore.Metadata{
-		ID:        "test-id",
-		Name:      "test-name",
-		Config:    config,
-		NetNSPath: "test-netns",
+		ID:             "test-id",
+		Name:           "test-name",
+		Config:         config,
+		NetNSPath:      "test-netns",
+		RuntimeHandler: "test-runtime-handler",
 	}
 	expect := &runtime.PodSandbox{
-		Id:          "test-id",
-		Metadata:    config.GetMetadata(),
-		CreatedAt:   createdAt.UnixNano(),
-		Labels:      config.GetLabels(),
-		Annotations: config.GetAnnotations(),
+		Id:             "test-id",
+		Metadata:       config.GetMetadata(),
+		CreatedAt:      createdAt.UnixNano(),
+		Labels:         config.GetLabels(),
+		Annotations:    config.GetAnnotations(),
+		RuntimeHandler: "test-runtime-handler",
 	}
 	for desc, test := range map[string]struct {
 		state         sandboxstore.State
@@ -93,6 +95,7 @@ func TestFilterSandboxes(t *testing.T) {
 						Attempt:   1,
 					},
 				},
+				RuntimeHandler: "test-runtime-handler",
 			},
 			sandboxstore.Status{
 				CreatedAt: time.Now(),
@@ -112,6 +115,7 @@ func TestFilterSandboxes(t *testing.T) {
 					},
 					Labels: map[string]string{"a": "b"},
 				},
+				RuntimeHandler: "test-runtime-handler",
 			},
 			sandboxstore.Status{
 				CreatedAt: time.Now(),
@@ -131,6 +135,7 @@ func TestFilterSandboxes(t *testing.T) {
 					},
 					Labels: map[string]string{"c": "d"},
 				},
+				RuntimeHandler: "test-runtime-handler",
 			},
 			sandboxstore.Status{
 				CreatedAt: time.Now(),

--- a/pkg/server/sandbox_status.go
+++ b/pkg/server/sandbox_status.go
@@ -107,21 +107,25 @@ func toCRISandboxStatus(meta sandboxstore.Metadata, status sandboxstore.Status, 
 				},
 			},
 		},
-		Labels:      meta.Config.GetLabels(),
-		Annotations: meta.Config.GetAnnotations(),
+		Labels:         meta.Config.GetLabels(),
+		Annotations:    meta.Config.GetAnnotations(),
+		RuntimeHandler: meta.RuntimeHandler,
 	}
 }
 
 // SandboxInfo is extra information for sandbox.
 // TODO (mikebrow): discuss predefining constants structures for some or all of these field names in CRI
 type SandboxInfo struct {
-	Pid            uint32                    `json:"pid"`
-	Status         string                    `json:"processStatus"`
-	NetNSClosed    bool                      `json:"netNamespaceClosed"`
-	Image          string                    `json:"image"`
-	SnapshotKey    string                    `json:"snapshotKey"`
-	Snapshotter    string                    `json:"snapshotter"`
-	RuntimeHandler string                    `json:"runtimeHandler"`
+	Pid         uint32 `json:"pid"`
+	Status      string `json:"processStatus"`
+	NetNSClosed bool   `json:"netNamespaceClosed"`
+	Image       string `json:"image"`
+	SnapshotKey string `json:"snapshotKey"`
+	Snapshotter string `json:"snapshotter"`
+	// Note: a new field `RuntimeHandler` has been added into the CRI PodSandboxStatus struct, and
+	// should be set. This `RuntimeHandler` field will be deprecated after containerd 1.3 (tracked
+	// in https://github.com/containerd/cri/issues/1064).
+	RuntimeHandler string                    `json:"runtimeHandler"` // see the Note above
 	RuntimeType    string                    `json:"runtimeType"`
 	RuntimeOptions interface{}               `json:"runtimeOptions"`
 	Config         *runtime.PodSandboxConfig `json:"config"`

--- a/pkg/server/sandbox_status_test.go
+++ b/pkg/server/sandbox_status_test.go
@@ -52,9 +52,10 @@ func TestPodSandboxStatus(t *testing.T) {
 		Annotations: map[string]string{"c": "d"},
 	}
 	metadata := sandboxstore.Metadata{
-		ID:     id,
-		Name:   "test-name",
-		Config: config,
+		ID:             id,
+		Name:           "test-name",
+		Config:         config,
+		RuntimeHandler: "test-runtime-handler",
 	}
 
 	expected := &runtime.PodSandboxStatus{
@@ -71,8 +72,9 @@ func TestPodSandboxStatus(t *testing.T) {
 				},
 			},
 		},
-		Labels:      config.GetLabels(),
-		Annotations: config.GetAnnotations(),
+		Labels:         config.GetLabels(),
+		Annotations:    config.GetAnnotations(),
+		RuntimeHandler: "test-runtime-handler",
 	}
 	for desc, test := range map[string]struct {
 		state         sandboxstore.State


### PR DESCRIPTION
Add RuntimeHandler into PodSandbox and PodSandboxStatus

The upstream CRI change: https://github.com/kubernetes/kubernetes/pull/73833

Signed-off-by: Haiyan Meng <haiyanmeng@google.com>