### PR TITLE
Add flag to overload default privileged host device behaviour

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -117,6 +117,12 @@ version = 2
       # * OCI: https://github.com/opencontainers/image-spec/blob/master/annotations.md
       pod_annotations = []
 
+      # privileged_without_host_devices allows overloading the default behaviour of passing host
+      # devices through to privileged containers. This is useful when using a runtime where it does
+      # not make sense to pass host devices to the container when privileged. Defaults to false -
+      # i.e pass host devices through to privileged containers.
+      privileged_without_host_devices = false
+
       # 'plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options' is options specific to
       # "io.containerd.runc.v1". Its corresponding options type is:
       #   https://github.com/containerd/containerd/blob/v1.2.0-rc.1/runtime/v2/runc/options/oci.pb.go#L39.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,6 +41,9 @@ type Runtime struct {
 	// Options are config options for the runtime. If options is loaded
 	// from toml config, it will be toml.Primitive.
 	Options *toml.Primitive `toml:"options" json:"options"`
+	// PrivilegedWithoutHostDevices overloads the default behaviour for adding host devices to the
+	// runtime spec when the container is privileged. Defaults to false.
+	PrivilegedWithoutHostDevices bool `toml:"privileged_without_host_devices" json:"privileged_without_host_devices"`
 }
 
 // ContainerdConfig contains toml config related to containerd


### PR DESCRIPTION
This commit adds a flag to the runtime config that allows overloading of the default
privileged behaviour. When the flag is enabled on a runtime, host devices won't
be appended to the runtime spec if the container is run as privileged.

By default the flag is false to maintain the current behaviour of privileged.

Fixes #1213

Signed-off-by: Alex Price <aprice@atlassian.com>