### PR TITLE
Update registry.md for auth config 

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -71,7 +71,7 @@ To configure a credential for a specific registry, create/modify the
 ```toml
 # The registry host has to be a domain name or IP. Port number is also
 # needed if the default HTTPS or HTTP port is not used.
-[plugins.cri.registry.configs."gcr.io".auth]
+[plugins.cri.registry.configs.auths."https://gcr.io"]
   username = ""
   password = ""
   auth = ""


### PR DESCRIPTION
I tried using the config `plugins.cri.registry.configs."quay.io".auth` in microk8s, but that didn't work for private registries. However, using `plugins.cri.registry.configs.auth."https://quay.io"` worked for me.
Found this here: https://stackoverflow.com/questions/56642311/microk8s-cannot-pull-from-private-registry

Signed-off-by: Joris De Winne <joris.dewinne@gmail.com>