### PR TITLE
Assign ImageSpec User if SecurityContext is not set

### DIFF
--- a/pkg/server/container_create_test.go
+++ b/pkg/server/container_create_test.go
@@ -1230,3 +1230,74 @@ func TestDisableCgroup(t *testing.T) {
 	t.Log("cgroup path should be empty")
 	assert.Empty(t, spec.Linux.CgroupsPath)
 }
+
+func TestGenerateUserString(t *testing.T) {
+	type testcase struct {
+		// the name of the test case
+		name string
+
+		u        string
+		uid, gid *runtime.Int64Value
+
+		result        string
+		expectedError bool
+	}
+	testcases := []testcase{
+		{
+			name:   "Empty",
+			result: "",
+		},
+		{
+			name:   "Username Only",
+			u:      "testuser",
+			result: "testuser",
+		},
+		{
+			name:   "Username, UID",
+			u:      "testuser",
+			uid:    &runtime.Int64Value{Value: 1},
+			result: "testuser",
+		},
+		{
+			name:   "Username, UID, GID",
+			u:      "testuser",
+			uid:    &runtime.Int64Value{Value: 1},
+			gid:    &runtime.Int64Value{Value: 10},
+			result: "testuser:10",
+		},
+		{
+			name:   "Username, GID",
+			u:      "testuser",
+			gid:    &runtime.Int64Value{Value: 10},
+			result: "testuser:10",
+		},
+		{
+			name:   "UID only",
+			uid:    &runtime.Int64Value{Value: 1},
+			result: "1",
+		},
+		{
+			name:   "UID, GID",
+			uid:    &runtime.Int64Value{Value: 1},
+			gid:    &runtime.Int64Value{Value: 10},
+			result: "1:10",
+		},
+		{
+			name:          "GID only",
+			gid:           &runtime.Int64Value{Value: 10},
+			result:        "",
+			expectedError: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := generateUserString(tc.u, tc.uid, tc.gid)
+			if tc.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.result, r)
+		})
+	}
+}

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -169,6 +169,11 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate user string")
 	}
+	if userstr == "" {
+		// Lastly, since no user override was passed via CRI try to set via OCI
+		// Image
+		userstr = image.ImageSpec.Config.User
+	}
 	if userstr != "" {
 		specOpts = append(specOpts, oci.WithUser(userstr))
 	}


### PR DESCRIPTION
By default the SecurityContext for Container activation can contain a Username
UID, GID. The order of precedences is username, UID, GID. If none of these
options are specified as a last resort attempt to set the ImageSpec username.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>