### PR TITLE
Add test for filtering container create masks when privileged

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -372,6 +372,7 @@ func (c *criService) generateContainerSpec(id string, sandboxID string, sandboxP
 	// Apply masked paths if specified.
 	// When `MaskedPaths` is not specified, keep runtime default for backward compatibility;
 	// When `MaskedPaths` is specified, but length is zero, clear masked path list.
+	// Note: If the container is privileged, then we clear any masked paths later on in the call to setOCIPrivileged()
 	if securityContext.GetMaskedPaths() != nil {
 		g.Config.Linux.MaskedPaths = nil
 		for _, path := range securityContext.GetMaskedPaths() {
@@ -380,6 +381,7 @@ func (c *criService) generateContainerSpec(id string, sandboxID string, sandboxP
 	}
 
 	// Apply readonly paths if specified.
+	// Note: If the container is privileged, then we clear any readonly paths later on in the call to setOCIPrivileged()
 	if securityContext.GetReadonlyPaths() != nil {
 		g.Config.Linux.ReadonlyPaths = nil
 		for _, path := range securityContext.GetReadonlyPaths() {


### PR DESCRIPTION
Changed PR from add filtering to testing the filtering...

Add test case to confirm we are processing masks correctly when privileged. see https://github.com/kubernetes/kubernetes/issues/75238

Based on the code in dockershim... we should not be masking/adding read only paths for privileged containers (even if requested). Shrug. 

Added note: Since we already do mask, simply adding a test case and comments to verify and explain to future readers.

Signed-off-by: Mike Brown <brownwm@us.ibm.com>