### PR TITLE
Remove `noSnat`

### DIFF
--- a/cluster/gce/cni.template
+++ b/cluster/gce/cni.template
@@ -19,8 +19,7 @@
       "type": "portmap",
       "capabilities": {
         "portMappings": true
-      },
-      "noSnat": true
+      }
     }
   ]
 }


### PR DESCRIPTION
Fixes https://github.com/containerd/cri/issues/1139.

Remove unused config `noSnat`.

See https://github.com/GoogleCloudPlatform/netd/pull/63.

Signed-off-by: Lantao Liu <lantaol@google.com>