### PR TITLE
Enable runc.v2 as the default runtime in test.

### DIFF
--- a/cluster/gce/configure.sh
+++ b/cluster/gce/configure.sh
@@ -164,10 +164,6 @@ disabled_plugins = ["restart"]
 [debug]
   level = "${log_level}"
 
-[plugins.linux]
-  shim = "${CONTAINERD_HOME}/usr/local/bin/containerd-shim"
-  runtime = "${CONTAINERD_HOME}/usr/local/sbin/runc"
-
 [plugins.cri]
   stream_server_address = "127.0.0.1"
   stream_server_port = "0"
@@ -178,6 +174,10 @@ disabled_plugins = ["restart"]
   conf_template = "${cni_template_path}"
 [plugins.cri.registry.mirrors."docker.io"]
   endpoint = ["https://mirror.gcr.io","https://registry-1.docker.io"]
+[plugins.cri.containerd.default_runtime]
+  runtime_type = "io.containerd.runc.v2"
+[plugins.cri.containerd.default_runtime.options]
+  BinaryName = "${CONTAINERD_HOME}/usr/local/sbin/runc"
 EOF
 chmod 644 "${config_path}"
 

--- a/pkg/server/helpers.go
+++ b/pkg/server/helpers.go
@@ -122,8 +122,10 @@ const (
 const (
 	// linuxRuntime is the legacy linux runtime for shim v1.
 	linuxRuntime = "io.containerd.runtime.v1.linux"
-	// runcRuntime is the runc runtime for shim v2.
-	runcRuntime = "io.containerd.runc.v1"
+	// runcRuntimeV1 is the runc v1 runtime for shim v2.
+	runcRuntimeV1 = "io.containerd.runc.v1"
+	// runcRuntimeV2 is the runc v2 runtime for shim v2.
+	runcRuntimeV2 = "io.containerd.runc.v2"
 )
 
 // makeSandboxName generates sandbox name from sandbox metadata. The name
@@ -427,7 +429,9 @@ func generateRuntimeOptions(r criconfig.Runtime, c criconfig.Config) (interface{
 // getRuntimeOptionsType gets empty runtime options by the runtime type name.
 func getRuntimeOptionsType(t string) interface{} {
 	switch t {
-	case runcRuntime:
+	case runcRuntimeV1:
+		fallthrough
+	case runcRuntimeV2:
 		return &runcoptions.Options{}
 	case linuxRuntime:
 		return &runctypes.RuncOptions{}


### PR DESCRIPTION
For https://github.com/containerd/cri/issues/1075.
/cc @crosbymichael @yujuhong 

Use per-pod shim in the node e2e and cluster e2e test.

We should consider switching the default runtime in `pkg/config/config.go`, once the test result looks good.

Signed-off-by: Lantao Liu <lantaol@google.com>