### PR TITLE
Fix ctr readiness check in test.

### DIFF
--- a/hack/test-utils.sh
+++ b/hack/test-utils.sh
@@ -69,7 +69,7 @@ test_setup() {
     echo "crictl is not in PATH"
     exit 1
   fi
-  readiness_check "sudo ${ctr_path} version"
+  readiness_check "sudo ${ctr_path} --address ${CONTAINERD_SOCK#"unix://"} version"
   readiness_check "sudo ${crictl_path} --runtime-endpoint=${CONTAINERD_SOCK} info"
 }
 


### PR DESCRIPTION
The ctr readiness check should also use the test containerd socket path.
Signed-off-by: Lantao Liu <lantaol@google.com>