### PR TITLE
WIP: Update bandwidth max to uint64

### DIFF
--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -389,12 +389,12 @@ func toCNIBandWidth(annotations map[string]string) (*cni.BandWidth, error) {
 
 	if ingress != nil {
 		bandWidth.IngressRate = uint64(ingress.Value())
-		bandWidth.IngressBurst = math.MaxUint32
+		bandWidth.IngressBurst = math.MaxUint32 * 8 // no limit
 	}
 
 	if egress != nil {
 		bandWidth.EgressRate = uint64(egress.Value())
-		bandWidth.EgressBurst = math.MaxUint32
+		bandWidth.EgressBurst = math.MaxUint32 * 8 // no limit
 	}
 
 	return bandWidth, nil


### PR DESCRIPTION
The new version of the bandwidth plugin supports `uint64` as burst rates: https://github.com/containernetworking/plugins/pull/389 also Kubernetes is going to use the `uint64`: https://github.com/kubernetes/kubernetes/pull/82871

We need to mention this change in the release notes since we would have an "action required" block for this change