### PR TITLE
Containerd version updated for kubernetes ansible example.

### DIFF
--- a/contrib/ansible/vars/vars.yaml
+++ b/contrib/ansible/vars/vars.yaml
@@ -1,4 +1,4 @@
 ---
-containerd_release_version: 1.1.0-rc.0
+containerd_release_version: 1.3.0
 cni_bin_dir: /opt/cni/bin/
 cni_conf_dir: /etc/cni/net.d/


### PR DESCRIPTION
Closes #1317 

Old version of containerd causes kubectl exec error like described in #856 