### PR TITLE
Remove deprecated runtime options.

### DIFF
--- a/cri.go
+++ b/cri.go
@@ -112,13 +112,6 @@ func initCRIService(ic *plugin.InitContext) (interface{}, error) {
 
 // validateConfig validates the given configuration.
 func validateConfig(c *criconfig.Config) error {
-	// It is an error to provide both an UntrustedWorkloadRuntime & define an 'untrusted' runtime.
-	if _, ok := c.ContainerdConfig.Runtimes[criconfig.RuntimeUntrusted]; ok {
-		if c.ContainerdConfig.UntrustedWorkloadRuntime.Type != "" {
-			return errors.New("conflicting definitions: configuration includes untrusted_workload_runtime and runtimes['untrusted']")
-		}
-	}
-
 	if c.StreamIdleTimeout != "" {
 		if _, err := time.ParseDuration(c.StreamIdleTimeout); err != nil {
 			return errors.Wrap(err, "invalid stream idle timeout")

--- a/docs/config.md
+++ b/docs/config.md
@@ -32,12 +32,6 @@ The explanation and default value of each configuration item are as follows:
   # stats_collect_period is the period (in seconds) of snapshots stats collection.
   stats_collect_period = 10
 
-  # systemd_cgroup enables systemd cgroup support. This only works for runtime
-  # type "io.containerd.runtime.v1.linux".
-  # DEPRECATED: use Runtime.Options for runtime specific config for shim v2 runtimes.
-  #   For runtime "io.containerd.runc.v1", use the option `SystemdCgroup`.
-  systemd_cgroup = false
-
   # enable_tls_streaming enables the TLS streaming support.
   # It generates a self-sign certificate unless the following x509_key_pair_streaming are both set.
   enable_tls_streaming = false
@@ -85,24 +79,9 @@ The explanation and default value of each configuration item are as follows:
       # runtime_type is the runtime type to use in containerd e.g. io.containerd.runtime.v1.linux
       runtime_type = "io.containerd.runtime.v1.linux"
 
-      # runtime_engine is the name of the runtime engine used by containerd.
-      # This only works for runtime type "io.containerd.runtime.v1.linux".
-      # DEPRECATED: use Runtime.Options for runtime specific config for shim v2 runtimes.
-      #   For runtime "io.containerd.runc.v1", use the option `BinaryName`.
-      runtime_engine = ""
-
-      # runtime_root is the directory used by containerd for runtime state.
-      # This only works for runtime type "io.containerd.runtime.v1.linux".
-      # DEPRECATED: use Runtime.Options for runtime specific config for shim v2 runtimes.
-      #   For runtime "io.containerd.runc.v1", use the option `Root`.
-      runtime_root = ""
-
       # "plugins.cri.containerd.default_runtime.options" is options specific to
       # the default runtime. The options type for "io.containerd.runtime.v1.linux" is:
       #   https://github.com/containerd/containerd/blob/v1.2.0-rc.1/runtime/linux/runctypes/runc.pb.go#L40
-      # NOTE: when `options` is specified, all related deprecated options will
-      #   be ignored, including `systemd_cgroup`, `no_pivot`, `runtime_engine`
-      #   and `runtime_root`.
       [plugins.cri.containerd.default_runtime.options]
         # Runtime is the binary name of the runtime.
         Runtime = ""
@@ -115,21 +94,6 @@ The explanation and default value of each configuration item are as follows:
 
         # SystemdCgroup enables systemd cgroups.
         SystemdCgroup = false
-
-    # "plugins.cri.containerd.untrusted_workload_runtime" is a runtime to run untrusted workloads on it.
-    # DEPRECATED: use plugins.cri.runtimes instead. If provided, this runtime is mapped to the
-    #   runtime handler named 'untrusted'. It is a configuration error to provide both the (now
-    #   deprecated) UntrustedWorkloadRuntime and a handler in the Runtimes handler map (below) for
-    #   'untrusted' workloads at the same time. Please provide one or the other.
-    [plugins.cri.containerd.untrusted_workload_runtime]
-      # runtime_type is the runtime type to use in containerd e.g. io.containerd.runtime.v1.linux
-      runtime_type = ""
-
-      # runtime_engine is the name of the runtime engine used by containerd.
-      runtime_engine = ""
-
-      # runtime_root is the directory used by containerd for runtime state.
-      runtime_root = ""
 
     # plugins.cri.containerd.runtimes is a map from CRI RuntimeHandler strings, which specify types
     # of runtime configurations, to the matching configurations. In this example,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,14 +27,6 @@ import (
 type Runtime struct {
 	// Type is the runtime type to use in containerd e.g. io.containerd.runtime.v1.linux
 	Type string `toml:"runtime_type" json:"runtimeType"`
-	// Engine is the name of the runtime engine used by containerd.
-	// This only works for runtime type "io.containerd.runtime.v1.linux".
-	// DEPRECATED: use Options instead. Remove when shim v1 is deprecated.
-	Engine string `toml:"runtime_engine" json:"runtimeEngine"`
-	// Root is the directory used by containerd for runtime state.
-	// DEPRECATED: use Options instead. Remove when shim v1 is deprecated.
-	// This only works for runtime type "io.containerd.runtime.v1.linux".
-	Root string `toml:"runtime_root" json:"runtimeRoot"`
 	// Options are config options for the runtime. If options is loaded
 	// from toml config, it will be toml.Primitive.
 	Options *toml.Primitive `toml:"options" json:"options"`
@@ -47,12 +39,6 @@ type ContainerdConfig struct {
 	// DefaultRuntime is the default runtime to use in containerd.
 	// This runtime is used when no runtime handler (or the empty string) is provided.
 	DefaultRuntime Runtime `toml:"default_runtime" json:"defaultRuntime"`
-	// UntrustedWorkloadRuntime is a runtime to run untrusted workloads on it.
-	// DEPRECATED: use Runtimes instead. If provided, this runtime is mapped to the runtime handler
-	//     named 'untrusted'. It is a configuration error to provide both the (now deprecated)
-	//     UntrustedWorkloadRuntime and a handler in the Runtimes handler map (below) for 'untrusted'
-	//     workloads at the same time. Please provide one or the other.
-	UntrustedWorkloadRuntime Runtime `toml:"untrusted_workload_runtime" json:"untrustedWorkloadRuntime"`
 	// Runtimes is a map from CRI RuntimeHandler strings, which specify types of runtime
 	// configurations, to the matching configurations.
 	Runtimes map[string]Runtime `toml:"runtimes" json:"runtimes"`
@@ -136,10 +122,6 @@ type PluginConfig struct {
 	SandboxImage string `toml:"sandbox_image" json:"sandboxImage"`
 	// StatsCollectPeriod is the period (in seconds) of snapshots stats collection.
 	StatsCollectPeriod int `toml:"stats_collect_period" json:"statsCollectPeriod"`
-	// SystemdCgroup enables systemd cgroup support.
-	// This only works for runtime type "io.containerd.runtime.v1.linux".
-	// DEPRECATED: config runc runtime handler instead. Remove when shim v1 is deprecated.
-	SystemdCgroup bool `toml:"systemd_cgroup" json:"systemdCgroup"`
 	// EnableTLSStreaming indicates to enable the TLS streaming support.
 	EnableTLSStreaming bool `toml:"enable_tls_streaming" json:"enableTLSStreaming"`
 	// X509KeyPairStreaming is a x509 key pair used for TLS streaming
@@ -194,9 +176,7 @@ func DefaultConfig() PluginConfig {
 		ContainerdConfig: ContainerdConfig{
 			Snapshotter: containerd.DefaultSnapshotter,
 			DefaultRuntime: Runtime{
-				Type:   "io.containerd.runtime.v1.linux",
-				Engine: "",
-				Root:   "",
+				Type: "io.containerd.runtime.v1.linux",
 			},
 			NoPivot: false,
 		},
@@ -211,7 +191,6 @@ func DefaultConfig() PluginConfig {
 		},
 		SandboxImage:            "k8s.gcr.io/pause:3.1",
 		StatsCollectPeriod:      10,
-		SystemdCgroup:           false,
 		MaxContainerLogLineSize: 16 * 1024,
 		Registry: Registry{
 			Mirrors: map[string]Mirror{

--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -425,8 +425,7 @@ func (c *criService) generateContainerSpec(id string, sandboxID string, sandboxP
 	} else {
 		setOCILinuxResourceCgroup(&g, config.GetLinux().GetResources())
 		if sandboxConfig.GetLinux().GetCgroupParent() != "" {
-			cgroupsPath := getCgroupsPath(sandboxConfig.GetLinux().GetCgroupParent(), id,
-				c.config.SystemdCgroup)
+			cgroupsPath := getCgroupsPath(sandboxConfig.GetLinux().GetCgroupParent(), id)
 			g.SetLinuxCgroupsPath(cgroupsPath)
 		}
 	}

--- a/pkg/server/container_create_test.go
+++ b/pkg/server/container_create_test.go
@@ -155,7 +155,7 @@ func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandbox
 		assert.Equal(t, spec.Process.NoNewPrivileges, true)
 
 		t.Logf("Check cgroup path")
-		assert.Equal(t, getCgroupsPath("/test/cgroup/parent", id, false), spec.Linux.CgroupsPath)
+		assert.Equal(t, getCgroupsPath("/test/cgroup/parent", id), spec.Linux.CgroupsPath)
 
 		t.Logf("Check namespaces")
 		assert.Contains(t, spec.Linux.Namespaces, runtimespec.LinuxNamespace{

--- a/pkg/server/helpers.go
+++ b/pkg/server/helpers.go
@@ -511,20 +511,11 @@ func parseImageReferences(refs []string) ([]string, []string) {
 
 // generateRuntimeOptions generates runtime options from cri plugin config.
 func generateRuntimeOptions(r criconfig.Runtime, c criconfig.Config) (interface{}, error) {
-	if r.Options == nil {
-		if r.Type != linuxRuntime {
-			return nil, nil
-		}
-		// This is a legacy config, generate runctypes.RuncOptions.
-		return &runctypes.RuncOptions{
-			Runtime:       r.Engine,
-			RuntimeRoot:   r.Root,
-			SystemdCgroup: c.SystemdCgroup,
-		}, nil
-	}
 	options := getRuntimeOptionsType(r.Type)
-	if err := toml.PrimitiveDecode(*r.Options, options); err != nil {
-		return nil, err
+	if r.Options != nil {
+		if err := toml.PrimitiveDecode(*r.Options, options); err != nil {
+			return nil, err
+		}
 	}
 	return options, nil
 }

--- a/pkg/server/helpers.go
+++ b/pkg/server/helpers.go
@@ -166,12 +166,12 @@ func makeContainerName(c *runtime.ContainerMetadata, s *runtime.PodSandboxMetada
 }
 
 // getCgroupsPath generates container cgroups path.
-func getCgroupsPath(cgroupsParent, id string, systemdCgroup bool) string {
-	if systemdCgroup {
-		// Convert a.slice/b.slice/c.slice to c.slice.
-		p := path.Base(cgroupsParent)
+func getCgroupsPath(cgroupsParent, id string) string {
+	base := path.Base(cgroupsParent)
+	if strings.HasSuffix(base, ".slice") {
+		// For a.slice/b.slice/c.slice, base is c.slice.
 		// runc systemd cgroup path format is "slice:prefix:name".
-		return strings.Join([]string{p, "cri-containerd", id}, ":")
+		return strings.Join([]string{base, "cri-containerd", id}, ":")
 	}
 	return filepath.Join(cgroupsParent, id)
 }

--- a/pkg/server/helpers_test.go
+++ b/pkg/server/helpers_test.go
@@ -240,7 +240,6 @@ func TestLocalResolve(t *testing.T) {
 
 func TestGenerateRuntimeOptions(t *testing.T) {
 	nilOpts := `
-systemd_cgroup = true
 [containerd]
   no_pivot = true
 [containerd.default_runtime]
@@ -249,7 +248,6 @@ systemd_cgroup = true
   runtime_type = "` + runcRuntime + `"
 `
 	nonNilOpts := `
-systemd_cgroup = true
 [containerd]
   no_pivot = true
 [containerd.default_runtime]
@@ -277,17 +275,15 @@ systemd_cgroup = true
 		c               criconfig.Config
 		expectedOptions interface{}
 	}{
-		"when options is nil, should return nil option for non legacy runtime": {
+		"when options is nil, should return empty option for non legacy runtime": {
 			r:               nilOptsConfig.Runtimes["runc"],
 			c:               nilOptsConfig,
-			expectedOptions: nil,
+			expectedOptions: &runcoptions.Options{},
 		},
-		"when options is nil, should use legacy fields for legacy runtime": {
-			r: nilOptsConfig.DefaultRuntime,
-			c: nilOptsConfig,
-			expectedOptions: &runctypes.RuncOptions{
-				SystemdCgroup: true,
-			},
+		"when options is nil, should return empty option for legacy runtime as well": {
+			r:               nilOptsConfig.DefaultRuntime,
+			c:               nilOptsConfig,
+			expectedOptions: &runctypes.RuncOptions{},
 		},
 		"when options is not nil, should be able to decode for io.containerd.runc.v1": {
 			r: nonNilOptsConfig.Runtimes["runc"],

--- a/pkg/server/helpers_test.go
+++ b/pkg/server/helpers_test.go
@@ -117,22 +117,31 @@ func TestGetCgroupsPath(t *testing.T) {
 	testID := "test-id"
 	for desc, test := range map[string]struct {
 		cgroupsParent string
-		systemdCgroup bool
 		expected      string
 	}{
 		"should support regular cgroup path": {
 			cgroupsParent: "/a/b",
-			systemdCgroup: false,
 			expected:      "/a/b/test-id",
 		},
 		"should support systemd cgroup path": {
 			cgroupsParent: "/a.slice/b.slice",
-			systemdCgroup: true,
 			expected:      "b.slice:cri-containerd:test-id",
+		},
+		"should support tailing slash for regular cgroup path": {
+			cgroupsParent: "/a/b/",
+			expected:      "/a/b/test-id",
+		},
+		"should support tailing slash for systemd cgroup path": {
+			cgroupsParent: "/a.slice/b.slice/",
+			expected:      "b.slice:cri-containerd:test-id",
+		},
+		"should treat root cgroup as regular cgroup path": {
+			cgroupsParent: "/",
+			expected:      "/test-id",
 		},
 	} {
 		t.Logf("TestCase %q", desc)
-		got := getCgroupsPath(test.cgroupsParent, testID, test.systemdCgroup)
+		got := getCgroupsPath(test.cgroupsParent, testID)
 		assert.Equal(t, test.expected, got)
 	}
 }

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -655,11 +655,6 @@ func (c *criService) getSandboxRuntime(config *runtime.PodSandboxConfig, runtime
 			return criconfig.Runtime{}, errors.New("untrusted workload with host access is not allowed")
 		}
 
-		// Handle the deprecated UntrustedWorkloadRuntime.
-		if c.config.ContainerdConfig.UntrustedWorkloadRuntime.Type != "" {
-			return c.config.ContainerdConfig.UntrustedWorkloadRuntime, nil
-		}
-
 		runtimeHandler = criconfig.RuntimeUntrusted
 	}
 

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -381,8 +381,7 @@ func (c *criService) generateSandboxContainerSpec(id string, config *runtime.Pod
 		g.SetLinuxCgroupsPath("")
 	} else {
 		if config.GetLinux().GetCgroupParent() != "" {
-			cgroupsPath := getCgroupsPath(config.GetLinux().GetCgroupParent(), id,
-				c.config.SystemdCgroup)
+			cgroupsPath := getCgroupsPath(config.GetLinux().GetCgroupParent(), id)
 			g.SetLinuxCgroupsPath(cgroupsPath)
 		}
 	}

--- a/pkg/server/sandbox_run_test.go
+++ b/pkg/server/sandbox_run_test.go
@@ -60,7 +60,7 @@ func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConf
 	}
 	specCheck := func(t *testing.T, id string, spec *runtimespec.Spec) {
 		assert.Equal(t, "test-hostname", spec.Hostname)
-		assert.Equal(t, getCgroupsPath("/test/cgroup/parent", id, false), spec.Linux.CgroupsPath)
+		assert.Equal(t, getCgroupsPath("/test/cgroup/parent", id), spec.Linux.CgroupsPath)
 		assert.Equal(t, relativeRootfsPath, spec.Root.Path)
 		assert.Equal(t, true, spec.Root.Readonly)
 		assert.Contains(t, spec.Process.Env, "a=b", "c=d")


### PR DESCRIPTION
This PR:
1) Auto detect systemd parent cgroup, so that we don't need a daemon level `SystemdCgroup` option any more. However, `SystemdCgroup` option in the runc options is still available, should we also auto detect if it is not explicitly set? /cc @yujuhong @filbranden 
2) Remove all deprecated daemon level runtime options. Users should use runtime specific options since containerd 1.3. Note that we keep the `no_pivot` option right now, because there is no runtime specific option for it in shim v1, we can only remove it when shim v1 is deprecated.