### PR TITLE
[WCOW] Extend permission denied retry to 3min.

### DIFF
--- a/test/windows/runner.sh
+++ b/test/windows/runner.sh
@@ -49,7 +49,7 @@ function retry_anyway() {
 }
 
 function retry_on_permission_error() {
-  retry_on_error 12 5 "Permission denied" "$@"
+  retry_on_error 36 5 "Permission denied" "$@"
 }
 
 function retry_on_error() {


### PR DESCRIPTION
Sometimes it recovers in a second retry: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-cri-containerd-cri-validation-windows/1177420340528156672.

However, sometimes it doesn't even recover after 1 min: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-cri-containerd-cri-validation-windows/1177404990424092672

Let's extend the timeout to be the same with ssh ready. If it still doesn't work, we need to look into this further.

/cc @yujuhong 
Signed-off-by: Lantao Liu <lantaol@google.com>