### PR TITLE
[release/1.2] fix: support empty auth config for anonymous registry

### DIFF
--- a/pkg/server/image_pull.go
+++ b/pkg/server/image_pull.go
@@ -166,7 +166,8 @@ func ParseAuth(auth *runtime.AuthConfig) (string, string, error) {
 		return user, strings.Trim(passwd, "\x00"), nil
 	}
 	// TODO(random-liu): Support RegistryToken.
-	return "", "", errors.New("invalid auth config")
+	// An empty auth config is valid for anonymous registry
+	return "", "", nil
 }
 
 // createImageReference creates image reference inside containerd image store.

--- a/pkg/server/image_pull_test.go
+++ b/pkg/server/image_pull_test.go
@@ -41,9 +41,9 @@ func TestParseAuth(t *testing.T) {
 		expectErr      bool
 	}{
 		"should not return error if auth config is nil": {},
-		"should return error if no supported auth is provided": {
+		"should not return error if empty auth is provided for access to anonymous registry": {
 			auth:      &runtime.AuthConfig{},
-			expectErr: true,
+			expectErr: false,
 		},
 		"should support identity token": {
 			auth:           &runtime.AuthConfig{IdentityToken: "abcd"},


### PR DESCRIPTION
cherry-pick f41675d234bb8212457ea04eae5d47dc3606bf6b from master
PR: https://github.com/containerd/cri/pull/1250