### PR TITLE
Return gRPC codes.DeadlineExceeded for all timeout operations

### DIFF
--- a/pkg/server/container_stop_test.go
+++ b/pkg/server/container_stop_test.go
@@ -74,7 +74,12 @@ func TestWaitContainerStop(t *testing.T) {
 			cancel()
 			ctx = cancelledCtx
 		}
-		err = c.waitContainerStop(ctx, container, test.timeout)
+		if test.timeout > 0 {
+			timeoutCtx, cancel := context.WithTimeout(ctx, test.timeout)
+			defer cancel()
+			ctx = timeoutCtx
+		}
+		err = c.waitContainerStop(ctx, container)
 		assert.Equal(t, test.expectErr, err != nil, desc)
 	}
 }

--- a/pkg/server/sandbox_stop.go
+++ b/pkg/server/sandbox_stop.go
@@ -142,18 +142,15 @@ func (c *criService) stopSandboxContainer(ctx context.Context, sandbox sandboxst
 		return errors.Wrap(err, "failed to kill sandbox container")
 	}
 
-	return c.waitSandboxStop(ctx, sandbox, killContainerTimeout)
+	return c.waitSandboxStop(ctx, sandbox)
 }
 
-// waitSandboxStop waits for sandbox to be stopped until timeout exceeds or context is cancelled.
-func (c *criService) waitSandboxStop(ctx context.Context, sandbox sandboxstore.Sandbox, timeout time.Duration) error {
-	timeoutTimer := time.NewTimer(timeout)
-	defer timeoutTimer.Stop()
+// waitSandboxStop waits for sandbox to be stopped until context is cancelled or
+// the context deadline is exceeded.
+func (c *criService) waitSandboxStop(ctx context.Context, sandbox sandboxstore.Sandbox) error {
 	select {
 	case <-ctx.Done():
-		return errors.Wrapf(ctx.Err(), "wait sandbox container %q is cancelled", sandbox.ID)
-	case <-timeoutTimer.C:
-		return errors.Errorf("wait sandbox container %q stop timeout", sandbox.ID)
+		return errors.Wrapf(ctx.Err(), "wait sandbox container %q", sandbox.ID)
 	case <-sandbox.Stopped():
 		return nil
 	}

--- a/pkg/server/sandbox_stop_test.go
+++ b/pkg/server/sandbox_stop_test.go
@@ -62,7 +62,12 @@ func TestWaitSandboxStop(t *testing.T) {
 			cancel()
 			ctx = cancelledCtx
 		}
-		err := c.waitSandboxStop(ctx, sandbox, test.timeout)
+		if test.timeout > 0 {
+			timeoutCtx, cancel := context.WithTimeout(ctx, test.timeout)
+			defer cancel()
+			ctx = timeoutCtx
+		}
+		err := c.waitSandboxStop(ctx, sandbox)
 		assert.Equal(t, test.expectErr, err != nil, desc)
 	}
 }


### PR DESCRIPTION
In order for a calling client to properly detect when a call failed due to a
timeout CRI should be returning codes.DeadlineExceeded from gRPC by contract.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>