### PR TITLE
Fix runc and critools version in release.

### DIFF
--- a/hack/install/install-critools.sh
+++ b/hack/install/install-critools.sh
@@ -29,7 +29,7 @@ GOPATH=${TMPGOPATH}
 #Install crictl
 checkout_repo ${CRITOOL_PKG} ${CRITOOL_VERSION} ${CRITOOL_REPO}
 cd ${GOPATH}/src/${CRITOOL_PKG}
-make
+make VERSION=${CRITOOL_VERSION}
 ${SUDO} make install -e BINDIR=${CRITOOL_DIR} GOPATH=${GOPATH}
 ${SUDO} mkdir -p ${CRICTL_CONFIG_DIR}
 ${SUDO} bash -c 'cat >'${CRICTL_CONFIG_DIR}'/crictl.yaml <<EOF

--- a/hack/install/install-runc.sh
+++ b/hack/install/install-runc.sh
@@ -30,7 +30,7 @@ GOPATH=${TMPGOPATH}
 from-vendor RUNC github.com/opencontainers/runc
 checkout_repo ${RUNC_PKG} ${RUNC_VERSION} ${RUNC_REPO}
 cd ${GOPATH}/src/${RUNC_PKG}
-make static BUILDTAGS="$BUILDTAGS"
+make static BUILDTAGS="$BUILDTAGS" VERSION=${RUNC_VERSION}
 ${SUDO} make install -e DESTDIR=${RUNC_DIR}
 
 # Clean the tmp GOPATH dir. Use sudo because runc build generates


### PR DESCRIPTION
Runc and critools are both versioned with containerd version, e.g. 1.2.6, without the fix.
Signed-off-by: Lantao Liu <lantaol@google.com>