### PR TITLE
Use runc.v1 for now for debugging.

### DIFF
--- a/cluster/gce/configure.sh
+++ b/cluster/gce/configure.sh
@@ -175,7 +175,7 @@ disabled_plugins = ["restart"]
 [plugins.cri.registry.mirrors."docker.io"]
   endpoint = ["https://mirror.gcr.io","https://registry-1.docker.io"]
 [plugins.cri.containerd.default_runtime]
-  runtime_type = "io.containerd.runc.v2"
+  runtime_type = "io.containerd.runc.v1"
 [plugins.cri.containerd.default_runtime.options]
   BinaryName = "${CONTAINERD_HOME}/usr/local/sbin/runc"
 EOF


### PR DESCRIPTION
Use runc.v1 to see whether https://github.com/containerd/containerd/issues/3177 is still reproducible.

This can help us figure out whether the issue is caused by the 5 seconds timeout introduced in the v2 shim, or architecture change from per-container shim to per-pod shim.

Signed-off-by: Lantao Liu <lantaol@google.com>