### PR TITLE
Document simpler kube-up.sh

### DIFF
--- a/docs/kube-up.md
+++ b/docs/kube-up.md
@@ -1,6 +1,11 @@
 # Production Quality Cluster on GCE
 This document provides the steps to bring up a production quality cluster on GCE with [`kube-up.sh`](https://kubernetes.io/docs/setup/turnkey/gce/).
 
+**If your Kubernetes version is 1.15 or greater, you can simply run:**
+```
+export KUBE_CONTAINER_RUNTIME=containerd
+```
+Follow these instructions [here](https://kubernetes.io/docs/setup/turnkey/gce/) to create a production quality Kubernetes cluster on GCE.
 ## Download CRI-Containerd Release Tarball
 To download release tarball, see [step 1](./installation.md#step-1-download-cri-containerd-release-tarball) in installation.md.
 


### PR DESCRIPTION
Now we just need a simple `KUBE_CONTAINER_RUNTIME=containerd` environment variable before kube-up.sh.