### PR TITLE
[release/1.3] Update cri-tools to v1.16.1.

### DIFF
--- a/hack/test-cri.sh
+++ b/hack/test-cri.sh
@@ -52,7 +52,8 @@ if [ ! -x "$(command -v ${CRITEST})" ]; then
   cd ${GOPATH}/src/${CRITOOL_PKG}
   git fetch --all
   git checkout ${CRITOOL_VERSION}
-  make
+  make critest
+  make install-critest -e BINDIR="${GOPATH}/bin"
 fi
 which ${CRITEST}
 

--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -17,7 +17,7 @@
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
 
 # Not from vendor.conf.
-CRITOOL_VERSION=v1.15.0
+CRITOOL_VERSION=v1.16.1
 CRITOOL_PKG=github.com/kubernetes-sigs/cri-tools
 CRITOOL_REPO=github.com/kubernetes-sigs/cri-tools
 


### PR DESCRIPTION
Let's update cri-tools to the newest release, which includes many useful bug fixes and features.

Signed-off-by: Lantao Liu <lantaol@google.com>