### PR TITLE
Add cri managed image label when pulling the image.

### DIFF
--- a/pkg/server/image_pull.go
+++ b/pkg/server/image_pull.go
@@ -105,6 +105,7 @@ func (c *criService) PullImage(ctx context.Context, r *runtime.PullImageRequest)
 		containerd.WithResolver(resolver),
 		containerd.WithPullSnapshotter(c.config.ContainerdConfig.Snapshotter),
 		containerd.WithPullUnpack,
+		containerd.WithPullLabel(imageLabelKey, imageLabelValue),
 	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to pull and unpack image %q", ref)


### PR DESCRIPTION
Fixes https://github.com/containerd/cri/issues/1161.

Add the cri managed image label when pulling the image.
Previously, we didn't add the image label when pulling the image, so the generated image create event also doesn't have the label:
```
time="2019-06-10T19:46:17.251529854Z" level=info msg="ImageCreate event &ImageCreate{Name:gcr.io/cri-tools/test-image-digest@sha256:9179135b4b4cc5a8721e09379244807553c318d92fa3111a65133241551ca343,Labels:map[string]string{},}" 
```

The cri plugin will [create/update the image reference to add the label](https://github.com/containerd/cri/blob/master/pkg/server/image_pull.go#L206), and this may happen after `PullImage` returns.

If `RemoveImage` is called right after `PullImage`, there will be a race condition before `RemoveImage` and the event triggered image reference create/update. https://github.com/containerd/cri/issues/1161 is caused just because the create/update happens after `RemoveImage.

Signed-off-by: Lantao Liu <lantaol@google.com>