### PR TITLE
Make sure exec process is killed when context is canceled.

### DIFF
--- a/pkg/server/container_execsync.go
+++ b/pkg/server/container_execsync.go
@@ -134,7 +134,7 @@ func (c *criService) execInContainer(ctx context.Context, id string, opts execOp
 	defer func() {
 		deferCtx, deferCancel := ctrdutil.DeferContext()
 		defer deferCancel()
-		if _, err := process.Delete(deferCtx); err != nil {
+		if _, err := process.Delete(deferCtx, containerd.WithProcessKill); err != nil {
 			logrus.WithError(err).Errorf("Failed to delete exec process %q for container %q", execID, id)
 		}
 	}()


### PR DESCRIPTION
When context is cancelled, the `process.Kill` won't work. We need to kill the process in the cleanup defer.

Signed-off-by: Lantao Liu <lantaol@google.com>