### PR TITLE
Add max concurrent downloads support.

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -76,6 +76,9 @@ version = 2
   # This is useful when the containerd does not have permission to decrease OOMScoreAdj.
   restrict_oom_score_adj = false
 
+  # max_concurrent_downloads restricts the number of concurrent downloads for each image.
+  max_concurrent_downloads = 3
+
   # 'plugins."io.containerd.grpc.v1.cri".containerd' contains config related to containerd
   [plugins."io.containerd.grpc.v1.cri".containerd]
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -177,6 +177,8 @@ type PluginConfig struct {
 	// current OOMScoreADj.
 	// This is useful when the containerd does not have permission to decrease OOMScoreAdj.
 	RestrictOOMScoreAdj bool `toml:"restrict_oom_score_adj" json:"restrictOOMScoreAdj"`
+	// MaxConcurrentDownloads restricts the number of concurrent downloads for each image.
+	MaxConcurrentDownloads int `toml:"max_concurrent_downloads" json:"maxConcurrentDownloads"`
 }
 
 // X509KeyPairStreaming contains the x509 configuration for streaming
@@ -242,6 +244,7 @@ func DefaultConfig() PluginConfig {
 				},
 			},
 		},
+		MaxConcurrentDownloads: 3,
 	}
 }
 

--- a/pkg/server/image_pull.go
+++ b/pkg/server/image_pull.go
@@ -108,6 +108,7 @@ func (c *criService) PullImage(ctx context.Context, r *runtime.PullImageRequest)
 		containerd.WithPullSnapshotter(c.config.ContainerdConfig.Snapshotter),
 		containerd.WithPullUnpack,
 		containerd.WithPullLabel(imageLabelKey, imageLabelValue),
+		containerd.WithMaxConcurrentDownloads(c.config.MaxConcurrentDownloads),
 	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to pull and unpack image %q", ref)


### PR DESCRIPTION
Add `max_concurrent_downloads`, and set default to `3` (the same with Docker, see https://docs.docker.com/engine/reference/commandline/dockerd/).

Signed-off-by: Lantao Liu <lantaol@google.com>