### PR TITLE
Do not deprecate no_pivot yet.

### DIFF
--- a/cri.go
+++ b/cri.go
@@ -148,6 +148,13 @@ func validateConfig(ctx context.Context, c *criconfig.Config) error {
 		}
 		log.G(ctx).Warning("`systemd_cgroup` is deprecated, please use runtime `options` instead")
 	}
+	if c.NoPivot {
+		if c.ContainerdConfig.Runtimes[c.ContainerdConfig.DefaultRuntimeName].Type != plugin.RuntimeLinuxV1 {
+			return errors.Errorf("`no_pivot` only works for runtime %s", plugin.RuntimeLinuxV1)
+		}
+		// NoPivot can't be deprecated yet, because there is no alternative config option
+		// for `io.containerd.runtime.v1.linux`.
+	}
 	for _, r := range c.ContainerdConfig.Runtimes {
 		if r.Engine != "" {
 			if r.Type != plugin.RuntimeLinuxV1 {

--- a/docs/config.md
+++ b/docs/config.md
@@ -85,8 +85,6 @@ version = 2
 
     # no_pivot disables pivot-root (linux only), required when running a container in a RamDisk with runc.
     # This only works for runtime type "io.containerd.runtime.v1.linux".
-    # DEPRECATED: use Runtime.Options for runtime specific config for shim v2 runtimes.
-    #   For runtime "io.containerd.runc.v1", use the option `NoPivotRoot`.
     no_pivot = false
 
     # default_runtime_name is the default runtime name to use.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,7 +61,6 @@ type ContainerdConfig struct {
 	Runtimes map[string]Runtime `toml:"runtimes" json:"runtimes"`
 	// NoPivot disables pivot-root (linux only), required when running a container in a RamDisk with runc
 	// This only works for runtime type "io.containerd.runtime.v1.linux".
-	// DEPRECATED: use Runtime.Options instead. Remove when shim v1 is deprecated.
 	NoPivot bool `toml:"no_pivot" json:"noPivot"`
 }
 


### PR DESCRIPTION
Do not deprecate `no_pivot` yet.

There is no alternative option for `io.containerd.runtime.v1.linux` runtime right now.

Signed-off-by: Lantao Liu <lantaol@google.com>