### PR TITLE
Integration test task.Delete fix

### DIFF
--- a/integration/sandbox_clean_remove_test.go
+++ b/integration/sandbox_clean_remove_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -53,7 +54,9 @@ func TestSandboxCleanRemove(t *testing.T) {
 	require.NoError(t, err)
 	task, err := cntr.Task(ctx, nil)
 	require.NoError(t, err)
-	_, err = task.Delete(ctx, containerd.WithProcessKill)
+	// Kill the task with signal SIGKILL, once the task exited,
+	// the TaskExit event will trigger the task.Delete().
+	err = task.Kill(ctx, syscall.SIGKILL, containerd.WithKillAll)
 	require.NoError(t, err)
 
 	t.Logf("Sandbox state should be NOTREADY")


### PR DESCRIPTION
task.Delete() will try to kill the task before delete it,
but once the task is killed, the TaskExit event will also
tigger another task.Delete() which would conflict with this
test task.Delete(). To avoid this conflict, kill the task instead
of Delete it, and let TaskExit trigger task.Delete().

Signed-off-by: lifupan <lifupan@gmail.com>