### PR TITLE
allow non-mutual TLS

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -37,6 +37,14 @@ To configure the TLS settings for a specific registry, create/modify the `/etc/c
 In the config example shown above, TLS mutual authentication will be used for communications with the registry endpoint located at https://my.custom.registry.
 `ca_file` is file name of the certificate authority (CA) certificate used to authenticate the x509 certificate/key pair specified by the files respectively pointed to by `cert_file` and `key_file`.
 
+`cert_file` and `key_file` are not needed when TLS mutual authentication is unused.
+
+```toml
+# The registry host has to be an FDQN or IP.
+[plugins.cri.registry.configs."my.custom.registry".tls]
+    ca_file   = "ca.pem"
+```
+
 ## Configure Registry Credentials
 
 `cri` plugin also supports docker like registry credential config.

--- a/pkg/server/image_pull.go
+++ b/pkg/server/image_pull.go
@@ -249,9 +249,21 @@ func (c *criService) updateImage(ctx context.Context, r string) error {
 
 // getTLSConfig returns a TLSConfig configured with a CA/Cert/Key specified by registryTLSConfig
 func (c *criService) getTLSConfig(registryTLSConfig criconfig.TLSConfig) (*tls.Config, error) {
-	cert, err := tls.LoadX509KeyPair(registryTLSConfig.CertFile, registryTLSConfig.KeyFile)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to load cert file")
+	var (
+		cert tls.Certificate
+		err  error
+	)
+	if registryTLSConfig.CertFile != "" && registryTLSConfig.KeyFile != "" {
+		cert, err = tls.LoadX509KeyPair(registryTLSConfig.CertFile, registryTLSConfig.KeyFile)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to load cert file")
+		}
+	}
+	if registryTLSConfig.CertFile != "" && registryTLSConfig.KeyFile == "" {
+		return nil, errors.Errorf("cert file %q was specified, but no corresponding key file was specified", registryTLSConfig.CertFile)
+	}
+	if registryTLSConfig.CertFile == "" && registryTLSConfig.KeyFile != "" {
+		return nil, errors.Errorf("key file %q was specified, but no corresponding cert file was specified", registryTLSConfig.KeyFile)
 	}
 
 	caCertPool, err := x509.SystemCertPool()
@@ -265,8 +277,10 @@ func (c *criService) getTLSConfig(registryTLSConfig criconfig.TLSConfig) (*tls.C
 	caCertPool.AppendCertsFromPEM(caCert)
 
 	tlsConfig := &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		RootCAs:      caCertPool,
+		RootCAs: caCertPool,
+	}
+	if len(cert.Certificate) != 0 {
+		tlsConfig.Certificates = []tls.Certificate{cert}
 	}
 	tlsConfig.BuildNameToCertificate()
 	return tlsConfig, nil


### PR DESCRIPTION
Previously, client keypair had needed to be specified even when unused.

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>