### PR TITLE
Add back default UNIX env to container config

### DIFF
--- a/pkg/server/container_create_unix.go
+++ b/pkg/server/container_create_unix.go
@@ -112,6 +112,7 @@ func (c *criService) containerSpec(id string, sandboxID string, sandboxPid uint3
 		customopts.WithoutDefaultSecuritySettings,
 		customopts.WithRelativeRoot(relativeRootfsPath),
 		customopts.WithProcessArgs(config, imageConfig),
+		oci.WithDefaultPathEnv,
 		// this will be set based on the security context below
 		oci.WithNewPrivileges,
 	}

--- a/pkg/server/container_create_unix_test.go
+++ b/pkg/server/container_create_unix_test.go
@@ -269,6 +269,27 @@ func TestContainerSpecTty(t *testing.T) {
 	}
 }
 
+func TestContainerSpecDefaultPath(t *testing.T) {
+	testID := "test-id"
+	testSandboxID := "sandbox-id"
+	testPid := uint32(1234)
+	expectedDefault := "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	containerConfig, sandboxConfig, imageConfig, specCheck := getCreateContainerTestData()
+	ociRuntime := config.Runtime{}
+	c := newTestCRIService()
+	for _, pathenv := range []string{"", "PATH=/usr/local/bin/games"} {
+		expected := expectedDefault
+		if pathenv != "" {
+			imageConfig.Env = append(imageConfig.Env, pathenv)
+			expected = pathenv
+		}
+		spec, err := c.containerSpec(testID, testSandboxID, testPid, "", containerConfig, sandboxConfig, imageConfig, nil, ociRuntime)
+		require.NoError(t, err)
+		specCheck(t, testID, testSandboxID, testPid, spec)
+		assert.Contains(t, spec.Process.Env, expected)
+	}
+}
+
 func TestContainerSpecReadonlyRootfs(t *testing.T) {
 	testID := "test-id"
 	testSandboxID := "sandbox-id"


### PR DESCRIPTION
Fixes: #1279 

Due to [changes to the defaults in containerd](https://github.com/containerd/containerd/pull/3551), the CRI path to creating a
container OCI config needs to add back in the default UNIX $PATH (and
any other defaults) as that is the expected behavior from other
runtimes.

This is a miss from our fix released in 1.2.9 after breaking in 1.2.8 with the standard path in containerd via the API and `ctr` client (reported in [containerd issue #3597](https://github.com/containerd/containerd/issues/3597) and fixed in [containerd PR #3599](https://github.com/containerd/containerd/pull/3599))

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>