### PR TITLE
Add TaskMax=infinity in the systemd unit.

### DIFF
--- a/cluster/gce/cloud-init/master.yaml
+++ b/cluster/gce/cloud-init/master.yaml
@@ -45,6 +45,7 @@ write_files:
       # in the kernel. We recommend using cgroups to do container-local accounting.
       LimitNPROC=infinity
       LimitCORE=infinity
+      TasksMax=infinity
       ExecStartPre=/sbin/modprobe overlay
       ExecStart=/home/containerd/usr/local/bin/containerd
 

--- a/cluster/gce/cloud-init/node.yaml
+++ b/cluster/gce/cloud-init/node.yaml
@@ -45,6 +45,7 @@ write_files:
       # in the kernel. We recommend using cgroups to do container-local accounting.
       LimitNPROC=infinity
       LimitCORE=infinity
+      TasksMax=infinity
       ExecStartPre=/sbin/modprobe overlay
       ExecStart=/home/containerd/usr/local/bin/containerd
 

--- a/contrib/systemd-units/containerd.service
+++ b/contrib/systemd-units/containerd.service
@@ -16,6 +16,7 @@ LimitNOFILE=1048576
 # in the kernel. We recommend using cgroups to do container-local accounting.
 LimitNPROC=infinity
 LimitCORE=infinity
+TasksMax=infinity
 
 [Install]
 WantedBy=multi-user.target

--- a/test/e2e_node/init.yaml
+++ b/test/e2e_node/init.yaml
@@ -44,6 +44,7 @@ write_files:
       # in the kernel. We recommend using cgroups to do container-local accounting.
       LimitNPROC=infinity
       LimitCORE=infinity
+      TasksMax=infinity
       ExecStartPre=/sbin/modprobe overlay
       ExecStart=/home/containerd/usr/local/bin/containerd
 


### PR DESCRIPTION
This PR:
1) added `TaskMax=infinity`, which we should have done long time ago;
2) ~~Removed `contrib/systemd-units`, because we already have https://github.com/containerd/containerd/blob/master/containerd.service~~ I found that `make release` still uses it, so keep it for now.

Signed-off-by: Lantao Liu <lantaol@google.com>