### PR TITLE
Add an OCI annotation for sandbox VM params

### DIFF
--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -45,6 +45,7 @@ import (
 	"github.com/containerd/cri/pkg/netns"
 	sandboxstore "github.com/containerd/cri/pkg/store/sandbox"
 	"github.com/containerd/cri/pkg/util"
+	sandboxAnnotations "github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
 )
 
 func init() {
@@ -451,6 +452,27 @@ func (c *criService) generateSandboxContainerSpec(id string, config *runtime.Pod
 		}
 	}
 	g.SetProcessOOMScoreAdj(adj)
+
+	vcAnnotations := []string{
+		sandboxAnnotations.KernelPath,
+		sandboxAnnotations.ImagePath,
+		sandboxAnnotations.InitrdPath,
+		sandboxAnnotations.HypervisorPath,
+		sandboxAnnotations.FirmwarePath,
+		sandboxAnnotations.KernelHash,
+		sandboxAnnotations.ImageHash,
+		sandboxAnnotations.InitrdHash,
+		sandboxAnnotations.HypervisorHash,
+		sandboxAnnotations.FirmwareHash,
+	}
+
+	for _, a := range vcAnnotations {
+		value, ok := config.Annotations[a]
+		if !ok {
+			continue
+		}
+		g.AddAnnotation(a, value)
+	}
 
 	g.AddAnnotation(annotations.ContainerType, annotations.ContainerTypeSandbox)
 	g.AddAnnotation(annotations.SandboxID, id)

--- a/pkg/server/sandbox_run_test.go
+++ b/pkg/server/sandbox_run_test.go
@@ -34,9 +34,23 @@ import (
 	criconfig "github.com/containerd/cri/pkg/config"
 	ostesting "github.com/containerd/cri/pkg/os/testing"
 	sandboxstore "github.com/containerd/cri/pkg/store/sandbox"
+	sandboxAnnotations "github.com/kata-containers/runtime/virtcontainers/pkg/annotations"
 )
 
 func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConfig, func(*testing.T, string, *runtimespec.Spec)) {
+
+	kernelPath := "/var/runtime/kernel"
+	initrdPath := "/var/runtime/initrd.img"
+	imagePath := "/var/runtime/image.img"
+	hypervisorPath := "/usr/bin/qemu-custom"
+	firmwarePath := "/var/run/custom-firmware/img"
+
+	kernelHash := "3971EBF11A18BCE250A282E6FF78739C9A0F7BCB9BC3552FE9CD8191E4A4DA573BB38983A47B2A86A63BFC4E41D3361D5D6AE1A1480BF3F27F730CC75FBC84DE"
+	initrdHash := "652DCF7057417D54C3236731A2CA47330B8809236B87DA89917403FEAAC34EA5DBE938EE60FDD606383B38DF9B51239D25968DDF1C0445C0E7AB448287197D64"
+	imageHash := "31D329DA77A2D0EF2943209EF432E3F0C7ED5B57124AFF1E37A5C7E6A01D780A473BD0FD594A3FA7CFBC2573FB150702BB11014C090D9222F9A0C048771F6F2A"
+	hypervisorHash := "0D4C6CCCCDCA141804EB236A07598FF118435450F58A181EED37E6E2D037720E1847473687558289F3972BDE6A9FD2E1F9EDC8C9B0550621D04198111FA955AD"
+	firmwareHash := "259870D2FF9DCB1C44E2D0C6FB467364422D9643E0577A55397E15ECEADA4668A9D1AD7FF776D1A93B9A70FE8C8C4EA77FE75E4BD21E7C24F1490FE09811CBD8"
+
 	config := &runtime.PodSandboxConfig{
 		Metadata: &runtime.PodSandboxMetadata{
 			Name:      "test-name",
@@ -47,7 +61,18 @@ func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConf
 		Hostname:     "test-hostname",
 		LogDirectory: "test-log-directory",
 		Labels:       map[string]string{"a": "b"},
-		Annotations:  map[string]string{"c": "d"},
+		Annotations: map[string]string{"c": "d",
+			sandboxAnnotations.KernelPath:     kernelPath,
+			sandboxAnnotations.InitrdPath:     initrdPath,
+			sandboxAnnotations.ImagePath:      imagePath,
+			sandboxAnnotations.HypervisorPath: hypervisorPath,
+			sandboxAnnotations.FirmwarePath:   firmwarePath,
+			sandboxAnnotations.KernelHash:     kernelHash,
+			sandboxAnnotations.InitrdHash:     initrdHash,
+			sandboxAnnotations.ImageHash:      imageHash,
+			sandboxAnnotations.HypervisorHash: hypervisorHash,
+			sandboxAnnotations.FirmwareHash:   firmwareHash,
+		},
 		Linux: &runtime.LinuxPodSandboxConfig{
 			CgroupParent: "/test/cgroup/parent",
 		},
@@ -75,6 +100,28 @@ func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConf
 
 		assert.Contains(t, spec.Annotations, annotations.ContainerType)
 		assert.EqualValues(t, spec.Annotations[annotations.ContainerType], annotations.ContainerTypeSandbox)
+
+		assert.Contains(t, spec.Annotations, sandboxAnnotations.KernelPath)
+		assert.EqualValues(t, spec.Annotations[sandboxAnnotations.KernelPath], kernelPath)
+		assert.Contains(t, spec.Annotations, sandboxAnnotations.InitrdPath)
+		assert.EqualValues(t, spec.Annotations[sandboxAnnotations.InitrdPath], initrdPath)
+		assert.Contains(t, spec.Annotations, sandboxAnnotations.ImagePath)
+		assert.EqualValues(t, spec.Annotations[sandboxAnnotations.ImagePath], imagePath)
+		assert.Contains(t, spec.Annotations, sandboxAnnotations.HypervisorPath)
+		assert.EqualValues(t, spec.Annotations[sandboxAnnotations.HypervisorPath], hypervisorPath)
+		assert.Contains(t, spec.Annotations, sandboxAnnotations.FirmwarePath)
+		assert.EqualValues(t, spec.Annotations[sandboxAnnotations.FirmwarePath], firmwarePath)
+
+		assert.Contains(t, spec.Annotations, sandboxAnnotations.KernelHash)
+		assert.EqualValues(t, spec.Annotations[sandboxAnnotations.KernelHash], kernelHash)
+		assert.Contains(t, spec.Annotations, sandboxAnnotations.InitrdHash)
+		assert.EqualValues(t, spec.Annotations[sandboxAnnotations.InitrdHash], initrdHash)
+		assert.Contains(t, spec.Annotations, sandboxAnnotations.ImageHash)
+		assert.EqualValues(t, spec.Annotations[sandboxAnnotations.ImageHash], imageHash)
+		assert.Contains(t, spec.Annotations, sandboxAnnotations.HypervisorHash)
+		assert.EqualValues(t, spec.Annotations[sandboxAnnotations.HypervisorHash], hypervisorHash)
+		assert.Contains(t, spec.Annotations, sandboxAnnotations.FirmwareHash)
+		assert.EqualValues(t, spec.Annotations[sandboxAnnotations.FirmwareHash], firmwareHash)
 	}
 	return config, imageConfig, specCheck
 }

--- a/vendor.conf
+++ b/vendor.conf
@@ -76,3 +76,4 @@ k8s.io/klog 8145543d67ada0bd556af97faeeb8a65a2651c98
 k8s.io/kubernetes v1.15.0-alpha.0
 k8s.io/utils c2654d5206da6b7b6ace12841e8f359bb89b443c
 sigs.k8s.io/yaml v1.1.0
+github.com/kata-containers/runtime ec6a1cc8236c5b7cae1708ad77b22b3aedc338b8

--- a/vendor/github.com/kata-containers/runtime/LICENSE
+++ b/vendor/github.com/kata-containers/runtime/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/kata-containers/runtime/README.md
+++ b/vendor/github.com/kata-containers/runtime/README.md
@@ -1,0 +1,176 @@
+[![Build Status](https://travis-ci.org/kata-containers/runtime.svg?branch=master)](https://travis-ci.org/kata-containers/runtime)
+[![Build Status](http://jenkins.katacontainers.io/job/kata-containers-runtime-ubuntu-18-04-master/badge/icon)](http://jenkins.katacontainers.io/job/kata-containers-runtime-ubuntu-18-04-master/)
+[![Go Report Card](https://goreportcard.com/badge/github.com/kata-containers/runtime)](https://goreportcard.com/report/github.com/kata-containers/runtime)
+[![GoDoc](https://godoc.org/github.com/kata-containers/runtime?status.svg)](https://godoc.org/github.com/kata-containers/runtime)
+
+# Runtime
+
+This repository contains the runtime for the
+[Kata Containers](https://github.com/kata-containers) project.
+
+For details of the other Kata Containers repositories, see the
+[repository summary](https://github.com/kata-containers/kata-containers).
+
+* [Introduction](#introduction)
+* [License](#license)
+* [Platform support](#platform-support)
+    * [Hardware requirements](#hardware-requirements)
+* [Download and install](#download-and-install)
+* [Quick start for developers](#quick-start-for-developers)
+* [Architecture overview](#architecture-overview)
+* [Configuration](#configuration)
+* [Logging](#logging)
+* [Debugging](#debugging)
+* [Limitations](#limitations)
+* [Community](#community)
+    * [Contact](#contact)
+* [Further information](#further-information)
+
+## Introduction
+
+`kata-runtime`, referred to as "the runtime", is the Command-Line Interface
+(CLI) part of the Kata Containers runtime component. It leverages the
+[virtcontainers](https://github.com/kata-containers/runtime/tree/master/virtcontainers)
+package to provide a high-performance standards-compliant runtime that creates
+hardware-virtualized containers.
+
+The runtime is
+[OCI](https://github.com/opencontainers/runtime-spec)-compatible,
+[CRI-O](https://github.com/kubernetes-incubator/cri-o)-compatible, and
+[Containerd](https://github.com/containerd/containerd)-compatible,
+ allowing it
+to work seamlessly with both Docker and Kubernetes respectively.
+
+## License
+
+The code is licensed under an Apache 2.0 license.
+
+See [the license file](LICENSE) for further details.
+
+## Platform support
+
+Kata Containers currently works on systems supporting the following
+technologies:
+
+- [Intel](https://www.intel.com) VT-x technology.
+- [ARM](https://www.arm.com) Hyp mode (virtualization extension).
+- [IBM](https://www.ibm.com) Power Systems.
+- [IBM](https://www.ibm.com) Z mainframes.
+### Hardware requirements
+
+The runtime has a built-in command to determine if your host system is capable
+of running a Kata Container:
+
+```bash
+$ kata-runtime kata-check
+```
+
+> **Note:**
+>
+> If you run the previous command as the `root` user, further checks will be
+> performed (e.g. it will check if another incompatible hypervisor is running):
+>
+> ```bash
+> $ sudo kata-runtime kata-check
+> ```
+
+## Download and install
+
+[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/kata-containers)
+
+See the [installation guides](https://github.com/kata-containers/documentation/tree/master/install/README.md)
+available for various operating systems.
+
+## Quick start for developers
+
+See the
+[developer guide](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md).
+
+## Architecture overview
+
+See the [architecture overview](https://github.com/kata-containers/documentation/blob/master/architecture.md)
+for details on the Kata Containers design.
+
+## Configuration
+
+The runtime uses a TOML format configuration file called `configuration.toml`.
+The file contains comments explaining all options.
+
+> **Note:**
+>
+> The initial values in the configuration file provide a good default configuration.
+> You might need to modify this file if you have specialist needs.
+
+Since the runtime supports a
+[stateless system](https://clearlinux.org/features/stateless),
+it checks for this configuration file in multiple locations, two of which are
+built in to the runtime. The default location is
+`/usr/share/defaults/kata-containers/configuration.toml` for a standard
+system. However, if `/etc/kata-containers/configuration.toml` exists, this
+takes priority.
+
+The command below lists the full paths to the configuration files that the
+runtime attempts to load. The first path that exists is used:
+
+```bash
+$ kata-runtime --kata-show-default-config-paths
+```
+
+Aside from the built-in locations, it is possible to specify the path to a
+custom configuration file using the `--kata-config` option:
+
+```bash
+$ kata-runtime --kata-config=/some/where/configuration.toml ...
+```
+
+The runtime will log the full path to the configuration file it is using. See
+the [logging](#Logging) section for further details.
+
+To see details of your systems runtime environment (including the location of
+the configuration file being used), run:
+
+```bash
+$ kata-runtime kata-env
+```
+
+## Logging
+
+The runtime provides `--log=` and `--log-format=` options. However, the
+runtime always logs to the system log (`syslog` or `journald`).
+
+To view runtime log output:
+
+```bash
+$ sudo journalctl -t kata-runtime
+```
+
+For detailed information and analysis on obtaining logs for other system
+components, see the documentation for the
+[kata-log-parser](https://github.com/kata-containers/tests/tree/master/cmd/log-parser)
+tool.
+
+## Debugging
+
+See the
+[debugging section of the developer guide](https://github.com/kata-containers/documentation/blob/master/Developer-Guide.md#troubleshoot-kata-containers).
+
+## Limitations
+
+See the
+[limitations file](https://github.com/kata-containers/documentation/blob/master/Limitations.md)
+for further details.
+
+## Community
+
+See [the community repository](https://github.com/kata-containers/community).
+
+### Contact
+
+See [how to reach the community](https://github.com/kata-containers/community/blob/master/CONTRIBUTING.md#contact).
+
+## Further information
+
+See the
+[project table of contents](https://github.com/kata-containers/kata-containers)
+and the
+[documentation repository](https://github.com/kata-containers/documentation).

--- a/vendor/github.com/kata-containers/runtime/virtcontainers/LICENSE
+++ b/vendor/github.com/kata-containers/runtime/virtcontainers/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/kata-containers/runtime/virtcontainers/README.md
+++ b/vendor/github.com/kata-containers/runtime/virtcontainers/README.md
@@ -1,0 +1,326 @@
+Table of Contents
+=================
+
+   * [What is it ?](#what-is-it-)
+   * [Background](#background)
+   * [Out of scope](#out-of-scope)
+      * [virtcontainers and Kubernetes CRI](#virtcontainers-and-kubernetes-cri)
+   * [Design](#design)
+      * [Sandboxes](#sandboxes)
+      * [Hypervisors](#hypervisors)
+      * [Agents](#agents)
+      * [Shim](#shim)
+      * [Proxy](#proxy)
+   * [API](#api)
+      * [Sandbox API](#sandbox-api)
+      * [Container API](#container-api)
+   * [Networking](#networking)
+      * [CNM](#cnm)
+   * [Storage](#storage)
+      * [How to check if container uses devicemapper block device as its rootfs](#how-to-check-if-container-uses-devicemapper-block-device-as-its-rootfs)
+   * [Devices](#devices)
+      * [How to pass a device using VFIO-passthrough](#how-to-pass-a-device-using-vfio-passthrough)
+   * [Developers](#developers)
+
+# What is it ?
+
+`virtcontainers` is a Go library that can be used to build hardware-virtualized container
+runtimes.
+
+# Background
+
+The few existing VM-based container runtimes (Clear Containers, runv, rkt's
+kvm stage 1) all share the same hardware virtualization semantics but use different
+code bases to implement them. `virtcontainers`'s goal is to factorize this code into
+a common Go library.
+
+Ideally, VM-based container runtime implementations would become translation
+layers from the runtime specification they implement (e.g. the [OCI runtime-spec][oci]
+or the [Kubernetes CRI][cri]) to the `virtcontainers` API.
+
+`virtcontainers` is [Clear Containers][cc]'s runtime foundational package for their
+[runtime][cc-runtime] implementation
+
+[oci]: https://github.com/opencontainers/runtime-spec
+[cri]: https://github.com/kubernetes/community/blob/master/contributors/devel/container-runtime-interface.md
+[cc]: https://github.com/clearcontainers/
+[cc-runtime]: https://github.com/clearcontainers/runtime/
+
+# Out of scope
+
+Implementing a container runtime is out of scope for this project. Any
+tools or executables in this repository are only provided for demonstration or
+testing purposes.
+
+## virtcontainers and Kubernetes CRI
+
+`virtcontainers`'s API is loosely inspired by the Kubernetes [CRI][cri] because
+we believe it provides the right level of abstractions for containerized sandboxes.
+However, despite the API similarities between the two projects, the goal of
+`virtcontainers` is _not_ to build a CRI implementation, but instead to provide a
+generic, runtime-specification agnostic, hardware-virtualized containers
+library that other projects could leverage to implement CRI themselves.
+
+# Design
+
+## Sandboxes
+
+The `virtcontainers` execution unit is a _sandbox_, i.e. `virtcontainers` users start sandboxes where
+containers will be running.
+
+`virtcontainers` creates a sandbox by starting a virtual machine and setting the sandbox
+up within that environment. Starting a sandbox means launching all containers with
+the VM sandbox runtime environment.
+
+## Hypervisors
+
+The `virtcontainers` package relies on hypervisors to start and stop virtual machine where
+sandboxes will be running. An hypervisor is defined by an Hypervisor interface implementation,
+and the default implementation is the QEMU one.
+
+## Agents
+
+During the lifecycle of a container, the runtime running on the host needs to interact with
+the virtual machine guest OS in order to start new commands to be executed as part of a given
+container workload, set new networking routes or interfaces, fetch a container standard or
+error output, and so on.
+There are many existing and potential solutions to resolve that problem and `virtcontainers` abstracts
+this through the Agent interface.
+
+## Shim
+
+In some cases the runtime will need a translation shim between the higher level container
+stack (e.g. Docker) and the virtual machine holding the container workload. This is needed
+for container stacks that make strong assumptions on the nature of the container they're
+monitoring. In cases where they assume containers are simply regular host processes, a shim
+layer is needed to translate host specific semantics into e.g. agent controlled virtual
+machine ones.
+
+## Proxy
+
+When hardware virtualized containers have limited I/O multiplexing capabilities,
+runtimes may decide to rely on an external host proxy to support cases where several
+runtime instances are talking to the same container.
+
+# API
+
+The high level `virtcontainers` API is the following one:
+
+## Sandbox API
+
+* `CreateSandbox(sandboxConfig SandboxConfig)` creates a Sandbox.
+The virtual machine is started and the Sandbox is prepared.
+
+* `DeleteSandbox(sandboxID string)` deletes a Sandbox.
+The virtual machine is shut down and all information related to the Sandbox are removed.
+The function will fail if the Sandbox is running. In that case `StopSandbox()` has to be called first.
+
+* `StartSandbox(sandboxID string)` starts an already created Sandbox.
+The Sandbox and all its containers are started.
+
+* `RunSandbox(sandboxConfig SandboxConfig)` creates and starts a Sandbox.
+This performs `CreateSandbox()` + `StartSandbox()`.
+
+* `StopSandbox(sandboxID string)` stops an already running Sandbox.
+The Sandbox and all its containers are stopped.
+
+* `PauseSandbox(sandboxID string)` pauses an existing Sandbox.
+
+* `ResumeSandbox(sandboxID string)` resume a paused Sandbox.
+
+* `StatusSandbox(sandboxID string)` returns a detailed Sandbox status.
+
+* `ListSandbox()` lists all Sandboxes on the host.
+It returns a detailed status for every Sandbox.
+
+## Container API
+
+* `CreateContainer(sandboxID string, containerConfig ContainerConfig)` creates a Container on an existing Sandbox.
+
+* `DeleteContainer(sandboxID, containerID string)` deletes a Container from a Sandbox.
+If the Container is running it has to be stopped first.
+
+* `StartContainer(sandboxID, containerID string)` starts an already created Container.
+The Sandbox has to be running.
+
+* `StopContainer(sandboxID, containerID string)` stops an already running Container.
+
+* `EnterContainer(sandboxID, containerID string, cmd Cmd)` enters an already running Container and runs a given command.
+
+* `StatusContainer(sandboxID, containerID string)` returns a detailed Container status.
+
+* `KillContainer(sandboxID, containerID string, signal syscall.Signal, all bool)` sends a signal to all or one container inside a Sandbox.
+
+An example tool using the `virtcontainers` API is provided in the `hack/virtc` package.
+
+# Networking
+
+`virtcontainers` supports the 2 major container networking models: the [Container Network Model (CNM)][cnm] and the [Container Network Interface (CNI)][cni].
+
+Typically the former is the Docker default networking model while the later is used on Kubernetes deployments.
+
+[cnm]: https://github.com/docker/libnetwork/blob/master/docs/design.md
+[cni]: https://github.com/containernetworking/cni/
+
+## CNM
+
+![High-level CNM Diagram](documentation/network/CNM_overall_diagram.png)
+
+__CNM lifecycle__
+
+1.  RequestPool
+
+2.  CreateNetwork
+
+3.  RequestAddress
+
+4.  CreateEndPoint
+
+5.  CreateContainer
+
+6.  Create config.json
+
+7.  Create PID and network namespace
+
+8.  ProcessExternalKey
+
+9.  JoinEndPoint
+
+10. LaunchContainer
+
+11. Launch
+
+12. Run container
+
+![Detailed CNM Diagram](documentation/network/CNM_detailed_diagram.png)
+
+__Runtime network setup with CNM__
+
+1. Read config.json
+
+2. Create the network namespace ([code](https://github.com/containers/virtcontainers/blob/0.5.0/cnm.go#L108-L120))
+
+3. Call the prestart hook (from inside the netns) ([code](https://github.com/containers/virtcontainers/blob/0.5.0/api.go#L46-L49))
+
+4. Scan network interfaces inside netns and get the name of the interface created by prestart hook ([code](https://github.com/containers/virtcontainers/blob/0.5.0/cnm.go#L70-L106))
+
+5. Create bridge, TAP, and link all together with network interface previously created ([code](https://github.com/containers/virtcontainers/blob/0.5.0/network.go#L123-L205))
+
+6. Start VM inside the netns and start the container ([code](https://github.com/containers/virtcontainers/blob/0.5.0/api.go#L66-L70))
+
+__Drawbacks of CNM__
+
+There are three drawbacks about using CNM instead of CNI:
+* The way we call into it is not very explicit: Have to re-exec dockerd binary so that it can accept parameters and execute the prestart hook related to network setup.
+* Implicit way to designate the network namespace: Instead of explicitely giving the netns to dockerd, we give it the PID of our runtime so that it can find the netns from this PID. This means we have to make sure being in the right netns while calling the hook, otherwise the veth pair will be created with the wrong netns.
+* No results are back from the hook: We have to scan the network interfaces to discover which one has been created inside the netns. This introduces more latency in the code because it forces us to scan the network in the CreateSandbox path, which is critical for starting the VM as quick as possible.
+
+# Storage
+
+Container workloads are shared with the virtualized environment through 9pfs.
+The devicemapper storage driver is a special case. The driver uses dedicated block devices rather than formatted filesystems, and operates at the block level rather than the file level. This knowledge has been used to directly use the underlying block device instead of the overlay file system for the container root file system. The block device maps to the top read-write layer for the overlay. This approach gives much better I/O performance compared to using 9pfs to share the container file system.
+
+The approach above does introduce a limitation in terms of dynamic file copy in/out of the container via `docker cp` operations.
+The copy operation from host to container accesses the mounted file system on the host side. This is not expected to work and may lead to inconsistencies as the block device will be simultaneously written to, from two different mounts.
+The copy operation from container to host will work, provided the user calls `sync(1)` from within the container prior to the copy to make sure any outstanding cached data is written to the block device.
+
+```
+docker cp [OPTIONS] CONTAINER:SRC_PATH HOST:DEST_PATH
+docker cp [OPTIONS] HOST:SRC_PATH CONTAINER:DEST_PATH
+```
+
+Ability to hotplug block devices has been added, which makes it possible to use block devices for containers started after the VM has been launched.
+
+## How to check if container uses devicemapper block device as its rootfs
+
+Start a container. Call mount(8) within the container. You should see '/' mounted on /dev/vda device.
+
+# Devices
+
+Support has been added to pass [VFIO](https://www.kernel.org/doc/Documentation/vfio.txt) 
+assigned devices on the docker command line with --device.
+Support for passing other devices including block devices with --device has
+not been added added yet.
+
+## How to pass a device using VFIO-passthrough
+
+1. Requirements
+
+IOMMU group represents the smallest set of devices for which the IOMMU has
+visibility and which is isolated from other groups.  VFIO uses this information
+to enforce safe ownership of devices for userspace. 
+
+You will need Intel VT-d capable hardware. Check if IOMMU is enabled in your host
+kernel by verifying `CONFIG_VFIO_NOIOMMU` is not in the kernel config. If it is set,
+you will need to rebuild your kernel.
+
+The following kernel configs need to be enabled:
+```
+CONFIG_VFIO_IOMMU_TYPE1=m 
+CONFIG_VFIO=m
+CONFIG_VFIO_PCI=m
+```
+
+In addition, you need to pass `intel_iommu=on` on the kernel command line.
+
+2. Identify BDF(Bus-Device-Function) of the PCI device to be assigned.
+
+
+```
+$ lspci -D | grep -e Ethernet -e Network
+0000:01:00.0 Ethernet controller: Intel Corporation Ethernet Controller 10-Gigabit X540-AT2 (rev 01)
+
+$ BDF=0000:01:00.0
+```
+
+3. Find vendor and device id.
+
+```
+$ lspci -n -s $BDF
+01:00.0 0200: 8086:1528 (rev 01)
+```
+
+4. Find IOMMU group.
+
+```
+$ readlink /sys/bus/pci/devices/$BDF/iommu_group
+../../../../kernel/iommu_groups/16
+```
+
+5. Unbind the device from host driver.
+
+```
+$ echo $BDF | sudo tee /sys/bus/pci/devices/$BDF/driver/unbind
+```
+
+6. Bind the device to vfio-pci.
+
+```
+$ sudo modprobe vfio-pci
+$ echo 8086 1528 | sudo tee /sys/bus/pci/drivers/vfio-pci/new_id
+$ echo $BDF | sudo tee --append /sys/bus/pci/drivers/vfio-pci/bind
+```
+
+7. Check /dev/vfio
+
+```
+$ ls /dev/vfio
+16 vfio
+```
+
+8. Start a Clear Containers container passing the VFIO group on the docker command line.
+
+```
+docker run -it --device=/dev/vfio/16 centos/tools bash
+```
+
+9. Running `lspci` within the container should show the device among the 
+PCI devices. The driver for the device needs to be present within the
+Clear Containers kernel. If the driver is missing,  you can add it to your
+custom container kernel using the [osbuilder](https://github.com/clearcontainers/osbuilder)
+tooling.
+
+# Developers
+
+For information on how to build, develop and test `virtcontainers`, see the
+[developer documentation](documentation/Developers.md).

--- a/vendor/github.com/kata-containers/runtime/virtcontainers/pkg/annotations/annotations.go
+++ b/vendor/github.com/kata-containers/runtime/virtcontainers/pkg/annotations/annotations.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package annotations
+
+const (
+	vcAnnotationsPrefix = "com.github.containers.virtcontainers."
+
+	// KernelPath is a sandbox annotation for passing a per container path pointing at the kernel needed to boot the container VM.
+	KernelPath = vcAnnotationsPrefix + "KernelPath"
+
+	// ImagePath is a sandbox annotation for passing a per container path pointing at the guest image that will run in the container VM.
+	ImagePath = vcAnnotationsPrefix + "ImagePath"
+
+	// InitrdPath is a sandbox annotation for passing a per container path pointing at the guest initrd image that will run in the container VM.
+	InitrdPath = vcAnnotationsPrefix + "InitrdPath"
+
+	// HypervisorPath is a sandbox annotation for passing a per container path pointing at the hypervisor that will run the container VM.
+	HypervisorPath = vcAnnotationsPrefix + "HypervisorPath"
+
+	// FirmwarePath is a sandbox annotation for passing a per container path pointing at the guest firmware that will run the container VM.
+	FirmwarePath = vcAnnotationsPrefix + "FirmwarePath"
+
+	// KernelHash is a sandbox annotation for passing a container kernel image SHA-512 hash value.
+	KernelHash = vcAnnotationsPrefix + "KernelHash"
+
+	// ImageHash is an sandbox annotation for passing a container guest image SHA-512 hash value.
+	ImageHash = vcAnnotationsPrefix + "ImageHash"
+
+	// InitrdHash is an sandbox annotation for passing a container guest initrd SHA-512 hash value.
+	InitrdHash = vcAnnotationsPrefix + "InitrdHash"
+
+	// HypervisorHash is an sandbox annotation for passing a container hypervisor binary SHA-512 hash value.
+	HypervisorHash = vcAnnotationsPrefix + "HypervisorHash"
+
+	// FirmwareHash is an sandbox annotation for passing a container guest firmware SHA-512 hash value.
+	FirmwareHash = vcAnnotationsPrefix + "FirmwareHash"
+
+	// AssetHashType is the hash type used for assets verification
+	AssetHashType = vcAnnotationsPrefix + "AssetHashType"
+
+	// ConfigJSONKey is the annotation key to fetch the OCI configuration.
+	ConfigJSONKey = vcAnnotationsPrefix + "pkg.oci.config"
+
+	// BundlePathKey is the annotation key to fetch the OCI configuration file path.
+	BundlePathKey = vcAnnotationsPrefix + "pkg.oci.bundle_path"
+
+	// ContainerTypeKey is the annotation key to fetch container type.
+	ContainerTypeKey = vcAnnotationsPrefix + "pkg.oci.container_type"
+)
+
+const (
+	// SHA512 is the SHA-512 (64) hash algorithm
+	SHA512 string = "sha512"
+)


### PR DESCRIPTION
OCI annotations can be used to set the sandbox related parameters. In case of VM based runtimes, such as kata, this can be used to dynamically select the `vmdisk` or `initrd` that can be custom built for that container image.

 e.g. With ppc64le ultravisors' upcoming capability to run secure VM which need to be encrypted with the public key of target system, user can specifically intruct the runtime, like kata, to use a specific initrd on the system for the given container image. 

Kata already supports setting those values via OCI annotations, it's just that until now CRI wasn't setting it. The corresponding k8s pod.yaml looks something like this,

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: foobar-kat3
  "annotations": {
    "com.github.containers.virtcontainers.InitrdPath" : "/usr/share/kata-containers/custom-secure-vm.img"
  }
spec:
  runtimeClassName: kataclass
  containers:
  - name: redis
    image: redis:latest 
```
Signed-off-by: Harshal Patil <harshal.patil@in.ibm.com>