### PR TITLE
[release/1.2 backport] Fix runc and critools version in release.

### DIFF
--- a/hack/install/install-critools.sh
+++ b/hack/install/install-critools.sh
@@ -29,7 +29,7 @@ GOPATH=${TMPGOPATH}
 #Install crictl
 checkout_repo ${CRITOOL_PKG} ${CRITOOL_VERSION} ${CRITOOL_REPO}
 cd ${GOPATH}/src/${CRITOOL_PKG}
-make
+make VERSION=${CRITOOL_VERSION}
 ${SUDO} make install -e BINDIR=${CRITOOL_DIR} GOPATH=${GOPATH}
 ${SUDO} mkdir -p ${CRICTL_CONFIG_DIR}
 ${SUDO} bash -c 'cat >'${CRICTL_CONFIG_DIR}'/crictl.yaml <<EOF

--- a/hack/install/install-runc.sh
+++ b/hack/install/install-runc.sh
@@ -30,7 +30,7 @@ GOPATH=${TMPGOPATH}
 from-vendor RUNC github.com/opencontainers/runc
 checkout_repo ${RUNC_PKG} ${RUNC_VERSION} ${RUNC_REPO}
 cd ${GOPATH}/src/${RUNC_PKG}
-make static BUILDTAGS="$BUILDTAGS"
+make static BUILDTAGS="$BUILDTAGS" VERSION=${RUNC_VERSION}
 ${SUDO} make install -e DESTDIR=${RUNC_DIR}
 
 # Clean the tmp GOPATH dir. Use sudo because runc build generates


### PR DESCRIPTION
Noticed that this one was labeled for backporting but no backport yet;

cherry-pick of https://github.com/containerd/cri/pull/1180 for the 1.2 branch

(cherry picked from commit 6afd137c026ee2133dddb22bc9a8d405852df674)
