### PR TITLE
Set default sandbox container cpu shares on windows.

### DIFF
--- a/pkg/containerd/opts/spec.go
+++ b/pkg/containerd/opts/spec.go
@@ -31,6 +31,10 @@ import (
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
+// DefaultSandboxCPUshares is default cpu shares for sandbox container.
+// TODO(windows): Revisit cpu shares for windows (https://github.com/containerd/cri/issues/1297)
+const DefaultSandboxCPUshares = 2
+
 // WithRelativeRoot sets the root for the container
 func WithRelativeRoot(root string) oci.SpecOpts {
 	return func(ctx context.Context, client oci.Client, c *containers.Container, s *runtimespec.Spec) (err error) {

--- a/pkg/containerd/opts/spec_unix.go
+++ b/pkg/containerd/opts/spec_unix.go
@@ -43,13 +43,6 @@ import (
 	"github.com/containerd/cri/pkg/util"
 )
 
-const (
-	// DefaultSandboxCPUshares is default cpu shares for sandbox container.
-	// TODO(windows): Evaluate whether this can be used for windows sandbox
-	// container cpu shares.
-	DefaultSandboxCPUshares = 2
-)
-
 // WithAdditionalGIDs adds any additional groups listed for a particular user in the
 // /etc/groups file of the image's root filesystem to the OCI spec's additionalGids array.
 func WithAdditionalGIDs(userstr string) oci.SpecOpts {

--- a/pkg/containerd/opts/spec_windows.go
+++ b/pkg/containerd/opts/spec_windows.go
@@ -172,3 +172,19 @@ func WithWindowsResources(resources *runtime.WindowsContainerResources) oci.Spec
 		return nil
 	}
 }
+
+// WithWindowsDefaultSandboxShares sets the default sandbox CPU shares
+func WithWindowsDefaultSandboxShares(ctx context.Context, client oci.Client, c *containers.Container, s *runtimespec.Spec) error {
+	if s.Windows == nil {
+		s.Windows = &runtimespec.Windows{}
+	}
+	if s.Windows.Resources == nil {
+		s.Windows.Resources = &runtimespec.WindowsResources{}
+	}
+	if s.Windows.Resources.CPU == nil {
+		s.Windows.Resources.CPU = &runtimespec.WindowsCPUResources{}
+	}
+	i := uint16(DefaultSandboxCPUshares)
+	s.Windows.Resources.CPU.Shares = &i
+	return nil
+}

--- a/pkg/server/sandbox_run_windows.go
+++ b/pkg/server/sandbox_run_windows.go
@@ -30,7 +30,6 @@ import (
 	customopts "github.com/containerd/cri/pkg/containerd/opts"
 )
 
-// TODO(windows): Configure windows sandbox shares
 func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxConfig,
 	imageConfig *imagespec.ImageConfig, nsPath string, runtimePodAnnotations []string) (*runtimespec.Spec, error) {
 	// Creates a spec Generator with the default spec.
@@ -54,6 +53,8 @@ func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 		customopts.WithoutRoot,
 		customopts.WithWindowsNetworkNamespace(nsPath),
 	)
+
+	specOpts = append(specOpts, customopts.WithWindowsDefaultSandboxShares)
 
 	for pKey, pValue := range getPassthroughAnnotations(config.Annotations,
 		runtimePodAnnotations) {

--- a/pkg/server/sandbox_run_windows_test.go
+++ b/pkg/server/sandbox_run_windows_test.go
@@ -27,6 +27,7 @@ import (
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 
 	"github.com/containerd/cri/pkg/annotations"
+	"github.com/containerd/cri/pkg/containerd/opts"
 )
 
 func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConfig, func(*testing.T, string, *runtimespec.Spec)) {
@@ -54,6 +55,7 @@ func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConf
 		assert.Contains(t, spec.Process.Env, "a=b", "c=d")
 		assert.Equal(t, []string{"/pause", "forever"}, spec.Process.Args)
 		assert.Equal(t, "/workspace", spec.Process.Cwd)
+		assert.EqualValues(t, *spec.Windows.Resources.CPU.Shares, opts.DefaultSandboxCPUshares)
 
 		t.Logf("Check PodSandbox annotations")
 		assert.Contains(t, spec.Annotations, annotations.SandboxID)


### PR DESCRIPTION
For https://github.com/containerd/cri/issues/1257

This PR sets the same default sandbox container cpu shares on windows.

For more details about this, see https://github.com/containerd/cri/issues/1297

@yujuhong @jterry75 
Signed-off-by: Lantao Liu <lantaol@google.com>