### PR TITLE
Add nil check in defer func for RunPodSandbox

### DIFF
--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -118,8 +118,10 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		sandbox.NetNSPath = sandbox.NetNS.GetPath()
 		defer func() {
 			if retErr != nil {
-				if err := sandbox.NetNS.Remove(); err != nil {
-					logrus.WithError(err).Errorf("Failed to remove network namespace %s for sandbox %q", sandbox.NetNSPath, id)
+				if sandbox.NetNS != nil {
+					if err := sandbox.NetNS.Remove(); err != nil {
+						logrus.WithError(err).Errorf("Failed to remove network namespace %s for sandbox %q", sandbox.NetNSPath, id)
+					}
 				}
 				sandbox.NetNSPath = ""
 			}


### PR DESCRIPTION
If NewNetNS return a error, sandbox.NetNS is nil, this will lead to panic.
```
               sandbox.NetNS, err = sandboxstore.NewNetNS()
		if err != nil {
			return nil, errors.Wrapf(err, "failed to create network namespace for sandbox %q", id)
		}
		sandbox.NetNSPath = sandbox.NetNS.GetPath()
		defer func() {
			if err := sandbox.NetNS.Remove(); err != nil {
                 ...
```

Signed-off-by: Shukui Yang <keloyangsk@gmail.com>