### PR TITLE
Fix /etc/hostname backward compatibility issue for in-place upgrade.

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -483,11 +483,19 @@ func (c *criService) generateContainerMounts(sandboxID string, config *runtime.C
 	var mounts []*runtime.Mount
 	securityContext := config.GetLinux().GetSecurityContext()
 	if !isInCRIMounts(etcHostname, config.GetMounts()) {
-		mounts = append(mounts, &runtime.Mount{
-			ContainerPath: etcHostname,
-			HostPath:      c.getSandboxHostname(sandboxID),
-			Readonly:      securityContext.GetReadonlyRootfs(),
-		})
+		// /etc/hostname is added since 1.1.6, 1.2.4 and 1.3.
+		// For in-place upgrade, the old sandbox doesn't have the hostname file,
+		// do not mount this in that case.
+		// TODO(random-liu): Remove the check and always mount this when
+		// containerd 1.1 and 1.2 are deprecated.
+		hostpath := c.getSandboxHostname(sandboxID)
+		if _, err := c.os.Stat(hostpath); err == nil {
+			mounts = append(mounts, &runtime.Mount{
+				ContainerPath: etcHostname,
+				HostPath:      hostpath,
+				Readonly:      securityContext.GetReadonlyRootfs(),
+			})
+		}
 	}
 
 	if !isInCRIMounts(etcHosts, config.GetMounts()) {


### PR DESCRIPTION
Fixes https://github.com/containerd/cri/issues/1082.

If people do in-place upgrade, old sandboxes may not have the `hostname` file. In that case, we shouldn't try to mount it into containers.

Another option is to create the hostname file for the old sandbox if it doesn't have it. However, that also causes inconsistency, e.g. inside the same pod, old running containers don't have the hostname file, new restarted containers have it.

Neither of them is a perfect solution, skipping mounting is cleaner and keeps consistency inside the same pod, so I implemented that one.

Signed-off-by: Lantao Liu <lantaol@google.com>