### PR TITLE
[release/1.0] Fix containerd build, use `libbtrfs-dev` when available.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,12 @@ cache:
         - "${HOME}/google-cloud-sdk/"
 
 before_install:
-    # libseccomp in trusty is not new enough, need backports version.
-    - sudo sh -c "echo 'deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse' > /etc/apt/sources.list.d/backports.list"
     - sudo apt-get update
 
 install:
     - sudo apt-get install btrfs-tools
-    - sudo apt-get install libseccomp2/trusty-backports
-    - sudo apt-get install libseccomp-dev/trusty-backports
+    - sudo apt-get install libseccomp2
+    - sudo apt-get install libseccomp-dev
     - sudo apt-get install socat
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,14 @@ jobs:
         - make containerd
         - sudo make install-containerd
         - make test
+        # Use a different port for stream server to avoid
+        # conflict with the docker-containerd.
+        - |
+          sudo mkdir -p /etc/containerd
+          sudo bash -c 'cat > /etc/containerd/config.toml <<EOF
+          [plugins.cri]
+            stream_server_port = "10011"
+          EOF'
         - make test-integration
         - make test-cri
       after_script:

--- a/test/build-utils.sh
+++ b/test/build-utils.sh
@@ -30,7 +30,11 @@ gcloud auth activate-service-account --key-file "${GOOGLE_APPLICATION_CREDENTIAL
 
 # Install dependent libraries.
 apt-get update
-apt-get install -y btrfs-tools
+if apt-cache show libbtrfs-dev > /dev/null; then
+  apt-get install -y libbtrfs-dev
+else
+  apt-get install -y btrfs-tools
+fi
 
 # Kubernetes test infra uses jessie and stretch.
 if cat /etc/os-release | grep jessie; then


### PR DESCRIPTION
Cherrypick #1319 to release/1.0.
Cherrypick #1312 to release/1.0.

We won't add new bug fix or feature into release/1.0, but this change is needed to fix the build. https://k8s-testgrid.appspot.com/sig-node-containerd#containerd-build-1.1

Signed-off-by: Lantao Liu <lantaol@google.com>