### PR TITLE
Move golangci-lint configuration out of Makefile

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,22 @@
+linters:
+  enable:
+    - structcheck
+    - varcheck
+    - staticcheck
+    - unconvert
+    - gofmt
+    - goimports
+    - golint
+    - ineffassign
+    - vet
+    - unused
+    - misspell
+  disable:
+    - errcheck
+
+run:
+  deadline: 2m
+  skip-dirs:
+    - integration
+  skip-files:
+    - ".*_test.go" 

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ version: ## print current cri plugin release version
 
 lint:
 	@echo "$(WHALE) $@"
-	golangci-lint run --skip-files .*_test.go --skip-dirs='(integration)'
+	golangci-lint run
 
 gofmt:
 	@echo "$(WHALE) $@"

--- a/pkg/containerd/opts/spec_unix.go
+++ b/pkg/containerd/opts/spec_unix.go
@@ -124,7 +124,7 @@ func WithMounts(osi osinterface.OS, config *runtime.ContainerConfig, extra []*ru
 			criMounts = config.GetMounts()
 			mounts    = append([]*runtime.Mount{}, criMounts...)
 		)
-		// Copy all mounts from extra mounts, except for mounts overriden by CRI.
+		// Copy all mounts from extra mounts, except for mounts overridden by CRI.
 		for _, e := range extra {
 			found := false
 			for _, c := range criMounts {
@@ -151,7 +151,7 @@ func WithMounts(osi osinterface.OS, config *runtime.ContainerConfig, extra []*ru
 		})
 
 		// Copy all mounts from default mounts, except for
-		// - mounts overriden by supplied mount;
+		// - mounts overridden by supplied mount;
 		// - all mounts under /dev if a supplied /dev is present.
 		mountSet := make(map[string]struct{})
 		for _, m := range mounts {
@@ -202,7 +202,7 @@ func WithMounts(osi osinterface.OS, config *runtime.ContainerConfig, extra []*ru
 			switch mount.GetPropagation() {
 			case runtime.MountPropagation_PROPAGATION_PRIVATE:
 				options = append(options, "rprivate")
-				// Since default root propogation in runc is rprivate ignore
+				// Since default root propagation in runc is rprivate ignore
 				// setting the root propagation
 			case runtime.MountPropagation_PROPAGATION_BIDIRECTIONAL:
 				if err := ensureShared(src, osi.(osinterface.UNIX).LookupMount); err != nil {

--- a/pkg/containerd/opts/spec_windows.go
+++ b/pkg/containerd/opts/spec_windows.go
@@ -58,7 +58,7 @@ func WithWindowsMounts(osi osinterface.OS, config *runtime.ContainerConfig, extr
 			criMounts = config.GetMounts()
 			mounts    = append([]*runtime.Mount{}, criMounts...)
 		)
-		// Copy all mounts from extra mounts, except for mounts overriden by CRI.
+		// Copy all mounts from extra mounts, except for mounts overridden by CRI.
 		for _, e := range extra {
 			found := false
 			for _, c := range criMounts {
@@ -77,7 +77,7 @@ func WithWindowsMounts(osi osinterface.OS, config *runtime.ContainerConfig, extr
 		sort.Sort(orderedMounts(mounts))
 
 		// Copy all mounts from default mounts, except for
-		// - mounts overriden by supplied mount;
+		// - mounts overridden by supplied mount;
 		// - all mounts under /dev if a supplied /dev is present.
 		mountSet := make(map[string]struct{})
 		for _, m := range mounts {

--- a/pkg/netns/netns_windows.go
+++ b/pkg/netns/netns_windows.go
@@ -33,7 +33,7 @@ func NewNetNS() (*NetNS, error) {
 		return nil, err
 	}
 
-	return &NetNS{path: string(hcnNamespace.Id)}, nil
+	return &NetNS{path: hcnNamespace.Id}, nil
 }
 
 // LoadNetNS loads existing network namespace.


### PR DESCRIPTION
Add 2m deadline; similar to containerd, recent issues with golangci-lint
taking more than 1 minute. This has been seen in recent containerd/cri PRs as well (recent [example](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/containerd_cri/1280/pull-cri-containerd-verify/1174669796445261825/)).

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>