### PR TITLE
Explicitly specify trusty in travis.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,7 +22,7 @@ install:
   - ps: $psversiontable
 
 build_script:
-  - bash.exe -elc "mingw32-make"
+  - bash.exe -elc "mingw32-make.exe"
 
 test_script:
-  - bash.exe -elc "mingw32-make test"
+  - bash.exe -elc "mingw32-make.exe test"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,5 +18,6 @@ run:
   deadline: 2m
   skip-dirs:
     - integration
+    - pkg/api
   skip-files:
-    - ".*_test.go" 
+    - ".*_test.go"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,16 +21,14 @@ cache:
     - "${HOME}/google-cloud-sdk/"
 
 before_install:
-  # libseccomp in trusty is not new enough, need backports version.
-  - sudo sh -c "echo 'deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse' > /etc/apt/sources.list.d/backports.list"
   - sudo apt-get update
   # Enable ipv6 for dualstack integration test.
   - sudo sysctl net.ipv6.conf.all.disable_ipv6=0
 
 install:
   - sudo apt-get install btrfs-tools
-  - sudo apt-get install libseccomp2/trusty-backports
-  - sudo apt-get install libseccomp-dev/trusty-backports
+  - sudo apt-get install libseccomp2
+  - sudo apt-get install libseccomp-dev
   - sudo apt-get install socat
 
 before_script:

--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,10 @@ install.tools: .install.gitvalidation .install.golangci-lint .install.vndr ## in
 
 .install.golangci-lint:
 	@echo "$(WHALE) $@"
-	$(GO) get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+	$(GO) get -d github.com/golangci/golangci-lint/cmd/golangci-lint
+	@cd $(GOPATH)/src/github.com/golangci/golangci-lint/cmd/golangci-lint; \
+		git checkout v1.18.0; \
+		go install
 
 .install.vndr:
 	@echo "$(WHALE) $@"

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"fmt"
 	"net"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -63,11 +64,12 @@ var criRoot = flag.String("cri-root", "/var/lib/containerd/io.containerd.grpc.v1
 var runtimeHandler = flag.String("runtime-handler", "", "The runtime handler to use in the test.")
 var containerdBin = flag.String("containerd-bin", "containerd", "The containerd binary name. The name is used to restart containerd during test.")
 
-func init() {
+func TestMain(m *testing.M) {
 	flag.Parse()
 	if err := ConnectDaemons(); err != nil {
 		logrus.WithError(err).Fatalf("Failed to connect daemons")
 	}
+	os.Exit(m.Run())
 }
 
 // ConnectDaemons connect cri plugin and containerd, and initialize the clients.


### PR DESCRIPTION
Fixes https://github.com/containerd/cri/issues/1311.

This PR:
1) Fixes appveyor test. Command without `.exe` stopped working somehow.
2) Fixes golangci-lint version (same with containerd/containerd). We hit a lot of unexpected verification timeout failures.
3) Updates `.travis.yml` based on new default ubuntu distro `xenial`. https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment
4) Updates integration test to work with golang 1.13 https://github.com/golang/go/issues/31859#issuecomment-532415187


2 and 3 should be cherry-picked.

Signed-off-by: Lantao Liu <lantaol@google.com>