### PR TITLE
Add s390x support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,13 @@ go:
   - 1.14
 
 matrix:
-  - go: 1.14
+  include:
+  - os: linux
+    arch: s390x
+    go: 1.13.8
+  - os: linux
+    arch: s390x
+    go: 1.14
 
 sudo: required
 
@@ -41,9 +47,13 @@ script:
   - make install.deps
   - make containerd
   - sudo PATH=$PATH GOPATH=$GOPATH make install-containerd
-  - make test
-  - make test-integration
-  - make test-cri
+  - if [ "$HOSTTYPE" == "s390x" ];then
+      make test;
+    else 
+      make test;
+      make test-integration;
+      make test-cri;
+    fi  
 after_script:
   # Abuse travis to preserve the log.
   - cat /tmp/test-integration/containerd.log

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@
 GO := go
 GOOS := $(shell $(GO) env GOOS)
 GOARCH := $(shell $(GO) env GOARCH)
+ARCH := $(shell uname -m)
 WHALE := "🇩"
 ONI := "👹"
 ifeq ($(GOOS),windows)
@@ -91,12 +92,21 @@ $(BUILD_DIR)/$(CONTAINERD_BIN): $(SOURCES) $(PLUGIN_SOURCES)
 		-gcflags '$(GO_GCFLAGS)' \
 		$(PROJECT)/cmd/containerd
 
+ifeq ($(ARCH),s390x)
+test: ## unit test
+	@echo "$(WHALE) $@"
+	$(GO) test -timeout=10m ./pkg/... \
+			-tags '$(BUILD_TAGS)' \
+	        	-ldflags '$(GO_LDFLAGS)' \
+			-gcflags '$(GO_GCFLAGS)'
+else
 test: ## unit test
 	@echo "$(WHALE) $@"
 	$(GO) test -timeout=10m -race ./pkg/... \
 		-tags '$(BUILD_TAGS)' \
 	        -ldflags '$(GO_LDFLAGS)' \
 		-gcflags '$(GO_GCFLAGS)'
+endif
 
 $(BUILD_DIR)/integration.test: $(INTEGRATION_SOURCES)
 	@echo "$(WHALE) $@"

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@
 GO := go
 GOOS := $(shell $(GO) env GOOS)
 GOARCH := $(shell $(GO) env GOARCH)
-ARCH := $(shell uname -m)
 WHALE := "🇩"
 ONI := "👹"
 ifeq ($(GOOS),windows)
@@ -39,6 +38,12 @@ GO_LDFLAGS := -X $(PROJECT)/vendor/github.com/containerd/containerd/version.Vers
 SOURCES := $(shell find cmd/ pkg/ vendor/ -name '*.go')
 PLUGIN_SOURCES := $(shell ls *.go)
 INTEGRATION_SOURCES := $(shell find integration/ -name '*.go')
+
+
+TESTFLAGS_RACE := -race
+ifeq ($(GOARCH),s390x)
+	TESTFLAGS_RACE :=
+endif
 
 CONTAINERD_BIN := containerd
 ifeq ($(GOOS),windows)
@@ -92,17 +97,9 @@ $(BUILD_DIR)/$(CONTAINERD_BIN): $(SOURCES) $(PLUGIN_SOURCES)
 		-gcflags '$(GO_GCFLAGS)' \
 		$(PROJECT)/cmd/containerd
 
-ifeq ($(ARCH),s390x)
 test: ## unit test
 	@echo "$(WHALE) $@"
-	$(GO) test -timeout=10m ./pkg/... \
-			-tags '$(BUILD_TAGS)' \
-	        	-ldflags '$(GO_LDFLAGS)' \
-			-gcflags '$(GO_GCFLAGS)'
-else
-test: ## unit test
-	@echo "$(WHALE) $@"
-	$(GO) test -timeout=10m -race ./pkg/... \
+	$(GO) test -timeout=10m $(TESTFLAGS_RACE) ./pkg/... \
 		-tags '$(BUILD_TAGS)' \
 	        -ldflags '$(GO_LDFLAGS)' \
 		-gcflags '$(GO_GCFLAGS)'

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,6 @@ test: ## unit test
 		-tags '$(BUILD_TAGS)' \
 	        -ldflags '$(GO_LDFLAGS)' \
 		-gcflags '$(GO_GCFLAGS)'
-endif
 
 $(BUILD_DIR)/integration.test: $(INTEGRATION_SOURCES)
 	@echo "$(WHALE) $@"


### PR DESCRIPTION
Add s390x support for Travis CI. 
Integration and validation tests are omitted for s390x, as two Integration tests( `TestVolumeCopyUp, TestVolumeOwnership`) and validation tests(`Security Context`) are failing as images being used for these tests are not multi-arch supported.

Signed-off-by: cnaik <Chandranana.Naik@ibm.com>
