### PR TITLE
[WIP] adds option for setting default oci hooks

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -77,6 +77,12 @@ version = 2
   # when using containerd with Kubernetes <=1.11.
   disable_proc_mount = false
 
+  # default_oci_hooks is the filepath to an OCI runtime spec Hooks struct in json.
+  # see details and example:
+  #    https://github.com/opencontainers/runtime-spec/blob/master/config.md#posix-platform-hooks
+  # ** Note: Overridden if set by CRI
+  default_oci_hooks = ""
+
   # 'plugins."io.containerd.grpc.v1.cri".containerd' contains config related to containerd
   [plugins."io.containerd.grpc.v1.cri".containerd]
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -205,6 +205,10 @@ type PluginConfig struct {
 	// DisableProcMount disables Kubernetes ProcMount support. This MUST be set to `true`
 	// when using containerd with Kubernetes <=1.11.
 	DisableProcMount bool `toml:"disable_proc_mount" json:"disableProcMount"`
+	// DefaultOCIHooks (optional) is a path to a json file that specifies a
+	// default OCI spec Hooks struct. ** Note: The any hooks set by default can be
+	// overridden if/when the hooks are set via the CRI.
+	DefaultOCIHooks string `toml:"default_oci_hooks" json:"defaultOCIHooks,omitempty"`
 }
 
 // X509KeyPairStreaming contains the x509 configuration for streaming

--- a/pkg/containerd/opts/spec.go
+++ b/pkg/containerd/opts/spec.go
@@ -101,6 +101,14 @@ func (m orderedMounts) parts(i int) int {
 	return strings.Count(filepath.Clean(m[i].ContainerPath), string(os.PathSeparator))
 }
 
+// WithHooks sets or replaces the runtimespec.Hooks with the provided hooks
+func WithHooks(hooks *runtimespec.Hooks) oci.SpecOpts {
+	return func(ctx context.Context, client oci.Client, c *containers.Container, s *runtimespec.Spec) error {
+		s.Hooks = hooks
+		return nil
+	}
+}
+
 // WithAnnotation sets the provided annotation
 func WithAnnotation(k, v string) oci.SpecOpts {
 	return func(ctx context.Context, client oci.Client, c *containers.Container, s *runtimespec.Spec) error {

--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -17,6 +17,8 @@ limitations under the License.
 package server
 
 import (
+	"encoding/json"
+	"io/ioutil"
 	"path/filepath"
 	"time"
 
@@ -292,4 +294,20 @@ func runtimeSpec(id string, opts ...oci.SpecOpts) (*runtimespec.Spec, error) {
 		return nil, err
 	}
 	return spec, nil
+}
+
+// generateOCIHooks generates a runtimespec.Hooks struct from json in the passed in filepath.
+func (c *criService) generateOCIHooks(profile string) (*runtimespec.Hooks, error) {
+	if profile == "" {
+		return nil, nil
+	}
+	hooks := &runtimespec.Hooks{}
+	f, err := ioutil.ReadFile(profile)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(f, hooks); err != nil {
+		return nil, err
+	}
+	return hooks, nil
 }

--- a/pkg/server/container_create_unix.go
+++ b/pkg/server/container_create_unix.go
@@ -164,6 +164,15 @@ func (c *criService) containerSpec(id string, sandboxID string, sandboxPid uint3
 		specOpts = append(specOpts, oci.WithReadonlyPaths(securityContext.GetReadonlyPaths()))
 	}
 
+	ociHooksProfile := c.config.DefaultOCIHooks
+	hooks, err := c.generateOCIHooks(ociHooksProfile)
+	if err != nil { // TODO (mikebrow): clean up prototype
+		return nil, errors.Wrapf(err, "failed to generate OCI hooks %+v", ociHooksProfile)
+	}
+	if hooks != nil {
+		specOpts = append(specOpts, customopts.WithHooks(hooks))
+	}
+
 	if securityContext.GetPrivileged() {
 		if !sandboxConfig.GetLinux().GetSecurityContext().GetPrivileged() {
 			return nil, errors.New("no privileged container allowed in sandbox")


### PR DESCRIPTION
To address issue containerd/containerd#6645 I've started a prototype. Actually this is a refactor'd prototype from containerd/cri#496 taking into account comments and updating to work with the current codebase. I closed the prior prototype PR because I had deleted that branch.

User must generate a json file for the hooks struct: https://github.com/opencontainers/runtime-spec/blob/master/specs-go/config.go#L114-L130

Hooks explained here: https://github.com/opencontainers/runtime-spec/blob/master/config.md#prestart

Signed-off-by: Mike Brown <brownwm@us.ibm.com>