### PR TITLE
[WIP] CRI reports Additional POD IPs

### DIFF
--- a/pkg/server/sandbox_run_test.go
+++ b/pkg/server/sandbox_run_test.go
@@ -119,16 +119,19 @@ func TestToCNIPortMappings(t *testing.T) {
 
 func TestSelectPodIP(t *testing.T) {
 	for desc, test := range map[string]struct {
-		ips      []string
-		expected string
+		ips                   []string
+		expectedIP            string
+		expectedAdditionalIPs []string
 	}{
 		"ipv4 should be picked even if ipv6 comes first": {
-			ips:      []string{"2001:db8:85a3::8a2e:370:7334", "192.168.17.43"},
-			expected: "192.168.17.43",
+			ips:                   []string{"2001:db8:85a3::8a2e:370:7334", "192.168.17.43"},
+			expectedIP:            "192.168.17.43",
+			expectedAdditionalIPs: []string{"2001:db8:85a3::8a2e:370:7334"},
 		},
 		"ipv6 should be picked when there is no ipv4": {
-			ips:      []string{"2001:db8:85a3::8a2e:370:7334"},
-			expected: "2001:db8:85a3::8a2e:370:7334",
+			ips:                   []string{"2001:db8:85a3::8a2e:370:7334"},
+			expectedIP:            "2001:db8:85a3::8a2e:370:7334",
+			expectedAdditionalIPs: nil,
 		},
 	} {
 		t.Logf("TestCase %q", desc)
@@ -138,7 +141,9 @@ func TestSelectPodIP(t *testing.T) {
 				IP: net.ParseIP(ip),
 			})
 		}
-		assert.Equal(t, test.expected, selectPodIP(ipConfigs))
+		ip, additionalIPs := selectPodIPs(ipConfigs)
+		assert.Equal(t, test.expectedIP, ip)
+		assert.Equal(t, test.expectedAdditionalIPs, additionalIPs)
 	}
 }
 

--- a/pkg/server/sandbox_status.go
+++ b/pkg/server/sandbox_status.go
@@ -38,11 +38,11 @@ func (c *criService) PodSandboxStatus(ctx context.Context, r *runtime.PodSandbox
 		return nil, errors.Wrap(err, "an error occurred when try to find sandbox")
 	}
 
-	ip, err := c.getIP(sandbox)
+	ip, additionalIPs, err := c.getIPs(sandbox)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get sandbox ip")
 	}
-	status := toCRISandboxStatus(sandbox.Metadata, sandbox.Status.Get(), ip)
+	status := toCRISandboxStatus(sandbox.Metadata, sandbox.Status.Get(), ip, additionalIPs)
 	if status.GetCreatedAt() == 0 {
 		// CRI doesn't allow CreatedAt == 0.
 		info, err := sandbox.Container.Info(ctx)
@@ -67,27 +67,27 @@ func (c *criService) PodSandboxStatus(ctx context.Context, r *runtime.PodSandbox
 	}, nil
 }
 
-func (c *criService) getIP(sandbox sandboxstore.Sandbox) (string, error) {
+func (c *criService) getIPs(sandbox sandboxstore.Sandbox) (string, []string, error) {
 	config := sandbox.Config
 
 	if goruntime.GOOS != "windows" &&
 		config.GetLinux().GetSecurityContext().GetNamespaceOptions().GetNetwork() == runtime.NamespaceMode_NODE {
 		// For sandboxes using the node network we are not
 		// responsible for reporting the IP.
-		return "", nil
+		return "", nil, nil
 	}
 
 	if closed, err := sandbox.NetNS.Closed(); err != nil {
-		return "", errors.Wrap(err, "check network namespace closed")
+		return "", nil, errors.Wrap(err, "check network namespace closed")
 	} else if closed {
-		return "", nil
+		return "", nil, nil
 	}
 
-	return sandbox.IP, nil
+	return sandbox.IP, sandbox.AdditionalIPs, nil
 }
 
 // toCRISandboxStatus converts sandbox metadata into CRI pod sandbox status.
-func toCRISandboxStatus(meta sandboxstore.Metadata, status sandboxstore.Status, ip string) *runtime.PodSandboxStatus {
+func toCRISandboxStatus(meta sandboxstore.Metadata, status sandboxstore.Status, ip string, additionalIPs []string) *runtime.PodSandboxStatus {
 	// Set sandbox state to NOTREADY by default.
 	state := runtime.PodSandboxState_SANDBOX_NOTREADY
 	if status.State == sandboxstore.StateReady {
@@ -99,7 +99,7 @@ func toCRISandboxStatus(meta sandboxstore.Metadata, status sandboxstore.Status, 
 		Metadata:  meta.Config.GetMetadata(),
 		State:     state,
 		CreatedAt: status.CreatedAt.UnixNano(),
-		Network:   &runtime.PodSandboxNetworkStatus{Ip: ip},
+		Network:   &runtime.PodSandboxNetworkStatus{Ip: ip, AdditionalIPs: additionalIPs},
 		Linux: &runtime.LinuxPodSandboxStatus{
 			Namespaces: &runtime.Namespace{
 				Options: &runtime.NamespaceOption{

--- a/pkg/server/sandbox_status_test.go
+++ b/pkg/server/sandbox_status_test.go
@@ -99,7 +99,86 @@ func TestPodSandboxStatus(t *testing.T) {
 			State:     test.state,
 		}
 		expected.State = test.expectedState
-		got := toCRISandboxStatus(metadata, status, ip)
+		got := toCRISandboxStatus(metadata, status, ip, nil)
+		assert.Equal(t, expected, got)
+	}
+}
+
+func TestPodSandboxStatusDualStack(t *testing.T) {
+	const (
+		id = "test-id"
+		ip = "10.10.10.10"
+	)
+	var additionalIPs = []string{"fd00:10:10::10"}
+	createdAt := time.Now()
+	config := &runtime.PodSandboxConfig{
+		Metadata: &runtime.PodSandboxMetadata{
+			Name:      "test-name",
+			Uid:       "test-uid",
+			Namespace: "test-ns",
+			Attempt:   1,
+		},
+		Linux: &runtime.LinuxPodSandboxConfig{
+			SecurityContext: &runtime.LinuxSandboxSecurityContext{
+				NamespaceOptions: &runtime.NamespaceOption{
+					Network: runtime.NamespaceMode_NODE,
+					Pid:     runtime.NamespaceMode_CONTAINER,
+					Ipc:     runtime.NamespaceMode_POD,
+				},
+			},
+		},
+		Labels:      map[string]string{"a": "b"},
+		Annotations: map[string]string{"c": "d"},
+	}
+	metadata := sandboxstore.Metadata{
+		ID:             id,
+		Name:           "test-name",
+		Config:         config,
+		RuntimeHandler: "test-runtime-handler",
+	}
+
+	expected := &runtime.PodSandboxStatus{
+		Id:        id,
+		Metadata:  config.GetMetadata(),
+		CreatedAt: createdAt.UnixNano(),
+		Network:   &runtime.PodSandboxNetworkStatus{Ip: ip, AdditionalIPs: additionalIPs},
+		Linux: &runtime.LinuxPodSandboxStatus{
+			Namespaces: &runtime.Namespace{
+				Options: &runtime.NamespaceOption{
+					Network: runtime.NamespaceMode_NODE,
+					Pid:     runtime.NamespaceMode_CONTAINER,
+					Ipc:     runtime.NamespaceMode_POD,
+				},
+			},
+		},
+		Labels:         config.GetLabels(),
+		Annotations:    config.GetAnnotations(),
+		RuntimeHandler: "test-runtime-handler",
+	}
+	for desc, test := range map[string]struct {
+		state         sandboxstore.State
+		expectedState runtime.PodSandboxState
+	}{
+		"sandbox state ready": {
+			state:         sandboxstore.StateReady,
+			expectedState: runtime.PodSandboxState_SANDBOX_READY,
+		},
+		"sandbox state not ready": {
+			state:         sandboxstore.StateNotReady,
+			expectedState: runtime.PodSandboxState_SANDBOX_NOTREADY,
+		},
+		"sandbox state unknown": {
+			state:         sandboxstore.StateUnknown,
+			expectedState: runtime.PodSandboxState_SANDBOX_NOTREADY,
+		},
+	} {
+		t.Logf("TestCase: %s", desc)
+		status := sandboxstore.Status{
+			CreatedAt: createdAt,
+			State:     test.state,
+		}
+		expected.State = test.expectedState
+		got := toCRISandboxStatus(metadata, status, ip, additionalIPs)
 		assert.Equal(t, expected, got)
 	}
 }

--- a/pkg/store/sandbox/metadata.go
+++ b/pkg/store/sandbox/metadata.go
@@ -55,6 +55,8 @@ type Metadata struct {
 	NetNSPath string
 	// IP of Pod if it is attached to non host network
 	IP string
+	// AdditionalIPs of the Pod if it is attached to no host network
+	AdditionalIPs []string
 	// RuntimeHandler is the runtime handler name of the pod.
 	RuntimeHandler string
 	// CNIresult resulting configuration for attached network namespace interfaces


### PR DESCRIPTION
Currently containerd only reports one IP per pod using the CRI-API.

However, since [kubernetes v1.16](https://github.com/kubernetes/cri-api/commit/290df9462a03994892048d64a91a836fea4f2877), the API was extended to support dual stack clusters, allowing multiple IPs per pod.

Fixes: https://github.com/kubernetes/kubernetes/issues/82634



