### PR TITLE
Fix using `http` for localhost, 127.0.0.1 and ::1 by default

### DIFF
--- a/pkg/server/image_pull.go
+++ b/pkg/server/image_pull.go
@@ -310,10 +310,6 @@ func (c *criService) registryHosts(auth *runtime.AuthConfig) docker.RegistryHost
 				config    = c.config.Registry.Configs[u.Host]
 			)
 
-			if u.Scheme == "" {
-				u.Scheme = defaultScheme(u.Host)
-			}
-
 			if u.Scheme != "https" && config.TLS != nil {
 				return nil, errors.Errorf("tls provided for http endpoint %q", e)
 			}
@@ -355,8 +351,7 @@ func defaultScheme(host string) string {
 	if h, _, err := net.SplitHostPort(host); err == nil {
 		host = h
 	}
-	if host == "localhost" || host == "127.0.0.1" ||
-		host == "::1" {
+	if host == "localhost" || host == "127.0.0.1" || host == "::1" {
 		return "http"
 	}
 	return "https"
@@ -387,7 +382,7 @@ func (c *criService) registryEndpoints(host string) ([]string, error) {
 			return endpoints, nil
 		}
 	}
-	return append(endpoints, "https://"+defaultHost), nil
+	return append(endpoints, defaultScheme(defaultHost)+"://"+defaultHost), nil
 }
 
 // newTransport returns a new HTTP transport used to pull image.


### PR DESCRIPTION
It appears that PR #1328 for issue #1327 needs to be re-arranged a little to work, since c.registryEndpoints is pre-pending https the default scheme should be inserted there.

/cc @Random-Liu 