### PR TITLE
Add advertise_stream_server_address option

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -121,6 +121,8 @@ type PluginConfig struct {
 	CniConfig `toml:"cni" json:"cni"`
 	// Registry contains config related to the registry
 	Registry Registry `toml:"registry" json:"registry"`
+	// AdvertiseStreamServerAddress is the ip address streaming server is advertising on.
+	AdvertiseStreamServerAddress string `toml:"advertise_stream_server_address" json:"advertiseStreamServerAddress"`
 	// StreamServerAddress is the ip address streaming server is listening on.
 	StreamServerAddress string `toml:"stream_server_address" json:"streamServerAddress"`
 	// StreamServerPort is the port streaming server is listening on.
@@ -200,11 +202,12 @@ func DefaultConfig() PluginConfig {
 			},
 			NoPivot: false,
 		},
-		StreamServerAddress: "127.0.0.1",
-		StreamServerPort:    "0",
-		StreamIdleTimeout:   streaming.DefaultConfig.StreamIdleTimeout.String(), // 4 hour
-		EnableSelinux:       false,
-		EnableTLSStreaming:  false,
+		AdvertiseStreamServerAddress: "127.0.0.1",
+		StreamServerAddress:          "127.0.0.1",
+		StreamServerPort:             "0",
+		StreamIdleTimeout:            streaming.DefaultConfig.StreamIdleTimeout.String(), // 4 hour
+		EnableSelinux:                false,
+		EnableTLSStreaming:           false,
 		X509KeyPairStreaming: X509KeyPairStreaming{
 			TLSKeyFile:  "",
 			TLSCertFile: "",

--- a/pkg/server/container_exec.go
+++ b/pkg/server/container_exec.go
@@ -43,12 +43,12 @@ func (c *criService) Exec(ctx context.Context, r *runtime.ExecRequest) (*runtime
 	}
 
 	if c.config.StreamServerAddress != c.config.AdvertiseStreamServerAddress {
-		if !c.isAdvertiseStreamServerRunning() {
+		if !isAdvertiseStreamServerRunning() {
 			// Use channel to make sure the first exec will be successful
 			advertiseStreamServerCh := make(chan struct{})
 			go func() {
-				c.setAdvertiseStreamServerRunning(true)
-				defer c.setAdvertiseStreamServerRunning(false)
+				setAdvertiseStreamServerRunning(true)
+				defer setAdvertiseStreamServerRunning(false)
 				close(advertiseStreamServerCh)
 				if err := c.advertiseStreamServer.Start(true); err != nil && err != http.ErrServerClosed {
 					logrus.WithError(err).Error("Failed to start advertise streaming server")
@@ -63,14 +63,14 @@ func (c *criService) Exec(ctx context.Context, r *runtime.ExecRequest) (*runtime
 	return c.streamServer.GetExec(r)
 }
 
-func (c *criService) isAdvertiseStreamServerRunning() bool {
+func isAdvertiseStreamServerRunning() bool {
 	mu.Lock()
 	defer mu.Unlock()
 
 	return advertiseStreamServerRunning
 }
 
-func (c *criService) setAdvertiseStreamServerRunning(v bool) {
+func setAdvertiseStreamServerRunning(v bool) {
 	mu.Lock()
 	defer mu.Unlock()
 

--- a/pkg/server/container_exec.go
+++ b/pkg/server/container_exec.go
@@ -32,5 +32,5 @@ func (c *criService) Exec(ctx context.Context, r *runtime.ExecRequest) (*runtime
 	if state != runtime.ContainerState_CONTAINER_RUNNING {
 		return nil, errors.Errorf("container is in %s state", criContainerStateToString(state))
 	}
-	return c.streamServer.GetExec(r)
+	return c.advertiseStreamServer.GetExec(r)
 }

--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -96,6 +96,8 @@ type criService struct {
 	client *containerd.Client
 	// streamServer is the streaming server serves container streaming request.
 	streamServer streaming.Server
+	// advertiseStreamServer is the advertise streaming server serves container streaming request.
+	advertiseStreamServer streaming.Server
 	// eventMonitor is the monitor monitors containerd events.
 	eventMonitor *eventMonitor
 	// initialized indicates whether the server is initialized. All GRPC services
@@ -162,6 +164,11 @@ func NewCRIService(config criconfig.Config, client *containerd.Client) (CRIServi
 	c.streamServer, err = newStreamServer(c, config.StreamServerAddress, config.StreamServerPort, config.StreamIdleTimeout)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create stream server")
+	}
+
+	c.advertiseStreamServer, err = newStreamServer(c, config.AdvertiseStreamServerAddress, config.StreamServerPort, config.StreamIdleTimeout)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create advertise stream server")
 	}
 
 	c.eventMonitor = newEventMonitor(c)

--- a/pkg/server/service.go
+++ b/pkg/server/service.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/plugin"
-	cni "github.com/containerd/go-cni"
+	"github.com/containerd/go-cni"
 	runcapparmor "github.com/opencontainers/runc/libcontainer/apparmor"
 	runcseccomp "github.com/opencontainers/runc/libcontainer/seccomp"
 	runcsystem "github.com/opencontainers/runc/libcontainer/system"


### PR DESCRIPTION
Fixes #1011
We try to start `advertiseStreamServer` right before `GetExec` because it is possible that advertising address can appear later than containerd starts.