### PR TITLE
Update parseDNSOptions maxDNSSearches in error message

### DIFF
--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -500,7 +500,7 @@ func parseDNSOptions(servers, searches, options []string) (string, error) {
 	resolvContent := ""
 
 	if len(searches) > maxDNSSearches {
-		return "", errors.New("DNSOption.Searches has more than 6 domains")
+		return "", errors.Errorf("DNSOption.Searches has more than %d domains", maxDNSSearches)
 	}
 
 	if len(searches) > 0 {


### PR DESCRIPTION
Minor correctness. We should use the value of the const in the error message
instead of hard coding it in the string so if maxDNSSearches ever changes so
does the error.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>