### PR TITLE
[release/1.3] Fix containerd build, use `libbtrfs-dev` when available.

### DIFF
--- a/test/build-utils.sh
+++ b/test/build-utils.sh
@@ -30,7 +30,11 @@ gcloud auth activate-service-account --key-file "${GOOGLE_APPLICATION_CREDENTIAL
 
 # Install dependent libraries.
 apt-get update
-apt-get install -y btrfs-tools
+if apt-cache show libbtrfs-dev > /dev/null; then
+  apt-get install -y libbtrfs-dev
+else
+  apt-get install -y btrfs-tools
+fi
 
 # Kubernetes test infra uses jessie and stretch.
 if cat /etc/os-release | grep jessie; then


### PR DESCRIPTION
Cherrypick #1319 to release/1.3

Signed-off-by: Lantao Liu <lantaol@google.com>