### PR TITLE
Move from unix to syscall package for SIG* signals

### DIFF
--- a/pkg/server/container_execsync.go
+++ b/pkg/server/container_execsync.go
@@ -19,6 +19,7 @@ package server
 import (
 	"bytes"
 	"io"
+	"syscall"
 	"time"
 
 	"github.com/containerd/containerd"
@@ -28,7 +29,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
-	"golang.org/x/sys/unix"
 	"k8s.io/client-go/tools/remotecommand"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
@@ -175,7 +175,7 @@ func (c *criService) execInContainer(ctx context.Context, id string, opts execOp
 	case <-timeoutCh:
 		//TODO(Abhi) Use context.WithDeadline instead of timeout.
 		// Ignore the not found error because the process may exit itself before killing.
-		if err := process.Kill(ctx, unix.SIGKILL); err != nil && !errdefs.IsNotFound(err) {
+		if err := process.Kill(ctx, syscall.SIGKILL); err != nil && !errdefs.IsNotFound(err) {
 			return nil, errors.Wrapf(err, "failed to kill exec %q", execID)
 		}
 		// Wait for the process to be killed.

--- a/pkg/server/container_stop.go
+++ b/pkg/server/container_stop.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"syscall"
 	"time"
 
 	"github.com/containerd/containerd"
@@ -25,7 +26,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
-	"golang.org/x/sys/unix"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
 	ctrdutil "github.com/containerd/cri/pkg/containerd/util"
@@ -149,7 +149,7 @@ func (c *criService) stopContainer(ctx context.Context, container containerstore
 	}
 
 	logrus.Infof("Kill container %q", id)
-	if err = task.Kill(ctx, unix.SIGKILL); err != nil && !errdefs.IsNotFound(err) {
+	if err = task.Kill(ctx, syscall.SIGKILL); err != nil && !errdefs.IsNotFound(err) {
 		return errors.Wrapf(err, "failed to kill container %q", id)
 	}
 

--- a/pkg/server/sandbox_stop.go
+++ b/pkg/server/sandbox_stop.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"syscall"
 	"time"
 
 	eventtypes "github.com/containerd/containerd/api/events"
@@ -25,7 +26,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
-	"golang.org/x/sys/unix"
 	runtime "k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2"
 
 	ctrdutil "github.com/containerd/cri/pkg/containerd/util"
@@ -138,7 +138,7 @@ func (c *criService) stopSandboxContainer(ctx context.Context, sandbox sandboxst
 	}
 
 	// Kill the sandbox container.
-	if err = task.Kill(ctx, unix.SIGKILL); err != nil && !errdefs.IsNotFound(err) {
+	if err = task.Kill(ctx, syscall.SIGKILL); err != nil && !errdefs.IsNotFound(err) {
 		return errors.Wrap(err, "failed to kill sandbox container")
 	}
 


### PR DESCRIPTION
To support cross compilation for SIG* signals perfer the syscall package over
the unix package.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>