### PR TITLE
move to v3.2 for the pause image

### DIFF
--- a/contrib/ansible/cri-containerd.yaml
+++ b/contrib/ansible/cri-containerd.yaml
@@ -1,9 +1,9 @@
 ---
-- hosts: all 
+- hosts: all
   become: true
   tasks:
     - include_vars: vars/vars.yaml # Contains tasks variables for installer
-    - include_tasks: tasks/bootstrap_ubuntu.yaml # Contains tasks bootstrap components for ubuntu systems 
+    - include_tasks: tasks/bootstrap_ubuntu.yaml # Contains tasks bootstrap components for ubuntu systems
       when: ansible_distribution == "Ubuntu"
     - include_tasks: tasks/bootstrap_centos.yaml # Contains tasks bootstrap components for centos systems
       when: ansible_distribution == "CentOS"
@@ -21,12 +21,12 @@
         name: br_netfilter
         state: present
 
-    - name: "Set bridge-nf-call-iptables" 
+    - name: "Set bridge-nf-call-iptables"
       sysctl:
         name: net.bridge.bridge-nf-call-iptables
         value: 1
 
-    - name: "Set ip_forward" 
+    - name: "Set ip_forward"
       sysctl:
         name: net.ipv4.ip_forward
         value: 1
@@ -41,13 +41,13 @@
         line: "Environment=\"KUBELET_EXTRA_ARGS= --runtime-cgroups=/system.slice/containerd.service --container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock\""
         insertafter: '\[Service\]'
       when: check_args.stdout == ""
-    
+
     - name: "Start Kubelet"
       systemd: name=kubelet daemon_reload=yes state=started enabled=yes
-    
+
     # TODO This needs to be removed once we have consistent concurrent pull results
     - name: "Pre-pull pause container image"
       shell: |
-        /usr/local/bin/ctr pull k8s.gcr.io/pause:3.1
+        /usr/local/bin/ctr pull k8s.gcr.io/pause:3.2
         /usr/local/bin/crictl --runtime-endpoint unix:///run/containerd/containerd.sock \
-        pull k8s.gcr.io/pause:3.1
+        pull k8s.gcr.io/pause:3.2

--- a/docs/config.md
+++ b/docs/config.md
@@ -35,7 +35,7 @@ version = 2
   enable_selinux = false
 
   # sandbox_image is the image used by sandbox container.
-  sandbox_image = "k8s.gcr.io/pause:3.1"
+  sandbox_image = "k8s.gcr.io/pause:3.2"
 
   # stats_collect_period is the period (in seconds) of snapshots stats collection.
   stats_collect_period = 10

--- a/docs/crictl.md
+++ b/docs/crictl.md
@@ -44,29 +44,29 @@ command. With the load command you inject a container image into the container
 runtime from a file. First you need to create a container image tarball. For
 example to create an image tarball for a pause container using Docker:
 ```console
-$ docker pull k8s.gcr.io/pause-amd64:3.1
-  3.1: Pulling from pause-amd64
+$ docker pull k8s.gcr.io/pause-amd64:3.2
+  3.2: Pulling from pause-amd64
   67ddbfb20a22: Pull complete
   Digest: sha256:59eec8837a4d942cc19a52b8c09ea75121acc38114a2c68b98983ce9356b8610
-  Status: Downloaded newer image for k8s.gcr.io/pause-amd64:3.1
-$ docker save k8s.gcr.io/pause-amd64:3.1 -o pause.tar
+  Status: Downloaded newer image for k8s.gcr.io/pause-amd64:3.2
+$ docker save k8s.gcr.io/pause-amd64:3.2 -o pause.tar
 ```
 Then use [`ctr`](https://github.com/containerd/containerd/blob/master/docs/man/ctr.1.md)
 to load the container image into the container runtime:
 ```console
 # The cri plugin uses the "k8s.io" containerd namespace.
 $ sudo ctr -n=k8s.io images import pause.tar
-  Loaded image: k8s.gcr.io/pause-amd64:3.1
+  Loaded image: k8s.gcr.io/pause-amd64:3.2
 ```
 List images and inspect the pause image:
 ```console
 $ sudo crictl images
 IMAGE                       TAG                 IMAGE ID            SIZE
 docker.io/library/busybox   latest              f6e427c148a76       728kB
-k8s.gcr.io/pause-amd64      3.1                 da86e6ba6ca19       746kB
+k8s.gcr.io/pause-amd64      3.2                 da86e6ba6ca19       746kB
 $ sudo crictl inspecti da86e6ba6ca19
   ... displays information about the pause image.
-$ sudo crictl inspecti k8s.gcr.io/pause-amd64:3.1
+$ sudo crictl inspecti k8s.gcr.io/pause-amd64:3.2
   ... displays information about the pause image.
 ```
 
@@ -186,7 +186,7 @@ $ crictl info
       }
     },
     "streamServerPort": "10010",
-    "sandboxImage": "k8s.gcr.io/pause:3.1",
+    "sandboxImage": "k8s.gcr.io/pause:3.2",
     "statsCollectPeriod": 10,
     "containerdRootDir": "/var/lib/containerd",
     "containerdEndpoint": "unix:///run/containerd/containerd.sock",

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -48,7 +48,7 @@ import (
 
 const (
 	timeout      = 1 * time.Minute
-	pauseImage   = "k8s.gcr.io/pause:3.1" // This is the same with default sandbox image.
+	pauseImage   = "k8s.gcr.io/pause:3.2" // This is the same with default sandbox image.
 	k8sNamespace = constants.K8sContainerdNamespace
 )
 

--- a/pkg/config/config_unix.go
+++ b/pkg/config/config_unix.go
@@ -52,7 +52,7 @@ func DefaultConfig() PluginConfig {
 			TLSKeyFile:  "",
 			TLSCertFile: "",
 		},
-		SandboxImage:            "k8s.gcr.io/pause:3.1",
+		SandboxImage:            "k8s.gcr.io/pause:3.2",
 		StatsCollectPeriod:      10,
 		SystemdCgroup:           false,
 		MaxContainerLogLineSize: 16 * 1024,


### PR DESCRIPTION
resolve issue #1398 

see https://github.com/kubernetes/kubernetes/pull/88129 and other related prs..

Waiting for kubernetes team to push the new v3.2 pause manifest and images to k8s.gcr.io.

Signed-off-by: Mike Brown <brownwm@us.ibm.com>