### PR TITLE
Update cri-tools to fix all image reference test failure.

### DIFF
--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -17,7 +17,7 @@
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
 
 # Not from vendor.conf.
-CRITOOL_VERSION=v1.15.0
+CRITOOL_VERSION=427262054f59f3b849391310856a19474acb7e83
 CRITOOL_PKG=github.com/kubernetes-sigs/cri-tools
 CRITOOL_REPO=github.com/kubernetes-sigs/cri-tools
 


### PR DESCRIPTION
Update cri-tools to include the image reference test fix. https://github.com/kubernetes-sigs/cri-tools/pull/503

I've hit the test failure in travis for several times.

Signed-off-by: Lantao Liu <lantaol@google.com>