### PR TITLE
[WCOW] Add windows release tar for test

### DIFF
--- a/hack/install/utils.sh
+++ b/hack/install/utils.sh
@@ -16,11 +16,12 @@
 
 source $(dirname "${BASH_SOURCE[0]}")/../utils.sh
 
-# DESTDIR is the dest path to install dependencies.
+# DESTDIR is the absolute dest path to install dependencies.
 DESTDIR=${DESTDIR:-"/"}
-# Convert to absolute path if it's relative.
+# Make sure that DESTDIR is an absolute path.
 if [[ ${DESTDIR} != /* ]]; then
-  DESTDIR=${ROOT}/${DESTDIR}
+  echo "DESTDIR is not an absolute path"
+  exit 1
 fi
 
 # NOSUDO indicates not to use sudo during installation.

--- a/hack/install/windows/install-cni-config.sh
+++ b/hack/install/windows/install-cni-config.sh
@@ -74,7 +74,7 @@ bash -c 'cat >"'"${CNI_CONFIG_DIR}"'"/0-containerd-nat.conf <<EOF
         "subnet": "'$subnet'",
         "routes": [
             {
-                "gateway": "'$gateway'"
+                "GW": "'$gateway'"
             }
         ]
     },

--- a/hack/install/windows/install-cni.sh
+++ b/hack/install/windows/install-cni.sh
@@ -22,7 +22,7 @@ source $(dirname "${BASH_SOURCE[0]}")/../utils.sh
 # WINCNI_BIN_DIR is the cni plugin directory
 WINCNI_BIN_DIR="${WINCNI_BIN_DIR:-"C:\\Program Files\\containerd\\cni\\bin"}"
 WINCNI_PKG=github.com/Microsoft/windows-container-networking
-WINCNI_VERSION=33bc4764ea3ad7c6ec58c5716370d329f5eb1266
+WINCNI_VERSION=aa10a0b31e9f72937063436454def1760b858ee2
 
 # Create a temporary GOPATH for cni installation.
 GOPATH="$(mktemp -d /tmp/cri-install-cni.XXXX)"
@@ -30,8 +30,10 @@ GOPATH="$(mktemp -d /tmp/cri-install-cni.XXXX)"
 # Install cni
 checkout_repo "${WINCNI_PKG}" "${WINCNI_VERSION}" "${WINCNI_PKG}"
 cd "${GOPATH}/src/${WINCNI_PKG}"
-go build "${WINCNI_PKG}/plugins/nat"
-install -D -m 755 "nat.exe" "${WINCNI_BIN_DIR}/nat.exe"
+make all
+install -D -m 755 "out/nat.exe" "${WINCNI_BIN_DIR}/nat.exe"
+install -D -m 755 "out/sdnbridge.exe" "${WINCNI_BIN_DIR}/sdnbridge.exe"
+install -D -m 755 "out/sdnoverlay.exe" "${WINCNI_BIN_DIR}/sdnoverlay.exe"
 
 # Clean the tmp GOPATH dir.
 rm -rf "${GOPATH}"

--- a/hack/install/windows/install-hcsshim.sh
+++ b/hack/install/windows/install-hcsshim.sh
@@ -30,7 +30,7 @@ from-vendor HCSSHIM "${HCSSHIM_PKG}"
 checkout_repo "${HCSSHIM_PKG}" "${HCSSHIM_VERSION}" "${HCSSHIM_REPO}"
 cd "${GOPATH}/src/${HCSSHIM_PKG}"
 go build "${HCSSHIM_PKG}/cmd/containerd-shim-runhcs-v1"
-install -D -m 755 containerd-shim-runhcs-v1 "${HCSSHIM_DIR}"/containerd-shim-runhcs-v1
+install -D -m 755 containerd-shim-runhcs-v1.exe "${HCSSHIM_DIR}"/containerd-shim-runhcs-v1.exe
 
 # Clean the tmp GOPATH dir. Use sudo because runc build generates
 # some privileged files.

--- a/hack/release-windows.sh
+++ b/hack/release-windows.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Copyright The containerd Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source $(dirname "${BASH_SOURCE[0]}")/utils.sh
+cd ${ROOT}
+
+umask 0022
+
+# BUILD_DIR is the directory to generate release tar.
+# TARBALL is the name of the release tar.
+BUILD_DIR=${BUILD_DIR:-"_output"}
+# Convert to absolute path if it's relative.
+if [[ ${BUILD_DIR} != /* ]]; then
+  BUILD_DIR=${ROOT}/${BUILD_DIR}
+fi
+TARBALL=${TARBALL:-"cri-containerd.tar.gz"}
+# INCLUDE_CNI indicates whether to install CNI. By default don't
+# include CNI in release tarball.
+INCLUDE_CNI=${INCLUDE_CNI:-false}
+# CUSTOM_CONTAINERD indicates whether to install customized containerd
+# for CI test.
+CUSTOM_CONTAINERD=${CUSTOM_CONTAINERD:-false}
+
+destdir=${BUILD_DIR}/release-stage
+
+if [[ -z "${VERSION}" ]]; then
+  echo "VERSION is not set"
+  exit 1
+fi
+
+# Remove release-stage directory to avoid including old files.
+rm -rf ${destdir}
+
+# Install dependencies into release stage.
+# Install hcsshim
+HCSSHIM_DIR=${destdir} ./hack/install/windows/install-hcsshim.sh
+
+if ${INCLUDE_CNI}; then
+  # Install cni
+  NOSUDO=true WINCNI_BIN_DIR=${destdir}/cni ./hack/install/windows/install-cni.sh
+fi
+
+# Build containerd from source
+NOSUDO=true CONTAINERD_DIR=${destdir} ./hack/install/install-containerd.sh
+# Containerd makefile always installs into a "bin" directory.
+mv "${destdir}"/bin/* "${destdir}"
+rm -rf "${destdir}/bin"
+
+if ${CUSTOM_CONTAINERD}; then
+  make install -e BINDIR=${destdir}
+fi
+
+# Create release tar
+tarball=${BUILD_DIR}/${TARBALL}
+tar -zcvf ${tarball} -C ${destdir} . --owner=0 --group=0
+checksum=$(sha256 ${tarball})
+echo "sha256sum: ${checksum} ${tarball}"
+echo ${checksum} > ${tarball}.sha256

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -26,6 +26,10 @@ umask 0022
 # BUILD_DIR is the directory to generate release tar.
 # TARBALL is the name of the release tar.
 BUILD_DIR=${BUILD_DIR:-"_output"}
+# Convert to absolute path if it's relative.
+if [[ ${BUILD_DIR} != /* ]]; then
+  BUILD_DIR=${ROOT}/${BUILD_DIR}
+fi
 TARBALL=${TARBALL:-"cri-containerd.tar.gz"}
 # INCLUDE_CNI indicates whether to install CNI. By default don't
 # include CNI in release tarball.

--- a/test/windows/build.sh
+++ b/test/windows/build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Copyright The containerd Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is used to build and upload containerd with latest CRI plugin
+# from containerd/cri in gcr.io/k8s-testimages/kubekins-e2e.
+
+set -o xtrace
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source $(dirname "${BASH_SOURCE[0]}")/../build-utils.sh
+cd "${ROOT}"
+
+# Make sure output directory is clean.
+GOOS=windows make clean
+# Build and push test tarball.
+PUSH_VERSION=true DEPLOY_DIR=${DEPLOY_DIR:-"windows"} GOOS=windows \
+  make push TARBALL_PREFIX=cri-containerd-cni INCLUDE_CNI=true CUSTOM_CONTAINERD=true

--- a/vendor.conf
+++ b/vendor.conf
@@ -7,10 +7,10 @@ github.com/docker/distribution 0d3efadf0154c2b8a4e7b6621fff9809655cc580
 # containerd dependencies
 go.opencensus.io v0.22.0
 go.etcd.io/bbolt v1.3.3
-google.golang.org/grpc 6eaf6f47437a6b4e2153a190160ef39a92c7eceb # v1.23.0
+google.golang.org/grpc 39e8a7b072a67ca2a75f57fa2e0d50995f5b22f6 # v1.23.1
 google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
 golang.org/x/text 19e51611da83d6be54ddafce4a4af510cb3e9ea4
-golang.org/x/sys c990c680b611ac1aeb7d8f2af94a825f98d69720 https://github.com/golang/sys # TODO(windows): update this in containerd/containerd
+golang.org/x/sys c990c680b611ac1aeb7d8f2af94a825f98d69720 https://github.com/golang/sys
 golang.org/x/sync 42b317875d0fa942474b76e1b46a6060d720ae6e
 golang.org/x/net f3200d17e092c607f615320ecaad13d87ad9a2b3
 github.com/urfave/cli 7bc6a0acffa589f415f88aca16cc1de5ffd66f9c

--- a/vendor/google.golang.org/grpc/internal/transport/http2_server.go
+++ b/vendor/google.golang.org/grpc/internal/transport/http2_server.go
@@ -138,7 +138,10 @@ func newHTTP2Server(conn net.Conn, config *ServerConfig) (_ ServerTransport, err
 	}
 	framer := newFramer(conn, writeBufSize, readBufSize, maxHeaderListSize)
 	// Send initial settings as connection preface to client.
-	var isettings []http2.Setting
+	isettings := []http2.Setting{{
+		ID:  http2.SettingMaxFrameSize,
+		Val: http2MaxFrameLen,
+	}}
 	// TODO(zhaoq): Have a better way to signal "no limit" because 0 is
 	// permitted in the HTTP2 spec.
 	maxStreams := config.MaxStreams

--- a/vendor/google.golang.org/grpc/internal/transport/http_util.go
+++ b/vendor/google.golang.org/grpc/internal/transport/http_util.go
@@ -667,6 +667,7 @@ func newFramer(conn net.Conn, writeBufferSize, readBufferSize int, maxHeaderList
 		writer: w,
 		fr:     http2.NewFramer(w, r),
 	}
+	f.fr.SetMaxReadFrameSize(http2MaxFrameLen)
 	// Opt-in to Frame reuse API on framer to reduce garbage.
 	// Frames aren't safe to read from after a subsequent call to ReadFrame.
 	f.fr.SetReuseFrames()

--- a/vendor/google.golang.org/grpc/version.go
+++ b/vendor/google.golang.org/grpc/version.go
@@ -19,4 +19,4 @@
 package grpc
 
 // Version is the current grpc version.
-const Version = "1.23.0"
+const Version = "1.23.1"


### PR DESCRIPTION
For https://github.com/containerd/cri/issues/1257

This PR:
1) Updated containerd to a176179a0894ca6768a0f993e678f08a7f8553d5 which included the change https://github.com/containerd/containerd/pull/3785 and https://github.com/containerd/containerd/pull/3823
2) Added `GOOS=windows make release` support mainly for testing. Here is the tarball:
```console
$ tar tvf _output/cri-containerd-9f79be1b.windows-amd64.tar.gz 
drwxr-xr-x root/root         0 2019-11-15 00:31 ./
-rwxr-xr-x root/root  17256960 2019-11-15 00:31 ./ctr.exe
-rwxr-xr-x root/root  18249728 2019-11-15 00:31 ./containerd-shim-runhcs-v1.exe
drwxr-xr-x root/root         0 2019-11-15 00:31 ./cni/
-rwxr-xr-x root/root   6020608 2019-11-15 00:31 ./cni/sdnbridge.exe
-rwxr-xr-x root/root   6020608 2019-11-15 00:31 ./cni/sdnoverlay.exe
-rwxr-xr-x root/root   6020608 2019-11-15 00:31 ./cni/nat.exe
-rwxr-xr-x root/root  17317376 2019-11-15 00:31 ./containerd-stress.exe
-rwxr-xr-x root/root  47841280 2019-11-15 00:31 ./containerd.exe
```