### PR TITLE
[release/1.3 backport] vendor: bump gopkg.in/yaml.v2 v2.2.8

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -64,7 +64,7 @@ k8s.io/client-go kubernetes-1.16.6
 k8s.io/api kubernetes-1.16.6
 k8s.io/apiserver kubernetes-1.16.6
 k8s.io/apimachinery kubernetes-1.16.6
-gopkg.in/yaml.v2 v2.2.4
+gopkg.in/yaml.v2 53403b58ad1b561927d19068c655246f2db79d48 # v2.2.8
 gopkg.in/inf.v0 v0.9.1
 golang.org/x/time 9d24e82272b4f38b78bc8cff74fa936d31ccd8ef
 golang.org/x/oauth2 0f29369cfe4552d0e4bcddc57cc75f4d7e672a33

--- a/vendor/gopkg.in/yaml.v2/decode.go
+++ b/vendor/gopkg.in/yaml.v2/decode.go
@@ -319,10 +319,14 @@ func (d *decoder) prepare(n *node, out reflect.Value) (newout reflect.Value, unm
 }
 
 const (
-	// 400,000 decode operations is ~500kb of dense object declarations, or ~5kb of dense object declarations with 10000% alias expansion
+	// 400,000 decode operations is ~500kb of dense object declarations, or
+	// ~5kb of dense object declarations with 10000% alias expansion
 	alias_ratio_range_low = 400000
-	// 4,000,000 decode operations is ~5MB of dense object declarations, or ~4.5MB of dense object declarations with 10% alias expansion
+
+	// 4,000,000 decode operations is ~5MB of dense object declarations, or
+	// ~4.5MB of dense object declarations with 10% alias expansion
 	alias_ratio_range_high = 4000000
+
 	// alias_ratio_range is the range over which we scale allowed alias ratios
 	alias_ratio_range = float64(alias_ratio_range_high - alias_ratio_range_low)
 )
@@ -784,8 +788,7 @@ func (d *decoder) merge(n *node, out reflect.Value) {
 	case mappingNode:
 		d.unmarshal(n, out)
 	case aliasNode:
-		an, ok := d.doc.anchors[n.value]
-		if ok && an.kind != mappingNode {
+		if n.alias != nil && n.alias.kind != mappingNode {
 			failWantMap()
 		}
 		d.unmarshal(n, out)
@@ -794,8 +797,7 @@ func (d *decoder) merge(n *node, out reflect.Value) {
 		for i := len(n.children) - 1; i >= 0; i-- {
 			ni := n.children[i]
 			if ni.kind == aliasNode {
-				an, ok := d.doc.anchors[ni.value]
-				if ok && an.kind != mappingNode {
+				if ni.alias != nil && ni.alias.kind != mappingNode {
 					failWantMap()
 				}
 			} else if ni.kind != mappingNode {

--- a/vendor/gopkg.in/yaml.v2/yaml.go
+++ b/vendor/gopkg.in/yaml.v2/yaml.go
@@ -89,7 +89,7 @@ func UnmarshalStrict(in []byte, out interface{}) (err error) {
 	return unmarshal(in, out, true)
 }
 
-// A Decorder reads and decodes YAML values from an input stream.
+// A Decoder reads and decodes YAML values from an input stream.
 type Decoder struct {
 	strict bool
 	parser *parser

--- a/vendor/gopkg.in/yaml.v2/yamlh.go
+++ b/vendor/gopkg.in/yaml.v2/yamlh.go
@@ -579,6 +579,7 @@ type yaml_parser_t struct {
 
 	simple_key_allowed bool                // May a simple key occur at the current position?
 	simple_keys        []yaml_simple_key_t // The stack of simple keys.
+	simple_keys_by_tok map[int]int         // possible simple_key indexes indexed by token_number
 
 	// Parser stuff
 


### PR DESCRIPTION
back port of https://github.com/containerd/cri/pull/1387 for the 1.3 branch


full diff: https://github.com/go-yaml/yaml/compare/v2.2.4...v2.2.8

includes:

- go-yaml/yaml@f90ceb4f409096b60e2e9076b38b304b8246e5fa Fix check for non-map alias merging in v2
    - fix for "yaml.Unmarshal crashes on "assignment to entry in nil map""
- go-yaml/yaml 543 Port stale simple_keys fix to v2
- go-yaml/yaml@1f64d6156d11335c3f22d9330b0ad14fc1e789ce Fix issue in simple_keys improvements
    - fixes "Invalid simple_keys now cause panics later in decode"
- go-yaml/yaml 555 Optimize cases with long potential simple_keys

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
(cherry picked from commit 3d0818d99e3fd012ebc2a3b299f0c5d9f3cef2f2)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>