### PR TITLE
Fix proc mount support.

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -79,6 +79,10 @@ version = 2
   # max_concurrent_downloads restricts the number of concurrent downloads for each image.
   max_concurrent_downloads = 3
 
+  # disable_proc_mount disables Kubernetes ProcMount support. This MUST be set to `true`
+  # when using containerd with Kubernetes <=1.11.
+  disable_proc_mount = false
+
   # 'plugins."io.containerd.grpc.v1.cri".containerd' contains config related to containerd
   [plugins."io.containerd.grpc.v1.cri".containerd]
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -179,6 +179,9 @@ type PluginConfig struct {
 	RestrictOOMScoreAdj bool `toml:"restrict_oom_score_adj" json:"restrictOOMScoreAdj"`
 	// MaxConcurrentDownloads restricts the number of concurrent downloads for each image.
 	MaxConcurrentDownloads int `toml:"max_concurrent_downloads" json:"maxConcurrentDownloads"`
+	// DisableProcMount disables Kubernetes ProcMount support. This MUST be set to `true`
+	// when using containerd with Kubernetes <=1.11.
+	DisableProcMount bool `toml:"disable_proc_mount" json:"disableProcMount"`
 }
 
 // X509KeyPairStreaming contains the x509 configuration for streaming
@@ -245,6 +248,7 @@ func DefaultConfig() PluginConfig {
 			},
 		},
 		MaxConcurrentDownloads: 3,
+		DisableProcMount:       false,
 	}
 }
 

--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -366,20 +366,14 @@ func (c *criService) generateContainerSpec(id string, sandboxID string, sandboxP
 	}
 	specOpts = append(specOpts, customopts.WithMounts(c.os, config, extraMounts, mountLabel))
 
-	// Apply masked paths if specified.
-	// When `MaskedPaths` is not specified, keep runtime default for backward compatibility;
-	// When `MaskedPaths` is specified, but length is zero, clear masked path list.
-	// Note: If the container is privileged, then we clear any masked paths later on in the call to setOCIPrivileged()
-	if maskedPaths := securityContext.GetMaskedPaths(); maskedPaths != nil {
-		specOpts = append(specOpts, oci.WithMaskedPaths(maskedPaths))
-	}
+	if !c.config.DisableProcMount {
+		// Apply masked paths if specified.
+		// Note: If the container is privileged, then we clear any masked paths later on in the call to setOCIPrivileged()
+		specOpts = append(specOpts, oci.WithMaskedPaths(securityContext.GetMaskedPaths()))
 
-	// Apply readonly paths if specified.
-	// Note: If the container is privileged, then we clear any readonly paths later on in the call to setOCIPrivileged()
-
-	// Apply readonly paths if specified.
-	if roPaths := securityContext.GetReadonlyPaths(); roPaths != nil {
-		specOpts = append(specOpts, oci.WithReadonlyPaths(roPaths))
+		// Apply readonly paths if specified.
+		// Note: If the container is privileged, then we clear any readonly paths later on in the call to setOCIPrivileged()
+		specOpts = append(specOpts, oci.WithReadonlyPaths(securityContext.GetReadonlyPaths()))
 	}
 
 	if securityContext.GetPrivileged() {


### PR DESCRIPTION
For https://github.com/containerd/cri/issues/1208.

Note that a `disable_proc_mount` option has to be introduced to support Kubernetes 1.11.

Given that 1) containerd 1.1 will go into security patch only mode soon; 2) 1.3 is still WIP; 3) many production Kubernetes clusters are still on 1.11; I think not supporting 1.11 is not an option.

@choury 

Signed-off-by: Lantao Liu <lantaol@google.com>