### PR TITLE
Explicitly import runtime v2 in the test containerd binary.

### DIFF
--- a/cmd/containerd/containerd.go
+++ b/cmd/containerd/containerd.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/containerd/containerd/gc/scheduler"
 	_ "github.com/containerd/containerd/metrics/cgroups"
 	_ "github.com/containerd/containerd/runtime/v1/linux"
+	_ "github.com/containerd/containerd/runtime/v2"
 	_ "github.com/containerd/containerd/services/containers"
 	_ "github.com/containerd/containerd/services/content"
 	_ "github.com/containerd/containerd/services/diff"


### PR DESCRIPTION
I'm surprised that we didn't explicitly import runtime v2 before.

Luckily it happened to be indirectly imported:
```console
$ git grep "\"github.com/containerd/containerd/runtime/v2\""
vendor/github.com/containerd/containerd/services/tasks/local.go:        v2 "github.com/containerd/containerd/runtime/v2"
```

Let's explicitly import it.

Signed-off-by: Lantao Liu <lantaol@google.com>