### PR TITLE
init cni in local cluster installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ sudo containerd
 ```bash
 CONTAINER_RUNTIME=remote CONTAINER_RUNTIME_ENDPOINT='unix:///run/containerd/containerd.sock' ./hack/local-up-cluster.sh
 ```
+3. Init [cni](https://github.com/containernetworking/cni#running-the-plugins) and make the node ready to create application
 ### Test
 See [here](./docs/testing.md) for information about test.
 ## Using crictl


### PR DESCRIPTION
When I tried containerd as kubernetes runtime in local cluster, node becomes notReady because of the `cni plugin not initialized` error in kubelet runtimeStatus api. It takes me some time to solve this problem.
I think cni initialization should be mentioned in the local cluster setup for beginners.