### PR TITLE
Better handle unknown state.

### DIFF
--- a/pkg/server/events.go
+++ b/pkg/server/events.go
@@ -333,6 +333,12 @@ func handleContainerExit(ctx context.Context, e *eventtypes.TaskExit, cntr conta
 		status.Pid = 0
 		status.FinishedAt = e.ExitedAt.UnixNano()
 		status.ExitCode = int32(e.ExitStatus)
+		// Unknown state can only transit to EXITED state, so we need
+		// to handle unknown state here.
+		if status.Unknown {
+			logrus.Debugf("Container %q transited from UNKNOWN to EXITED", cntr.ID)
+			status.Unknown = false
+		}
 		return status, nil
 	})
 	if err != nil {

--- a/pkg/server/helpers.go
+++ b/pkg/server/helpers.go
@@ -359,6 +359,7 @@ func unknownContainerStatus() containerstore.Status {
 		FinishedAt: 0,
 		ExitCode:   unknownExitCode,
 		Reason:     unknownExitReason,
+		Unknown:    true,
 	}
 }
 

--- a/pkg/server/restart.go
+++ b/pkg/server/restart.go
@@ -308,7 +308,9 @@ func (c *criService) loadContainer(ctx context.Context, cntr containerd.Containe
 	}()
 	if err != nil {
 		log.G(ctx).WithError(err).Errorf("Failed to load container status for %q", id)
-		status = unknownContainerStatus()
+		// Only set the unknown field in this case, because other fields may
+		// contain useful information loaded from the checkpoint.
+		status.Unknown = true
 	}
 	opts := []containerstore.Opts{
 		containerstore.WithStatus(status, containerDir),

--- a/pkg/store/container/status.go
+++ b/pkg/store/container/status.go
@@ -94,10 +94,16 @@ type Status struct {
 	// Removing indicates that the container is in removing state.
 	// This field doesn't need to be checkpointed.
 	Removing bool `json:"-"`
+	// Unknown indicates that the container status is not fully loaded.
+	// This field doesn't need to be checkpointed.
+	Unknown bool `json:"-"`
 }
 
 // State returns current state of the container based on the container status.
 func (s Status) State() runtime.ContainerState {
+	if s.Unknown {
+		return runtime.ContainerState_CONTAINER_UNKNOWN
+	}
 	if s.FinishedAt != 0 {
 		return runtime.ContainerState_CONTAINER_EXITED
 	}

--- a/pkg/store/container/status_test.go
+++ b/pkg/store/container/status_test.go
@@ -36,6 +36,12 @@ func TestContainerState(t *testing.T) {
 		state  runtime.ContainerState
 	}{
 		"unknown state": {
+			status: Status{
+				Unknown: true,
+			},
+			state: runtime.ContainerState_CONTAINER_UNKNOWN,
+		},
+		"unknown state because there is no timestamp set": {
 			status: Status{},
 			state:  runtime.ContainerState_CONTAINER_UNKNOWN,
 		},
@@ -76,6 +82,7 @@ func TestStatusEncodeDecode(t *testing.T) {
 		Message:    "test-message",
 		Removing:   true,
 		Starting:   true,
+		Unknown:    true,
 	}
 	assert := assertlib.New(t)
 	data, err := s.encode()
@@ -84,6 +91,7 @@ func TestStatusEncodeDecode(t *testing.T) {
 	assert.NoError(newS.decode(data))
 	s.Removing = false // Removing should not be encoded.
 	s.Starting = false // Starting should not be encoded.
+	s.Unknown = false  // Unknown should not be encoded.
 	assert.Equal(s, newS)
 
 	unsupported, err := json.Marshal(&versionedStatus{


### PR DESCRIPTION
Fixes https://github.com/containerd/cri/issues/1039.
For https://github.com/containerd/containerd/issues/3873.

Use a new in-memory only field to represent `unknown` state. With this, we'll preserve the status checkpoint, instead of overwriting it with unknown status.

We may want to cherry-pick the fix.

/cc @sofat1989  

Signed-off-by: Lantao Liu <lantaol@google.com>