### PR TITLE
Add option to register on TCP server

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -15,6 +15,10 @@ version = 2
 # The 'plugins."io.containerd.grpc.v1.cri"' table contains all of the server options.
 [plugins."io.containerd.grpc.v1.cri"]
 
+  # disable_tcp_service disables serving CRI on the TCP server.
+  # Note that a TCP server is enabled for containerd if TCPAddress is set in section [grpc].
+  disable_tcp_service = true
+
   # stream_server_address is the ip address streaming server is listening on.
   stream_server_address = "127.0.0.1"
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -138,6 +138,8 @@ type PluginConfig struct {
 	CniConfig `toml:"cni" json:"cni"`
 	// Registry contains config related to the registry
 	Registry Registry `toml:"registry" json:"registry"`
+	// DisableTCPService disables serving CRI on the TCP server.
+	DisableTCPService bool `toml:"disable_tcp_service" json:"disableTCPService"`
 	// StreamServerAddress is the ip address streaming server is listening on.
 	StreamServerAddress string `toml:"stream_server_address" json:"streamServerAddress"`
 	// StreamServerPort is the port streaming server is listening on.
@@ -219,6 +221,7 @@ func DefaultConfig() PluginConfig {
 				},
 			},
 		},
+		DisableTCPService:   true,
 		StreamServerAddress: "127.0.0.1",
 		StreamServerPort:    "0",
 		StreamIdleTimeout:   streaming.DefaultConfig.StreamIdleTimeout.String(), // 4 hour


### PR DESCRIPTION
If enabled, register CRI on containerd's TCP endpoint

#1181 