### PR TITLE
[release/1.2 backport] bump selinux v1.2.1

### DIFF
--- a/pkg/server/helpers.go
+++ b/pkg/server/helpers.go
@@ -37,7 +37,6 @@ import (
 	imagedigest "github.com/opencontainers/go-digest"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-tools/generate"
-	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -355,7 +354,12 @@ func initSelinuxOpts(selinuxOpt *runtime.SELinuxOption) (string, string, error) 
 		selinuxOpt.GetRole(),
 		selinuxOpt.GetType(),
 		selinuxOpt.GetLevel())
-	return label.InitLabels(selinux.DupSecOpt(labelOpts))
+
+	options, err := label.DupSecOpt(labelOpts)
+	if err != nil {
+		return "", "", err
+	}
+	return label.InitLabels(options)
 }
 
 func checkSelinuxLevel(level string) (bool, error) {

--- a/vendor.conf
+++ b/vendor.conf
@@ -42,7 +42,7 @@ github.com/opencontainers/image-spec v1.0.1
 github.com/opencontainers/runc 2b18fe1d885ee5083ef9f0838fee39b62d653e30
 github.com/opencontainers/runtime-spec eba862dc2470385a233c7507392675cbeadf7353
 github.com/opencontainers/runtime-tools v0.6.0
-github.com/opencontainers/selinux v1.2
+github.com/opencontainers/selinux v1.2.1
 github.com/pkg/errors v0.8.0
 github.com/pmezard/go-difflib v1.0.0
 github.com/prometheus/client_golang f4fb1b73fb099f396a7f0036bf86aa8def4ed823

--- a/vendor.conf
+++ b/vendor.conf
@@ -42,7 +42,7 @@ github.com/opencontainers/image-spec v1.0.1
 github.com/opencontainers/runc 2b18fe1d885ee5083ef9f0838fee39b62d653e30
 github.com/opencontainers/runtime-spec eba862dc2470385a233c7507392675cbeadf7353
 github.com/opencontainers/runtime-tools v0.6.0
-github.com/opencontainers/selinux b6fa367ed7f534f9ba25391cc2d467085dbb445a
+github.com/opencontainers/selinux v1.2
 github.com/pkg/errors v0.8.0
 github.com/pmezard/go-difflib v1.0.0
 github.com/prometheus/client_golang f4fb1b73fb099f396a7f0036bf86aa8def4ed823

--- a/vendor/github.com/opencontainers/selinux/README.md
+++ b/vendor/github.com/opencontainers/selinux/README.md
@@ -5,3 +5,14 @@
 Common SELinux package used across the container ecosystem.
 
 Please see the [godoc](https://godoc.org/github.com/opencontainers/selinux) for more information.
+
+## Code of Conduct
+
+Participation in the OpenContainers community is governed by [OpenContainer's Code of Conduct][code-of-conduct].
+
+## Security
+
+If you find an issue, please follow the [security][security] protocol to report it.
+
+[security]: https://github.com/opencontainers/org/blob/master/security
+[code-of-conduct]: https://github.com/opencontainers/org/blob/master/CODE_OF_CONDUCT.md

--- a/vendor/github.com/opencontainers/selinux/go-selinux/label/label.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/label/label.go
@@ -9,7 +9,7 @@ func InitLabels(options []string) (string, string, error) {
 	return "", "", nil
 }
 
-func GetROMountLabel() string {
+func ROMountLabel() string {
 	return ""
 }
 
@@ -25,7 +25,27 @@ func SetProcessLabel(processLabel string) error {
 	return nil
 }
 
-func GetFileLabel(path string) (string, error) {
+func ProcessLabel() (string, error) {
+	return "", nil
+}
+
+func SetSocketLabel(processLabel string) error {
+	return nil
+}
+
+func SocketLabel() (string, error) {
+	return "", nil
+}
+
+func SetKeyLabel(processLabel string) error {
+	return nil
+}
+
+func KeyLabel() (string, error) {
+	return "", nil
+}
+
+func FileLabel(path string) (string, error) {
 	return "", nil
 }
 
@@ -41,11 +61,16 @@ func Relabel(path string, fileLabel string, shared bool) error {
 	return nil
 }
 
-func GetPidLabel(pid int) (string, error) {
+func PidLabel(pid int) (string, error) {
 	return "", nil
 }
 
 func Init() {
+}
+
+// ClearLabels clears all reserved labels
+func ClearLabels() {
+	return
 }
 
 func ReserveLabel(label string) error {
@@ -58,8 +83,8 @@ func ReleaseLabel(label string) error {
 
 // DupSecOpt takes a process label and returns security options that
 // can be used to set duplicate labels on future container processes
-func DupSecOpt(src string) []string {
-	return nil
+func DupSecOpt(src string) ([]string, error) {
+	return nil, nil
 }
 
 // DisableSecOpt returns a security opt that can disable labeling

--- a/vendor/github.com/opencontainers/selinux/go-selinux/label/label_selinux.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/label/label_selinux.go
@@ -4,6 +4,8 @@ package label
 
 import (
 	"fmt"
+	"os"
+	"os/user"
 	"strings"
 
 	"github.com/opencontainers/selinux/go-selinux"
@@ -24,17 +26,29 @@ var ErrIncompatibleLabel = fmt.Errorf("Bad SELinux option z and Z can not be use
 // the container.  A list of options can be passed into this function to alter
 // the labels.  The labels returned will include a random MCS String, that is
 // guaranteed to be unique.
-func InitLabels(options []string) (string, string, error) {
+func InitLabels(options []string) (plabel string, mlabel string, Err error) {
 	if !selinux.GetEnabled() {
 		return "", "", nil
 	}
 	processLabel, mountLabel := selinux.ContainerLabels()
 	if processLabel != "" {
-		pcon := selinux.NewContext(processLabel)
-		mcon := selinux.NewContext(mountLabel)
+		defer func() {
+			if Err != nil {
+				ReleaseLabel(mountLabel)
+			}
+		}()
+		pcon, err := selinux.NewContext(processLabel)
+		if err != nil {
+			return "", "", err
+		}
+
+		mcon, err := selinux.NewContext(mountLabel)
+		if err != nil {
+			return "", "", err
+		}
 		for _, opt := range options {
 			if opt == "disable" {
-				return "", "", nil
+				return "", mountLabel, nil
 			}
 			if i := strings.Index(opt, ":"); i == -1 {
 				return "", "", fmt.Errorf("Bad label option %q, valid options 'disable' or \n'user, role, level, type' followed by ':' and a value", opt)
@@ -90,6 +104,28 @@ func SetProcessLabel(processLabel string) error {
 	return selinux.SetExecLabel(processLabel)
 }
 
+// SetSocketLabel takes a process label and tells the kernel to assign the
+// label to the next socket that gets created
+func SetSocketLabel(processLabel string) error {
+	return selinux.SetSocketLabel(processLabel)
+}
+
+// SocketLabel retrieves the current default socket label setting
+func SocketLabel() (string, error) {
+	return selinux.SocketLabel()
+}
+
+// SetKeyLabel takes a process label and tells the kernel to assign the
+// label to the next kernel keyring that gets created
+func SetKeyLabel(processLabel string) error {
+	return selinux.SetKeyLabel(processLabel)
+}
+
+// KeyLabel retrieves the current default kernel keyring label setting
+func KeyLabel() (string, error) {
+	return selinux.KeyLabel()
+}
+
 // ProcessLabel returns the process label that the kernel will assign
 // to the next program executed by the current process.  If "" is returned
 // this indicates that the default labeling will happen for the process.
@@ -97,7 +133,7 @@ func ProcessLabel() (string, error) {
 	return selinux.ExecLabel()
 }
 
-// GetFileLabel returns the label for specified path
+// FileLabel returns the label for specified path
 func FileLabel(path string) (string, error) {
 	return selinux.FileLabel(path)
 }
@@ -130,13 +166,56 @@ func Relabel(path string, fileLabel string, shared bool) error {
 		return nil
 	}
 
-	exclude_paths := map[string]bool{"/": true, "/usr": true, "/etc": true, "/tmp": true, "/home": true, "/run": true, "/var": true, "/root": true}
+	exclude_paths := map[string]bool{
+		"/":           true,
+		"/bin":        true,
+		"/boot":       true,
+		"/dev":        true,
+		"/etc":        true,
+		"/etc/passwd": true,
+		"/etc/pki":    true,
+		"/etc/shadow": true,
+		"/home":       true,
+		"/lib":        true,
+		"/lib64":      true,
+		"/media":      true,
+		"/opt":        true,
+		"/proc":       true,
+		"/root":       true,
+		"/run":        true,
+		"/sbin":       true,
+		"/srv":        true,
+		"/sys":        true,
+		"/tmp":        true,
+		"/usr":        true,
+		"/var":        true,
+		"/var/lib":    true,
+		"/var/log":    true,
+	}
+
+	if home := os.Getenv("HOME"); home != "" {
+		exclude_paths[home] = true
+	}
+
+	if sudoUser := os.Getenv("SUDO_USER"); sudoUser != "" {
+		if usr, err := user.Lookup(sudoUser); err == nil {
+			exclude_paths[usr.HomeDir] = true
+		}
+	}
+
+	if path != "/" {
+		path = strings.TrimSuffix(path, "/")
+	}
 	if exclude_paths[path] {
 		return fmt.Errorf("SELinux relabeling of %s is not allowed", path)
 	}
 
 	if shared {
-		c := selinux.NewContext(fileLabel)
+		c, err := selinux.NewContext(fileLabel)
+		if err != nil {
+			return err
+		}
+
 		c["level"] = "s0"
 		fileLabel = c.Get()
 	}
@@ -154,6 +233,11 @@ func PidLabel(pid int) (string, error) {
 // Init initialises the labeling system
 func Init() {
 	selinux.GetEnabled()
+}
+
+// ClearLabels will clear all reserved labels
+func ClearLabels() {
+	selinux.ClearLabels()
 }
 
 // ReserveLabel will record the fact that the MCS label has already been used.
@@ -174,7 +258,7 @@ func ReleaseLabel(label string) error {
 
 // DupSecOpt takes a process label and returns security options that
 // can be used to set duplicate labels on future container processes
-func DupSecOpt(src string) []string {
+func DupSecOpt(src string) ([]string, error) {
 	return selinux.DupSecOpt(src)
 }
 

--- a/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go
@@ -333,6 +333,11 @@ func writeCon(fpath string, val string) error {
 	if fpath == "" {
 		return ErrEmptyPath
 	}
+	if val == "" {
+		if !GetEnabled() {
+			return nil
+		}
+	}
 
 	out, err := os.OpenFile(fpath, os.O_WRONLY, 0)
 	if err != nil {

--- a/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go
@@ -52,6 +52,8 @@ var (
 	ErrMCSAlreadyExists = errors.New("MCS label already exists")
 	// ErrEmptyPath is returned when an empty path has been specified.
 	ErrEmptyPath = errors.New("empty path")
+	// InvalidLabel is returned when an invalid label is specified.
+	InvalidLabel = errors.New("Invalid Label")
 
 	assignRegex = regexp.MustCompile(`^([^=]+)=(.*)$`)
 	roFileLabel string
@@ -385,6 +387,28 @@ func SetExecLabel(label string) error {
 	return writeCon(fmt.Sprintf("/proc/self/task/%d/attr/exec", syscall.Gettid()), label)
 }
 
+// SetSocketLabel takes a process label and tells the kernel to assign the
+// label to the next socket that gets created
+func SetSocketLabel(label string) error {
+	return writeCon(fmt.Sprintf("/proc/self/task/%d/attr/sockcreate", syscall.Gettid()), label)
+}
+
+// SocketLabel retrieves the current socket label setting
+func SocketLabel() (string, error) {
+	return readCon(fmt.Sprintf("/proc/self/task/%d/attr/sockcreate", syscall.Gettid()))
+}
+
+// SetKeyLabel takes a process label and tells the kernel to assign the
+// label to the next kernel keyring that gets created
+func SetKeyLabel(label string) error {
+	return writeCon("/proc/self/attr/keycreate", label)
+}
+
+// KeyLabel retrieves the current kernel keyring label setting
+func KeyLabel() (string, error) {
+	return readCon("/proc/self/attr/keycreate")
+}
+
 // Get returns the Context as a string
 func (c Context) Get() string {
 	if c["level"] != "" {
@@ -394,11 +418,14 @@ func (c Context) Get() string {
 }
 
 // NewContext creates a new Context struct from the specified label
-func NewContext(label string) Context {
+func NewContext(label string) (Context, error) {
 	c := make(Context)
 
 	if len(label) != 0 {
 		con := strings.SplitN(label, ":", 4)
+		if len(con) < 3 {
+			return c, InvalidLabel
+		}
 		c["user"] = con[0]
 		c["role"] = con[1]
 		c["type"] = con[2]
@@ -406,7 +433,14 @@ func NewContext(label string) Context {
 			c["level"] = con[3]
 		}
 	}
-	return c
+	return c, nil
+}
+
+// ClearLabels clears all reserved labels
+func ClearLabels() {
+	state.Lock()
+	state.mcsList = make(map[string]bool)
+	state.Unlock()
 }
 
 // ReserveLabel reserves the MLS/MCS level component of the specified label
@@ -612,12 +646,12 @@ func ContainerLabels() (processLabel string, fileLabel string) {
 		roFileLabel = fileLabel
 	}
 exit:
-	scon := NewContext(processLabel)
+	scon, _ := NewContext(processLabel)
 	if scon["level"] != "" {
 		mcs := uniqMcs(1024)
 		scon["level"] = mcs
 		processLabel = scon.Get()
-		scon = NewContext(fileLabel)
+		scon, _ = NewContext(fileLabel)
 		scon["level"] = mcs
 		fileLabel = scon.Get()
 	}
@@ -643,8 +677,14 @@ func CopyLevel(src, dest string) (string, error) {
 	if err := SecurityCheckContext(dest); err != nil {
 		return "", err
 	}
-	scon := NewContext(src)
-	tcon := NewContext(dest)
+	scon, err := NewContext(src)
+	if err != nil {
+		return "", err
+	}
+	tcon, err := NewContext(dest)
+	if err != nil {
+		return "", err
+	}
 	mcsDelete(tcon["level"])
 	mcsAdd(scon["level"])
 	tcon["level"] = scon["level"]
@@ -680,7 +720,11 @@ func Chcon(fpath string, label string, recurse bool) error {
 		return err
 	}
 	callback := func(p string, info os.FileInfo, err error) error {
-		return SetFileLabel(p, label)
+		e := SetFileLabel(p, label)
+		if os.IsNotExist(e) {
+			return nil
+		}
+		return e
 	}
 
 	if recurse {
@@ -692,15 +736,18 @@ func Chcon(fpath string, label string, recurse bool) error {
 
 // DupSecOpt takes an SELinux process label and returns security options that
 // can be used to set the SELinux Type and Level for future container processes.
-func DupSecOpt(src string) []string {
+func DupSecOpt(src string) ([]string, error) {
 	if src == "" {
-		return nil
+		return nil, nil
 	}
-	con := NewContext(src)
+	con, err := NewContext(src)
+	if err != nil {
+		return nil, err
+	}
 	if con["user"] == "" ||
 		con["role"] == "" ||
 		con["type"] == "" {
-		return nil
+		return nil, nil
 	}
 	dup := []string{"user:" + con["user"],
 		"role:" + con["role"],
@@ -711,7 +758,7 @@ func DupSecOpt(src string) []string {
 		dup = append(dup, "level:"+con["level"])
 	}
 
-	return dup
+	return dup, nil
 }
 
 // DisableSecOpt returns a security opt that can be used to disable SELinux

--- a/vendor/github.com/opencontainers/selinux/go-selinux/selinux_stub.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/selinux_stub.go
@@ -96,15 +96,44 @@ func SetExecLabel(label string) error {
 	return nil
 }
 
+/*
+SetSocketLabel sets the SELinux label that the kernel will use for any programs
+that are executed by the current process thread, or an error.
+*/
+func SetSocketLabel(label string) error {
+	return nil
+}
+
+// SocketLabel retrieves the current socket label setting
+func SocketLabel() (string, error) {
+	return "", nil
+}
+
+// SetKeyLabel takes a process label and tells the kernel to assign the
+// label to the next kernel keyring that gets created
+func SetKeyLabel(label string) error {
+	return nil
+}
+
+// KeyLabel retrieves the current kernel keyring label setting
+func KeyLabel() (string, error) {
+	return "", nil
+}
+
 // Get returns the Context as a string
 func (c Context) Get() string {
 	return ""
 }
 
 // NewContext creates a new Context struct from the specified label
-func NewContext(label string) Context {
+func NewContext(label string) (Context, error) {
 	c := make(Context)
-	return c
+	return c, nil
+}
+
+// ClearLabels clears all reserved MLS/MCS levels
+func ClearLabels() {
+	return
 }
 
 // ReserveLabel reserves the MLS/MCS level component of the specified label
@@ -177,8 +206,8 @@ func Chcon(fpath string, label string, recurse bool) error {
 
 // DupSecOpt takes an SELinux process label and returns security options that
 // can be used to set the SELinux Type and Level for future container processes.
-func DupSecOpt(src string) []string {
-	return nil
+func DupSecOpt(src string) ([]string, error) {
+	return nil, nil
 }
 
 // DisableSecOpt returns a security opt that can be used to disable SELinux


### PR DESCRIPTION
backports of https://github.com/containerd/cri/pull/1101 and https://github.com/containerd/cri/pull/1113 for the 1.2 branch