### PR TITLE
Rename the test binary to containerd-test.

### DIFF
--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -36,7 +36,8 @@ test_setup ${REPORT_DIR}
 sudo PATH=${PATH} ${ROOT}/_output/integration.test --test.run="${FOCUS}" --test.v \
   --cri-endpoint=${CONTAINERD_SOCK} \
   --cri-root=${CRI_ROOT} \
-  --runtime-handler=${RUNTIME}
+  --runtime-handler=${RUNTIME} \
+  --containerd-bin=${CONTAINERD_BIN}
 
 test_exit_code=$?
 

--- a/hack/test-utils.sh
+++ b/hack/test-utils.sh
@@ -32,6 +32,8 @@ CONTAINERD_ROOT=${CONTAINERD_ROOT:-"/var/lib/containerd${CONTAINERD_TEST_SUFFIX}
 CONTAINERD_STATE=${CONTAINERD_STATE:-"/run/containerd${CONTAINERD_TEST_SUFFIX}"}
 # The containerd socket address.
 CONTAINERD_SOCK=${CONTAINERD_SOCK:-unix://${CONTAINERD_STATE}/containerd.sock}
+# The containerd binary name.
+CONTAINERD_BIN=${CONTAINERD_BIN:-"containerd${CONTAINERD_TEST_SUFFIX}"}
 if [ -f "${CONTAINERD_CONFIG_FILE}" ]; then
   CONTAINERD_FLAGS+="--config ${CONTAINERD_CONFIG_FILE} "
 fi
@@ -49,10 +51,13 @@ test_setup() {
     echo "containerd is not built"
     exit 1
   fi
+  # rename the test containerd binary, so that we can easily
+  # distinguish it.
+  cp ${ROOT}/_output/containerd ${ROOT}/_output/${CONTAINERD_BIN}
   set -m
   # Create containerd in a different process group
   # so that we can easily clean them up.
-  keepalive "sudo PATH=${PATH} ${ROOT}/_output/containerd ${CONTAINERD_FLAGS}" \
+  keepalive "sudo PATH=${PATH} ${ROOT}/_output/${CONTAINERD_BIN} ${CONTAINERD_FLAGS}" \
     ${RESTART_WAIT_PERIOD} &> ${report_dir}/containerd.log &
   pid=$!
   set +m

--- a/integration/test_utils.go
+++ b/integration/test_utils.go
@@ -60,6 +60,7 @@ var (
 var criEndpoint = flag.String("cri-endpoint", "unix:///run/containerd/containerd.sock", "The endpoint of cri plugin.")
 var criRoot = flag.String("cri-root", "/var/lib/containerd/io.containerd.grpc.v1.cri", "The root directory of cri plugin.")
 var runtimeHandler = flag.String("runtime-handler", "", "The runtime handler to use in the test.")
+var containerdBin = flag.String("containerd-bin", "containerd", "The containerd binary name. The name is used to restart containerd during test.")
 
 func init() {
 	flag.Parse()
@@ -395,12 +396,12 @@ func SandboxInfo(id string) (*runtime.PodSandboxStatus, *server.SandboxInfo, err
 }
 
 func RestartContainerd(t *testing.T) {
-	require.NoError(t, KillProcess("containerd"))
+	require.NoError(t, KillProcess(*containerdBin))
 
 	// Use assert so that the 3rd wait always runs, this makes sure
 	// containerd is running before this function returns.
 	assert.NoError(t, Eventually(func() (bool, error) {
-		pid, err := PidOf("containerd")
+		pid, err := PidOf(*containerdBin)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
Rename test containerd binary to containerd-test, so that we can easily restart it in the integration test.

With this change, now we can run containerd integration and CRI test without breaking Docker 18.09+ on the node.

Signed-off-by: Lantao Liu <lantaol@google.com>