### PR TITLE
Update hcsshim to c088f411aaf3585d8dffc9deb4289ffa32854497.

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -48,7 +48,7 @@ github.com/containerd/containerd 59a625defb21c958c25424fa5cc806167e22382e
 github.com/containerd/console 0650fd9eeb50bab4fc99dceb9f2e14cf58f36e7f
 github.com/containerd/cgroups c4b9ac5c7601384c965b9646fc515884e091ebb9
 github.com/beorn7/perks 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
-github.com/Microsoft/hcsshim 1354cb2e878d37d2f5c11595634290ea9e2600a1 # TODO(windows): update this in containerd/containerd
+github.com/Microsoft/hcsshim c088f411aaf3585d8dffc9deb4289ffa32854497 # TODO(windows): update this in containerd/containerd
 github.com/Microsoft/go-winio v0.4.14
 github.com/BurntSushi/toml v0.3.1
 


### PR DESCRIPTION
Update hcsshim to fix the "namespace is required" error:
```
time="2019-09-24T05:59:34.749740900Z" level=error msg=Span duration=0s endTime="2019-09-24 05:59:34.7497409 +0000 GMT m=+14.068572301" error="namespace is required: failed precondition" name=publishEvent parentSpanID=e1cfaf6f314ab5db spanID=48465af455147951 startTime="2019-09-24 05:59:34.7497409 +0000 GMT m=+14.068572301" topic=/tasks/exit traceID=a7d80c2d887a9b8285a25cd754f2a854
```

The commit we need https://github.com/microsoft/hcsshim/commit/c088f411aaf3585d8dffc9deb4289ffa32854497

Signed-off-by: Lantao Liu <lantaol@google.com>