### PR TITLE
Cleanup pod annotation test and only support wildcard

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -138,10 +138,14 @@ The explanation and default value of each configuration item are as follows:
       # runtime_type is the runtime type to use in containerd e.g. io.containerd.runtime.v1.linux
       runtime_type = "io.containerd.runc.v1"
 
-      # pod_annotations is list of pod annotations passed to both pod sandbox as well as
-      # container OCI annotations. Pod_annotations also support golang supported
-      # regular expression - https://github.com/google/re2/wiki/Syntax.
-      # e.g. ["runc.com.github.containers.runc.*"]
+      # pod_annotations is a list of pod annotations passed to both pod
+      # sandbox as well as container OCI annotations. Pod_annotations also
+      # supports golang path match pattern - https://golang.org/pkg/path/#Match.
+      # e.g. ["runc.com.*"], ["*.runc.com"], ["runc.com/*"].
+      #
+      # For the naming convention of annotation keys, please reference:
+      # * Kubernetes: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
+      # * OCI: https://github.com/opencontainers/image-spec/blob/master/annotations.md
       pod_annotations = []
 
       # "plugins.cri.containerd.runtimes.runc.options" is options specific to

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,7 +31,7 @@ type Runtime struct {
 	// This only works for runtime type "io.containerd.runtime.v1.linux".
 	// DEPRECATED: use Options instead. Remove when shim v1 is deprecated.
 	Engine string `toml:"runtime_engine" json:"runtimeEngine"`
-	// PodAnnotations is list of pod annotations passed to both pod sandbox as well as
+	// PodAnnotations is a list of pod annotations passed to both pod sandbox as well as
 	// container OCI annotations.
 	PodAnnotations []string `toml:"pod_annotations" json:"PodAnnotations"`
 	// Root is the directory used by containerd for runtime state.

--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -169,7 +169,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get sandbox runtime")
 	}
-	logrus.Debugf("Use OCI %+v for sandbox %q and container %q", ociRuntime, sandboxID, id)
+	logrus.Debugf("Use OCI runtime %+v for sandbox %q and container %q", ociRuntime, sandboxID, id)
 
 	spec, err := c.generateContainerSpec(id, sandboxID, sandboxPid, config, sandboxConfig,
 		&image.ImageSpec.Config, append(mounts, volumeMounts...), ociRuntime.PodAnnotations)

--- a/pkg/server/helpers.go
+++ b/pkg/server/helpers.go
@@ -634,9 +634,11 @@ func getPassthroughAnnotations(podAnnotations map[string]string,
 	passthroughAnnotations = make(map[string]string)
 
 	for podAnnotationKey, podAnnotationValue := range podAnnotations {
-		for _, r := range runtimePodAnnotations {
-			match, _ := regexp.MatchString(r, podAnnotationKey)
-			if match {
+		for _, pattern := range runtimePodAnnotations {
+			// Use path.Match instead of filepath.Match here.
+			// filepath.Match treated `\\` as path separator
+			// on windows, which is not what we want.
+			if ok, _ := path.Match(pattern, podAnnotationKey); ok {
 				passthroughAnnotations[podAnnotationKey] = podAnnotationValue
 			}
 		}


### PR DESCRIPTION
This is a follow up of #1084.

This PR:
1) Cleanup passthrough pod annotation test;
2) Change back to only support wildcard, reason https://github.com/containerd/cri/pull/1084#discussion_r268091851.

/cc @harche I think your original solution is better, because:
1) Regular expression is not convenient for domain name matching, especially for matching `.`.
2) A generic wildcard support requires dynamic planning, which makes the code complicated.
Let's just do tailing wildcard support.

Signed-off-by: Lantao Liu <lantaol@google.com>