### PR TITLE
Forward SandboxConfig.Hostname to Workload container activation

### DIFF
--- a/pkg/server/container_create_windows.go
+++ b/pkg/server/container_create_windows.go
@@ -63,6 +63,7 @@ func (c *criService) containerSpec(id string, sandboxID string, sandboxPid uint3
 		// NOTE: readonly rootfs doesn't work on windows.
 		customopts.WithoutRoot,
 		customopts.WithWindowsNetworkNamespace(netNSPath),
+		oci.WithHostname(sandboxConfig.GetHostname()),
 	)
 
 	specOpts = append(specOpts, customopts.WithWindowsMounts(c.os, config, extraMounts))


### PR DESCRIPTION
For https://github.com/containerd/cri/issues/1257

1. For Windows the Hostname property is not inherited from the sandbox and must
be passed for the Workload container activations as well.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>