### PR TITLE
need to move instr to more recent golang; remove integration/*.go from lint verify test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ version: ## print current cri plugin release version
 
 lint:
 	@echo "$(WHALE) $@"
-	golangci-lint run --skip-files .*_test.go
+	golangci-lint run --skip-files .*_test.go --skip-dirs='(integration)'
 
 gofmt:
 	@echo "$(WHALE) $@"

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ specifications as appropriate.
 backport version of `libseccomp-dev` is required. See [travis.yml](.travis.yml) for an example on trusty.
 * **btrfs development library.** Required by containerd btrfs support. `btrfs-tools`(Ubuntu, Debian) / `btrfs-progs-devel`(Fedora, CentOS, RHEL)
 2. Install **`socat`** (required by portforward).
-2. Install and setup a go 1.10 development environment.
+2. Install and setup a go 1.12.9 development environment. (Note: You can check the travis logs for a recent pull request to confirm the version(s) of golang currently being used to build and test master.)
 3. Make a local clone of this repository.
 4. Install binary dependencies by running the following command from your cloned `cri/` project directory:
 ```bash


### PR DESCRIPTION
Instructions point to golang 1.10.. which is a bit long in the tooth now. Time to ask them to use 1.12.9 see #1268

Signed-off-by: Mike Brown <brownwm@us.ibm.com>