### PR TITLE
adds cni config data to the cri status/info

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -72,6 +72,12 @@ func (c *criService) Status(ctx context.Context, r *runtime.StatusRequest) (*run
 			return nil, err
 		}
 		resp.Info["golang"] = string(versionByt)
+
+		cniConfig, err := json.Marshal(c.netPlugin.GetConfig())
+		if err != nil {
+			logrus.WithError(err).Errorf("Failed to marshal CNI config %v", err)
+		}
+		resp.Info["cniconfig"] = string(cniConfig)
 	}
 	return resp, nil
 }

--- a/pkg/store/sandbox/metadata.go
+++ b/pkg/store/sandbox/metadata.go
@@ -57,7 +57,7 @@ type Metadata struct {
 	IP string
 	// RuntimeHandler is the runtime handler name of the pod.
 	RuntimeHandler string
-	// CNI result
+	// CNIresult resulting configuration for attached network namespace interfaces
 	CNIResult *cni.CNIResult
 }
 


### PR DESCRIPTION
Addressing  #979 and comments from first attempt #982

Adds the CNI plugin path and config source information used to create the cni plugin results.

see cniconfig below:

```
sudo crictl info
{
  "status": {
    "conditions": [
      {
        "type": "RuntimeReady",
        "status": true,
        "reason": "",
        "message": ""
      },
      {
        "type": "NetworkReady",
        "status": true,
        "reason": "",
        "message": ""
      }
    ]
  },
  "cniconfig": {
    "PluginDirs": [
      "/opt/cni/bin"
    ],
    "PluginConfDir": "/etc/cni/net.d",
    "Prefix": "eth",
    "Networks": [
      {
        "Config": {
          "Name": "cni-loopback",
          "CNIVersion": "0.3.1",
          "Plugins": [
            {
              "Network": {
                "type": "loopback",
                "ipam": {},
                "dns": {}
              },
              "Source": "{\"type\":\"loopback\"}"
            }
          ],
          "Source": "{\n\"cniVersion\": \"0.3.1\",\n\"name\": \"cni-loopback\",\n\"plugins\": [{\n  \"type\": \"loopback\"\n}]\n}"
        },
        "IFName": "lo"
      },
      {
        "Config": {
          "Name": "containerd-net",
          "CNIVersion": "0.3.1",
          "Plugins": [
            {
              "Network": {
                "type": "bridge",
                "ipam": {
                  "type": "host-local"
                },
                "dns": {}
              },
              "Source": "{\"bridge\":\"cni0\",\"ipMasq\":true,\"ipam\":{\"routes\":[{\"dst\":\"0.0.0.0/0\"}],\"subnet\":\"10.88.0.0/16\",\"type\":\"host-local\"},\"isGateway\":true,\"promiscMode\":true,\"type\":\"bridge\"}"
            },
            {
              "Network": {
                "type": "portmap",
                "capabilities": {
                  "portMappings": true
                },
                "ipam": {},
                "dns": {}
              },
              "Source": "{\"capabilities\":{\"portMappings\":true},\"type\":\"portmap\"}"
            }
          ],
          "Source": "{\n  \"cniVersion\": \"0.3.1\",\n  \"name\": \"containerd-net\",\n  \"plugins\": [\n    {\n      \"type\": \"bridge\",\n      \"bridge\": \"cni0\",\n      \"isGateway\": true,\n      \"ipMasq\": true,\n      \"promiscMode\": true,\n      \"ipam\": {\n        \"type\": \"host-local\",\n        \"subnet\": \"10.88.0.0/16\",\n        \"routes\": [\n          { \"dst\": \"0.0.0.0/0\" }\n        ]\n      }\n    },\n    {\n      \"type\": \"portmap\",\n      \"capabilities\": {\"portMappings\": true}\n    }\n  ]\n}\n"
        },
        "IFName": "eth0"
      }
    ]
  },
  "config": {
    "containerd": {
      "snapshotter": "overlayfs",
      "defaultRuntimeName": "runc",
      "defaultRuntime": {
        "runtimeType": "",
        "runtimeEngine": "",
        "PodAnnotations": null,
        "runtimeRoot": "",
        "options": null
      },
      "untrustedWorkloadRuntime": {
        "runtimeType": "",
        "runtimeEngine": "",
        "PodAnnotations": null,
        "runtimeRoot": "",
        "options": null
      },
      "runtimes": {
        "runc": {
          "runtimeType": "io.containerd.runc.v1",
          "runtimeEngine": "",
          "PodAnnotations": null,
          "runtimeRoot": "",
          "options": null
        }
      },
      "noPivot": false
    },
    "cni": {
      "binDir": "/opt/cni/bin",
      "confDir": "/etc/cni/net.d",
      "confTemplate": ""
    },
    "registry": {
      "mirrors": {
        "docker.io": {
          "endpoint": [
            "https://registry-1.docker.io"
          ]
        }
      },
      "auths": null
    },
    "streamServerAddress": "127.0.0.1",
    "streamServerPort": "0",
    "streamIdleTimeout": "4h0m0s",
    "enableSelinux": false,
    "sandboxImage": "k8s.gcr.io/pause:3.1",
    "statsCollectPeriod": 10,
    "systemdCgroup": false,
    "enableTLSStreaming": false,
    "x509KeyPairStreaming": {
      "tlsCertFile": "",
      "tlsKeyFile": ""
    },
    "maxContainerLogSize": 16384,
    "disableCgroup": false,
    "disableApparmor": false,
    "restrictOOMScoreAdj": false,
    "containerdRootDir": "/var/lib/containerd",
    "containerdEndpoint": "/run/containerd/containerd.sock",
    "rootDir": "/var/lib/containerd/io.containerd.grpc.v1.cri",
    "stateDir": "/run/containerd/io.containerd.grpc.v1.cri"
  },
  "golang": "go1.11.2"
}
```

Might want to arrange it so it falls below the containerd/cri config info

Signed-off-by: Mike Brown <brownwm@us.ibm.com>