### PR TITLE
use dynamic slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ For sync communication we have a community slack with a #containerd channel that
 everyone is welcome to join and chat about development.
 
 **Slack:** Catch us in the #containerd and #containerd-dev channels on dockercommunity.slack.com.
-[Click here for an invite to docker community slack.](https://join.slack.com/t/dockercommunity/shared_invite/enQtNDY4MDc1Mzc0MzIwLTgxZDBlMmM4ZGEyNDc1N2FkMzlhODJkYmE1YTVkYjM1MDE3ZjAwZjBkOGFlOTJkZjRmZGYzNjYyY2M3ZTUxYzQ)
+[Click here for an invite to docker community slack.](https://dockr.ly/slack)
 
 ## Other Communications
 As this project is tightly coupled to CRI and CRI-Tools and they are Kubernetes


### PR DESCRIPTION
Fixes the broken Slack Link.

Signed-off-by: Mike Brown <brownwm@us.ibm.com>