### PR TITLE
Add extra TCP server for CRI service

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -138,6 +138,9 @@ type PluginConfig struct {
 	CniConfig `toml:"cni" json:"cni"`
 	// Registry contains config related to the registry
 	Registry Registry `toml:"registry" json:"registry"`
+	// TCPServerEndpoint is an additional TCP endpoint where the CRI will be served.
+	// Leave empty to disable.
+	TCPServerEndpoint string `toml:"tcp_server_endpoint" json:"tcpServerEndpoint"`
 	// StreamServerAddress is the ip address streaming server is listening on.
 	StreamServerAddress string `toml:"stream_server_address" json:"streamServerAddress"`
 	// StreamServerPort is the port streaming server is listening on.
@@ -219,6 +222,7 @@ func DefaultConfig() PluginConfig {
 				},
 			},
 		},
+		TCPServerEndpoint:   "", // Disabled.
 		StreamServerAddress: "127.0.0.1",
 		StreamServerPort:    "0",
 		StreamIdleTimeout:   streaming.DefaultConfig.StreamIdleTimeout.String(), // 4 hour

--- a/pkg/server/tcp.go
+++ b/pkg/server/tcp.go
@@ -1,0 +1,42 @@
+package server
+
+import (
+	"net"
+
+	"github.com/grpc-ecosystem/go-grpc-prometheus"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+)
+
+type tcpServer struct {
+	l   net.Listener
+	rpc *grpc.Server
+}
+
+func newTCPServer(c *criService, endpoint string) (*tcpServer, error) {
+	l, err := net.Listen("tcp", endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	serverOpts := []grpc.ServerOption{
+		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
+		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
+	}
+	rpc := grpc.NewServer(serverOpts...)
+	if err := c.Register(rpc); err != nil {
+		return nil, errors.Wrap(err, "registering CRI on TCP server")
+	}
+	return &tcpServer{
+		l:   l,
+		rpc: rpc,
+	}, nil
+}
+
+func (s *tcpServer) start() error {
+	return s.rpc.Serve(s.l)
+}
+
+func (s *tcpServer) stop() {
+	s.rpc.GracefulStop()
+}


### PR DESCRIPTION
If an endpoint is provided, CRI will be served over TCP, in addition to the service in the global containerd socket.

The feature is disabled by default.

#1181 