### PR TITLE
Use `http` for localhost and 127.0.0.1 by default.

### DIFF
--- a/pkg/server/image_pull.go
+++ b/pkg/server/image_pull.go
@@ -310,6 +310,10 @@ func (c *criService) registryHosts(auth *runtime.AuthConfig) docker.RegistryHost
 				config    = c.config.Registry.Configs[u.Host]
 			)
 
+			if u.Scheme == "" {
+				u.Scheme = defaultScheme(u.Host)
+			}
+
 			if u.Scheme != "https" && config.TLS != nil {
 				return nil, errors.Errorf("tls provided for http endpoint %q", e)
 			}
@@ -344,6 +348,18 @@ func (c *criService) registryHosts(auth *runtime.AuthConfig) docker.RegistryHost
 		}
 		return registries, nil
 	}
+}
+
+// defaultScheme returns the default scheme for a registry host.
+func defaultScheme(host string) string {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	if host == "localhost" || host == "127.0.0.1" ||
+		host == "::1" {
+		return "http"
+	}
+	return "https"
 }
 
 // registryEndpoints returns endpoints for a given host.

--- a/pkg/server/image_pull_test.go
+++ b/pkg/server/image_pull_test.go
@@ -236,3 +236,55 @@ func TestRegistryEndpoints(t *testing.T) {
 		assert.Equal(t, test.expected, got)
 	}
 }
+
+func TestDefaultScheme(t *testing.T) {
+	for desc, test := range map[string]struct {
+		host     string
+		expected string
+	}{
+		"should use http by default for localhost": {
+			host:     "localhost",
+			expected: "http",
+		},
+		"should use http by default for localhost with port": {
+			host:     "localhost:8080",
+			expected: "http",
+		},
+		"should use http by default for 127.0.0.1": {
+			host:     "127.0.0.1",
+			expected: "http",
+		},
+		"should use http by default for 127.0.0.1 with port": {
+			host:     "127.0.0.1:8080",
+			expected: "http",
+		},
+		"should use http by default for ::1": {
+			host:     "::1",
+			expected: "http",
+		},
+		"should use http by default for ::1 with port": {
+			host:     "[::1]:8080",
+			expected: "http",
+		},
+		"should use https by default for remote host": {
+			host:     "remote",
+			expected: "https",
+		},
+		"should use https by default for remote host with port": {
+			host:     "remote:8080",
+			expected: "https",
+		},
+		"should use https by default for remote ip": {
+			host:     "8.8.8.8",
+			expected: "https",
+		},
+		"should use https by default for remote ip with port": {
+			host:     "8.8.8.8:8080",
+			expected: "https",
+		},
+	} {
+		t.Logf("TestCase %q", desc)
+		got := defaultScheme(test.host)
+		assert.Equal(t, test.expected, got)
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/containerd/cri/issues/1327.

This changes the behavior to be consistent with Docker. We should make sure we mention this in the release note.

/cc @liyimeng 

Signed-off-by: Lantao Liu <lantaol@google.com>