### PR TITLE
[release/1.2] Backport fix for default UNIX environment in OCI container config

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -264,6 +264,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get runtime options")
 	}
+
 	opts = append(opts,
 		containerd.WithSpec(spec, specOpts...),
 		containerd.WithRuntime(sandboxInfo.Runtime.Name, runtimeOptions),
@@ -904,6 +905,8 @@ func defaultRuntimeSpec(id string) (*runtimespec.Spec, error) {
 	}
 	if spec.Linux != nil {
 		spec.Linux.Seccomp = nil
+		// add default UNIX path; will be optionally overwritten by image config PATH env
+		spec.Process.Env = append(spec.Process.Env, "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
 	}
 
 	// Remove default rlimits (See issue #515)

--- a/pkg/server/container_create_test.go
+++ b/pkg/server/container_create_test.go
@@ -287,6 +287,26 @@ func TestContainerSpecTty(t *testing.T) {
 	}
 }
 
+func TestContainerSpecDefaultPath(t *testing.T) {
+	testID := "test-id"
+	testSandboxID := "sandbox-id"
+	testPid := uint32(1234)
+	expectedDefault := "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+	containerConfig, sandboxConfig, imageConfig, specCheck := getCreateContainerTestData()
+	c := newTestCRIService()
+	for _, pathenv := range []string{"", "PATH=/usr/local/bin/games"} {
+		expected := expectedDefault
+		if pathenv != "" {
+			imageConfig.Env = append(imageConfig.Env, pathenv)
+			expected = pathenv
+		}
+		spec, err := c.generateContainerSpec(testID, testSandboxID, testPid, containerConfig, sandboxConfig, imageConfig, nil)
+		require.NoError(t, err)
+		specCheck(t, testID, testSandboxID, testPid, spec)
+		assert.Contains(t, spec.Process.Env, expected)
+	}
+}
+
 func TestContainerSpecReadonlyRootfs(t *testing.T) {
 	testID := "test-id"
 	testSandboxID := "sandbox-id"


### PR DESCRIPTION
Backport test from #1280; harcoded `defaultUnixEnv` from containerd/containerd brought into the spec generator sequence, as there is no clear way to fix the bug using the `oci.With..` helper in this design.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>