### PR TITLE
[release/1.0] Make sure exec process is killed when context is canceled.

### DIFF
--- a/pkg/server/container_execsync.go
+++ b/pkg/server/container_execsync.go
@@ -131,7 +131,7 @@ func (c *criService) execInContainer(ctx context.Context, id string, opts execOp
 	defer func() {
 		deferCtx, deferCancel := ctrdutil.DeferContext()
 		defer deferCancel()
-		if _, err := process.Delete(deferCtx); err != nil {
+		if _, err := process.Delete(deferCtx, containerd.WithProcessKill); err != nil {
 			logrus.WithError(err).Errorf("Failed to delete exec process %q for container %q", execID, id)
 		}
 	}()


### PR DESCRIPTION
Cherrypick https://github.com/containerd/cri/pull/1156 into release/1.0

I think this is the only pre-August thing we need to backport from the commits https://github.com/containerd/cri/commits/release/1.2

Signed-off-by: Lantao Liu <lantaol@google.com>