### PR TITLE
Use clean path for map and comparison.

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -186,7 +186,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	if len(volumeMounts) > 0 {
 		mountMap := make(map[string]string)
 		for _, v := range volumeMounts {
-			mountMap[v.HostPath] = v.ContainerPath
+			mountMap[filepath.Clean(v.HostPath)] = v.ContainerPath
 		}
 		opts = append(opts, customopts.WithVolumes(mountMap))
 	}
@@ -750,7 +750,7 @@ func setOCIBindMountsPrivileged(g *generator) {
 	spec := g.Config
 	// clear readonly for /sys and cgroup
 	for i, m := range spec.Mounts {
-		if spec.Mounts[i].Destination == "/sys" {
+		if filepath.Clean(spec.Mounts[i].Destination) == "/sys" {
 			clearReadOnly(&spec.Mounts[i])
 		}
 		if m.Type == "cgroup" {
@@ -908,7 +908,7 @@ func defaultRuntimeSpec(id string) (*runtimespec.Spec, error) {
 	// TODO(random-liu): Mount tmpfs for /run and handle copy-up.
 	var mounts []runtimespec.Mount
 	for _, mount := range spec.Mounts {
-		if mount.Destination == "/run" {
+		if filepath.Clean(mount.Destination) == "/run" {
 			continue
 		}
 		mounts = append(mounts, mount)

--- a/pkg/server/helpers.go
+++ b/pkg/server/helpers.go
@@ -374,7 +374,7 @@ func checkSelinuxLevel(level string) (bool, error) {
 // isInCRIMounts checks whether a destination is in CRI mount list.
 func isInCRIMounts(dst string, mounts []*runtime.Mount) bool {
 	for _, m := range mounts {
-		if m.ContainerPath == dst {
+		if filepath.Clean(m.ContainerPath) == filepath.Clean(dst) {
 			return true
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/containerd/cri/issues/1059.

Use `filepath.Clean` for map deduplication and path comparison.

I've searched with `git grep -i`: `==.*path`, `path.*==`, `\[.*path.*\]`, `==.*source`, `source.*==`, `\[.*source.*\]`, `==.*src`, `src.*==`, `\[.*src.*\]`, `==.*dst`, `dst.*==`,  `\[.*dst.*\]`,`==.*dest`, `dest.*==`, `\[.*dest.*\]`. And added `filepath.Clean` for all appearance.

We should cherry-pick this fix into all supported branches.
Signed-off-by: Lantao Liu <lantaol@google.com>