### PR TITLE
FDQN is a typo, and we don't support trailing dot in FQDN.

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -38,7 +38,7 @@ After modify this config, you need restart the `containerd` service.
 
 To configure the TLS settings for a specific registry, create/modify the `/etc/containerd/config.toml` as follows:
 ```toml
-# The registry host has to be an FDQN or IP.
+# The registry host has to be an domain name or IP.
 [plugins.cri.registry.configs."my.custom.registry".tls]
     ca_file   = "ca.pem"
     cert_file = "cert.pem"
@@ -51,7 +51,7 @@ In the config example shown above, TLS mutual authentication will be used for co
 `cert_file` and `key_file` are not needed when TLS mutual authentication is unused.
 
 ```toml
-# The registry host has to be an FDQN or IP.
+# The registry host has to be an domain name or IP.
 [plugins.cri.registry.configs."my.custom.registry".tls]
     ca_file   = "ca.pem"
 ```
@@ -63,7 +63,7 @@ In the config example shown above, TLS mutual authentication will be used for co
 To configure a credential for a specific registry, create/modify the
 `/etc/containerd/config.toml` as follows:
 ```toml
-# The registry host has to be an FDQN or IP.
+# The registry host has to be an domain name or IP.
 [plugins.cri.registry.configs."gcr.io".auth]
   username = ""
   password = ""

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -131,7 +131,7 @@ type Registry struct {
 	// Mirrors are namespace to mirror mapping for all namespaces.
 	Mirrors map[string]Mirror `toml:"mirrors" json:"mirrors"`
 	// Configs are configs for each registry.
-	// The key is the FDQN or IP of the registry.
+	// The key is the domain name or IP of the registry.
 	Configs map[string]RegistryConfig `toml:"configs" json:"configs"`
 
 	// Auths are registry endpoint to auth config mapping. The registry endpoint must


### PR DESCRIPTION
`FDQN` is a typo.

And actually we are not supporting `FQDN` which requires a trailing dot.

Signed-off-by: Lantao Liu <lantaol@google.com>