### PR TITLE
Fix containerd build, use `libbtrfs-dev` when available.

### DIFF
--- a/test/build-utils.sh
+++ b/test/build-utils.sh
@@ -30,7 +30,11 @@ gcloud auth activate-service-account --key-file "${GOOGLE_APPLICATION_CREDENTIAL
 
 # Install dependent libraries.
 apt-get update
-apt-get install -y btrfs-tools
+if apt-cache show libbtrfs-dev > /dev/null; then
+  apt-get install -y libbtrfs-dev
+else
+  apt-get install -y btrfs-tools
+fi
 
 # Kubernetes test infra uses jessie and stretch.
 if cat /etc/os-release | grep jessie; then


### PR DESCRIPTION
The test image was updated recently, and the `btrfs-tools` version was updated to `4.20.1-2` which doesn't contain `btrfs/ioctl.h` any more.

Here is the error message without this fix:
```
W1017 18:52:29.516] vendor/github.com/containerd/btrfs/btrfs.go:38:10: fatal error: btrfs/ioctl.h: No such file or directory
W1017 18:52:29.516]  #include <btrfs/ioctl.h>
W1017 18:52:29.516]           ^~~~~~~~~~~~~~~
W1017 18:52:29.517] compilation terminated.
```

Signed-off-by: Lantao Liu <lantaol@google.com>