### PR TITLE
Add support for passing sandbox annotations to runtime

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -138,6 +138,12 @@ The explanation and default value of each configuration item are as follows:
       # runtime_type is the runtime type to use in containerd e.g. io.containerd.runtime.v1.linux
       runtime_type = "io.containerd.runc.v1"
 
+      # pod_annotations is list of pod annotations passed to both pod sandbox as well as
+      # container OCI annotations. Pod_annotations also support golang supported
+      # regular expression - https://github.com/google/re2/wiki/Syntax.
+      # e.g. ["runc.com.github.containers.runc.*"]
+      pod_annotations = []
+
       # "plugins.cri.containerd.runtimes.runc.options" is options specific to
       # "io.containerd.runc.v1". Its corresponding options type is:
       #   https://github.com/containerd/containerd/blob/v1.2.0-rc.1/runtime/v2/runc/options/oci.pb.go#L39.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,6 +31,9 @@ type Runtime struct {
 	// This only works for runtime type "io.containerd.runtime.v1.linux".
 	// DEPRECATED: use Options instead. Remove when shim v1 is deprecated.
 	Engine string `toml:"runtime_engine" json:"runtimeEngine"`
+	// PodAnnotations is list of pod annotations passed to both pod sandbox as well as
+	// container OCI annotations.
+	PodAnnotations []string `toml:"pod_annotations" json:"PodAnnotations"`
 	// Root is the directory used by containerd for runtime state.
 	// DEPRECATED: use Options instead. Remove when shim v1 is deprecated.
 	// This only works for runtime type "io.containerd.runtime.v1.linux".

--- a/pkg/server/helpers.go
+++ b/pkg/server/helpers.go
@@ -626,3 +626,20 @@ func getTaskStatus(ctx context.Context, task containerd.Task) (containerd.Status
 	}
 	return status, nil
 }
+
+// getPassthroughAnnotations filters requested pod annotations by comparing
+// against permitted annotations for the given runtime.
+func getPassthroughAnnotations(podAnnotations map[string]string,
+	runtimePodAnnotations []string) (passthroughAnnotations map[string]string) {
+	passthroughAnnotations = make(map[string]string)
+
+	for podAnnotationKey, podAnnotationValue := range podAnnotations {
+		for _, r := range runtimePodAnnotations {
+			match, _ := regexp.MatchString(r, podAnnotationKey)
+			if match {
+				passthroughAnnotations[podAnnotationKey] = podAnnotationValue
+			}
+		}
+	}
+	return passthroughAnnotations
+}


### PR DESCRIPTION
OCI annotations can be used to set the sandbox related parameters. In the case of VM based runtimes, such as kata, this can be used to dynamically select the `vmdisk` or `initrd` that can be custom built for that container image.

 e.g. With ppc64le ultravisors' upcoming capability to run secure VM which need to be encrypted with the public key of target system, user can specifically intruct the runtime, like kata, to use a specific initrd on the system for the given container image. 

Kata already supports setting those values via OCI annotations, it's just that until now CRI wasn't setting it. The corresponding k8s pod.yaml looks something like this,

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: foobar-kat3
  "annotations": {
    "com.github.containers.virtcontainers.InitrdPath" : "/usr/share/kata-containers/custom-secure-vm.img",
    "com.github.containers.virtcontainers.InitrdHash" : "3971EBF11A18BCE250A282E6FF78739C9A0F7BCB9BC3552FE9CD8191E4A4DA573BB38983A47B2A86A63BFC4E41D3361D5D6AE1A1480BF3F27F730CC75FBC84DE" 
 }
spec:
  runtimeClassName: kataclass
  containers:
  - name: redis
    image: redis:latest 
```

```toml
[plugins.cri]
     # pod annotations can be passed down the runtime by using OCI annotations
     runtime_option_pod_annotations = [ "com.github.containers.virtcontainers.InitrdPath", 
                                        "com.github.containers.virtcontainers.InitrdHash"]
```

@Random-Liu I have renamed the `passthrough_pod_annotations` to `runtime_option_pod_annotations` as suggested in [this](https://github.com/containerd/cri/pull/1077#issuecomment-470877046) comment. 

@mikebrow configuration option is still under `[plugins.cri]`. I feel that this should not be tied to any specific runtime like kata. Instead, this feature can even be used by `runc` in the future to test experimental features. Also, I haven't added support for wildcard support that you mentioned in [this](https://github.com/containerd/cri/pull/1077#issuecomment-470626651) comment. I am still not sure if we should allow wildcards there for a couple of reasons. It leads to more code complexity (a simple key look up in a hash table vs full featured regex handling) and since pod annotations can contain any arbitary user defined annotations, I feel it would be good if we could precisey select and allow ony selected annotations to pass through. Let me know what do you think.  

@AkihiroSuda ping. 

Signed-off-by: Harshal Patil <harshal.patil@in.ibm.com>