### PR TITLE
Use golang 1.11.6 for now.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ git:
 
 language: go
 go:
-  - 1.11.x
+  # FIXME: change back to 1.11.x
+  - 1.11.6
   - tip
 
 matrix:


### PR DESCRIPTION
1.11.7 doesn't work on travis right now:
```
/home/travis/.gimme/versions/go1.11.7.linux.amd64/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/bin/ld: /tmp/go-link-869411160/000016.o: unrecognized relocation (0x2a) in section `.text'
/usr/bin/ld: final link failed: Bad value
```

See:
* https://travis-ci.org/containerd/cri/jobs/517237868
* https://travis-ci.org/containerd/cri/builds/516837021
* https://travis-ci.org/containerd/cri/builds/516560894


Signed-off-by: Lantao Liu <lantaol@google.com>