### PR TITLE
Support comment in vendor.

### DIFF
--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -81,7 +81,7 @@ from-vendor() {
                   BEGIN { rc=1 }                        # Assume we did not find what we were looking for.
                   // {
                      if ($1 == REPO) {
-                        if ($3 != "") { gsub(/http.*\/\//, "", $3); REPO = $3 };    # Override repo.
+                        if ($3 != "" && $3 !~ /#.*/ ) { gsub(/http.*\/\//, "", $3); REPO = $3 };    # Override repo.
                         printf("%s_VERSION=%s; %s_REPO=%s\n", WHAT, $2, WHAT, REPO);
                         rc=0;                           # Note success for use in END block.
                         exit                            # No point looking further.


### PR DESCRIPTION
The containerd build is broken, because we added a vendor comment for runc in https://github.com/containerd/containerd/pull/3184 and https://github.com/containerd/containerd/pull/3183.
* https://k8s-testgrid.appspot.com/sig-node-containerd#containerd-build-1.1
* https://k8s-testgrid.appspot.com/sig-node-containerd#containerd-build-1.2

This should not happen.
Signed-off-by: Lantao Liu <lantaol@google.com>