### PR TITLE
Uts namespace and fix array

### DIFF
--- a/pkg/containerd/opts/spec_test.go
+++ b/pkg/containerd/opts/spec_test.go
@@ -28,7 +28,7 @@ import (
 func TestMergeGids(t *testing.T) {
 	gids1 := []uint32{3, 2, 1}
 	gids2 := []uint32{2, 3, 4}
-	assert.Equal(t, []uint32{3, 2, 1, 4}, mergeGids(gids1, gids2))
+	assert.Equal(t, []uint32{1, 2, 3, 4}, mergeGids(gids1, gids2))
 }
 
 func TestOrderedMounts(t *testing.T) {

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -385,6 +385,7 @@ func (c *criService) generateSandboxContainerSpec(id string, config *runtime.Pod
 	)
 	if nsOptions.GetNetwork() == runtime.NamespaceMode_NODE {
 		specOpts = append(specOpts, customopts.WithoutNamespace(runtimespec.NetworkNamespace))
+		specOpts = append(specOpts, customopts.WithoutNamespace(runtimespec.UTSNamespace))
 	} else {
 		//TODO(Abhi): May be move this to containerd spec opts (WithLinuxSpaceOption)
 		specOpts = append(specOpts, oci.WithLinuxNamespace(

--- a/pkg/server/sandbox_run_test.go
+++ b/pkg/server/sandbox_run_test.go
@@ -102,6 +102,9 @@ func TestGenerateSandboxContainerSpec(t *testing.T) {
 					Path: nsPath,
 				})
 				assert.Contains(t, spec.Linux.Namespaces, runtimespec.LinuxNamespace{
+					Type: runtimespec.UTSNamespace,
+				})
+				assert.Contains(t, spec.Linux.Namespaces, runtimespec.LinuxNamespace{
 					Type: runtimespec.PIDNamespace,
 				})
 				assert.Contains(t, spec.Linux.Namespaces, runtimespec.LinuxNamespace{
@@ -124,6 +127,9 @@ func TestGenerateSandboxContainerSpec(t *testing.T) {
 				require.NotNil(t, spec.Linux)
 				assert.NotContains(t, spec.Linux.Namespaces, runtimespec.LinuxNamespace{
 					Type: runtimespec.NetworkNamespace,
+				})
+				assert.NotContains(t, spec.Linux.Namespaces, runtimespec.LinuxNamespace{
+					Type: runtimespec.UTSNamespace,
 				})
 				assert.NotContains(t, spec.Linux.Namespaces, runtimespec.LinuxNamespace{
 					Type: runtimespec.PIDNamespace,


### PR DESCRIPTION
This PR:
1) Remove UTS namespace for hostnetwork. This is to keep the behavior consistent with dockershim https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/dockershim/security_context.go#L204.
2) Stop assuming arrays don't contain duplicated elements.


1 is important, and we should cherry-pick to supported branches.
2 is not that critical.