### PR TITLE
Move context cancel into defer.

### DIFF
--- a/pkg/server/container_stop.go
+++ b/pkg/server/container_stop.go
@@ -135,18 +135,16 @@ func (c *criService) stopContainer(ctx context.Context, container containerstore
 		}
 
 		sigTermCtx, sigTermCtxCancel := context.WithTimeout(ctx, timeout)
+		defer sigTermCtxCancel()
 		err = c.waitContainerStop(sigTermCtx, container)
 		if err == nil {
 			// Container stopped on first signal no need for SIGKILL
-			sigTermCtxCancel()
 			return nil
 		}
 		// If the parent context was cancelled or exceeded return immediately
 		if ctx.Err() != nil {
-			sigTermCtxCancel()
 			return ctx.Err()
 		}
-		sigTermCtxCancel()
 		// sigTermCtx was exceeded. Send SIGKILL
 		logrus.Debugf("Stop container %q with signal %v timed out", id, sig)
 	}


### PR DESCRIPTION
Just a small cleanup. :) Move `sigTermCtxCancel` into defer.

If `waitContainerStop` returns error, sigTermCtx should have already `Done`;
If `waitContainerStop` returns nil, sigTermCtxCancel will be called in defer immediately.

Signed-off-by: Lantao Liu <lantaol@google.com>