### PR TITLE
Consider endpoint path when checking default host.

### DIFF
--- a/pkg/server/image_pull_test.go
+++ b/pkg/server/image_pull_test.go
@@ -147,6 +147,19 @@ func TestAddDefaultEndpoint(t *testing.T) {
 				"https://registry-3.io",
 			},
 		},
+		"default endpoint in list with path": {
+			endpoints: []string{
+				"https://registry-1.io",
+				"https://registry-2.io",
+				"https://registry-3.io/path",
+			},
+			host: "registry-3.io",
+			expected: []string{
+				"https://registry-1.io",
+				"https://registry-2.io",
+				"https://registry-3.io/path",
+			},
+		},
 	} {
 		t.Logf("TestCase %q", desc)
 		got, err := addDefaultEndpoint(test.endpoints, test.host)


### PR DESCRIPTION
We support `path` in mirror endpoint now. We should also consider that when checking default host.

Signed-off-by: Lantao Liu <lantaol@google.com>