### PR TITLE
Update support metrics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,22 +35,20 @@ See [test dashboard](https://k8s-testgrid.appspot.com/sig-node-containerd)
 |:----------------------:|:------------------:|:------------------:|:-----------:|
 |     v1.0.0-alpha.x     |                    |      1.7, 1.8      |   v1alpha1  |
 |      v1.0.0-beta.x     |                    |        1.9         |   v1alpha1  |
-|       End-Of-Life      |        v1.1        |        1.10+       |   v1alpha2  |
+|       End-Of-Life      | v1.1 (End-Of-Life) |        1.10+       |   v1alpha2  |
 |                        |        v1.2        |        1.10+       |   v1alpha2  |
+|                        |        v1.3        |        1.12+       |   v1alpha2  |
 |                        |        HEAD        |        1.10+       |   v1alpha2  |
 
 **Note:** The support table above specifies the Kubernetes Version that was supported at time of release of the containerd - cri integration.
 
-The following is the current support table for containerd CRI integration taking into account that Kubernetes only supports n-3 minor release versions and 1.10 and 1.11 are now end-of-life.
+The following is the current support table for containerd CRI integration taking into account that Kubernetes only supports n-3 minor release versions.
 
 | Containerd Version | Kubernetes Version | CRI Version |
 |:------------------:|:------------------:|:-----------:|
-|        v1.1        |        1.12+       |   v1alpha2  |
-|        v1.2        |        1.12+       |   v1alpha2  |
-|        HEAD        |        1.12+       |   v1alpha2  |
-
-***Although not recommended, if you still plan to use containerd 1.2+ with Kubernetes
-<=1.11, please be sure to set `disable_proc_mount=true`.***
+|        v1.2        |        1.14+       |   v1alpha2  |
+|        v1.3        |        1.14+       |   v1alpha2  |
+|        HEAD        |        1.14+       |   v1alpha2  |
 
 ## Production Quality Cluster on GCE
 For a production quality cluster on GCE brought up with `kube-up.sh` refer [here](docs/kube-up.md).


### PR DESCRIPTION
Update support metrics to reflect that:
1) containerd 1.1 is end of life;
2) Kubernetes 1.13 is end of life.

Signed-off-by: Lantao Liu <lantaol@google.com>