### PR TITLE
add removal of old go

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,6 +15,7 @@ install:
   # Install Mingw
   - choco install -y mingw --version 5.3.0
   # Install Go
+  - rd C:\Go /s /q
   - appveyor DownloadFile https://storage.googleapis.com/golang/go%GO_VERSION%.windows-amd64.zip
   - 7z x go%GO_VERSION%.windows-amd64.zip -oC:\ >nul
   - go version


### PR DESCRIPTION
Should remove the old go before attempting to install new one.

fixes app veyor build break seen on latest PRs... #1356
 
Signed-off-by: Mike Brown <brownwm@us.ibm.com>