### PR TITLE
move up to golang 1.12.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ git:
 
 language: go
 go:
-  # FIXME: change back to 1.11.x
-  - 1.11.6
+  - 1.12.x
   - tip
+
 
 matrix:
   allow_failures:


### PR DESCRIPTION
address #1175 move up to golang 1.12.x in build 1.11 not necessary now

Signed-off-by: Mike Brown <brownwm@us.ibm.com>