### PR TITLE
Provide resolvConf to sandbox container's mounts

### DIFF
--- a/pkg/server/sandbox_run_unix.go
+++ b/pkg/server/sandbox_run_unix.go
@@ -108,6 +108,13 @@ func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 			Type:        "bind",
 			Options:     []string{"rbind", "ro"},
 		},
+		// Add resolv.conf for katacontainers to setup the DNS of pod VM properly.
+		{
+			Source:      c.getResolvPath(id),
+			Destination: resolvConfPath,
+			Type:        "bind",
+			Options:     []string{"rbind", "ro"},
+		},
 	}))
 
 	selinuxOpt := securityContext.GetSelinuxOptions()


### PR DESCRIPTION
As https://github.com/kata-containers/runtime/issues/1603 discussed, kata relies on such mount spec to setup resolv.conf for pod VM properly.

Signed-off-by: Li Yuxuan <liyuxuan04@baidu.com>