### PR TITLE
Support docker 18.09 in the test script.

### DIFF
--- a/cluster/gce/cloud-init/master.yaml
+++ b/cluster/gce/cloud-init/master.yaml
@@ -174,6 +174,8 @@ write_files:
       WantedBy=multi-user.target
 
 runcmd:
+  # Stop the existing containerd service if there is one. (for Docker 18.09+)
+  - systemctl is-active containerd && systemctl stop containerd
   - systemctl daemon-reload
   - systemctl enable containerd-installation.service
   - systemctl enable containerd.service
@@ -186,3 +188,5 @@ runcmd:
   - systemctl enable kube-logrotate.service
   - systemctl enable kubernetes.target
   - systemctl start kubernetes.target
+  # Start docker after containerd is running. (for Docker 18.09+)
+  - systemctl is-enabled docker && (systemctl is-active docker || systemctl start docker)

--- a/cluster/gce/cloud-init/node.yaml
+++ b/cluster/gce/cloud-init/node.yaml
@@ -174,6 +174,8 @@ write_files:
       WantedBy=multi-user.target
 
 runcmd:
+  # Stop the existing containerd service if there is one. (for Docker 18.09+)
+  - systemctl is-active containerd && systemctl stop containerd
   - systemctl daemon-reload
   - systemctl enable containerd-installation.service
   - systemctl enable containerd.service
@@ -186,3 +188,5 @@ runcmd:
   - systemctl enable kube-logrotate.service
   - systemctl enable kubernetes.target
   - systemctl start kubernetes.target
+  # Start docker after containerd is running. (for Docker 18.09+)
+  - systemctl is-enabled docker && (systemctl is-active docker || systemctl start docker)

--- a/test/e2e_node/init.yaml
+++ b/test/e2e_node/init.yaml
@@ -61,8 +61,12 @@ write_files:
       WantedBy=multi-user.target
 
 runcmd:
+  # Stop the existing containerd service if there is one. (for Docker 18.09+)
+  - systemctl is-active containerd && systemctl stop containerd
   - systemctl daemon-reload
   - systemctl enable containerd-installation.service
   - systemctl enable containerd.service
   - systemctl enable containerd.target
   - systemctl start containerd.target
+  # Start docker after containerd is running. (for Docker 18.09+)
+  - systemctl is-enabled docker && (systemctl is-active docker || systemctl start docker)


### PR DESCRIPTION
We also tested containerd 1.2 with Docker 18.09, so this change is needed in 1.2 as well.

See test failure caused by this: https://k8s-testgrid.appspot.com/sig-node-containerd#containerd-e2e-shielded-gci-1.2

Signed-off-by: Lantao Liu <lantaol@google.com>