### PR TITLE
Reformat vendor.conf: use columns, pin by git-sha, and sort alphabetically

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,95 +1,95 @@
 # cri dependencies
-github.com/tchap/go-patricia 666120de432aea38ab06bd5c818f04f4129882c9 # v2.2.6
-github.com/opencontainers/selinux 31f70552238c5e017d78c3f1ba65e85f593f48e0 # 1.3.3
-github.com/docker/docker d1d5f6476656c6aad457e2a91d3436e66b6f2251
 github.com/docker/distribution 0d3efadf0154c2b8a4e7b6621fff9809655cc580
+github.com/docker/docker d1d5f6476656c6aad457e2a91d3436e66b6f2251
+github.com/opencontainers/selinux 31f70552238c5e017d78c3f1ba65e85f593f48e0 # 1.3.3
+github.com/tchap/go-patricia 666120de432aea38ab06bd5c818f04f4129882c9 # v2.2.6
 
 # containerd dependencies
-go.opencensus.io v0.22.0
-go.etcd.io/bbolt a0458a2b35708eef59eb5f620ceb3cd1c01a824d # v1.3.3
-google.golang.org/grpc 39e8a7b072a67ca2a75f57fa2e0d50995f5b22f6 # v1.23.1
-google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
-golang.org/x/text 19e51611da83d6be54ddafce4a4af510cb3e9ea4
-golang.org/x/sys 52ab431487773bc9dd1b0766228b1cf3944126bf https://github.com/golang/sys
-golang.org/x/sync 42b317875d0fa942474b76e1b46a6060d720ae6e
-golang.org/x/net f3200d17e092c607f615320ecaad13d87ad9a2b3
-github.com/urfave/cli bfe2e925cfb6d44b40ad3a779165ea7e8aff9212 # v1.22.0
-github.com/syndtr/gocapability d98352740cb2c55f81556b63d4a1ec64c5a319c2
-github.com/sirupsen/logrus 8bdbc7bcc01dcbb8ec23dc8a28e332258d25251f # v1.4.1
-github.com/prometheus/procfs cb4147076ac75738c9a7d279075a253c0cc5acbd
-github.com/prometheus/common 89604d197083d4781071d3c65855d24ecfb0a563
-github.com/prometheus/client_model 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
-github.com/prometheus/client_golang f4fb1b73fb099f396a7f0036bf86aa8def4ed823
-github.com/pkg/errors ba968bfe8b2f7e042a574c888954fccecfa385b4 # v0.8.1
-github.com/opencontainers/runtime-spec 29686dbc5559d93fb1ef402eeda3e35c38d75af4 # v1.0.1-59-g29686db
-github.com/opencontainers/runc dc9208a3303feef5b3839f4323d9beb36df0a9dd # v1.0.0-rc10
-github.com/opencontainers/image-spec d60099175f88c47cd379c4738d158884749ed235 # v1.0.1
-github.com/opencontainers/go-digest c9281466c8b2f606084ac71339773efd177436e7
-github.com/matttproud/golang_protobuf_extensions c12348ce28de40eed0136aa2b644d0ee0650e56c # v1.0.1
-github.com/konsorten/go-windows-terminal-sequences 5c8c8bd35d3832f5d134ae1e1e375b69a4d25242 # v1.0.1
-github.com/imdario/mergo 7c29201646fa3de8506f701213473dd407f19646 # v0.3.7
-github.com/hashicorp/golang-lru 7f827b33c0f158ec5dfbba01bb0b14a4541fd81d # v0.5.3
-github.com/grpc-ecosystem/go-grpc-prometheus 6b7015e65d366bf3f19b2b2a000a831940f0f7e0
-github.com/google/uuid 0cd6bf5da1e1c83f8b45653022c74f71af0538a4 # v1.1.1
-github.com/golang/protobuf aa810b61a9c79d51363740d207bb46cf8e620ed5 # v1.2.0
-github.com/gogo/protobuf ba06b47c162d49f2af050fb4c75bcbc86a159d5c # v1.2.1
-github.com/gogo/googleapis d31c731455cb061f42baff3bda55bad0118b126b # v1.2.0
-github.com/godbus/dbus/v5 37bf87eef99d69c4f1d3528bd66e3a87dc201472 # v5.0.3
-github.com/docker/go-units 519db1ee28dcc9fd2474ae59fca29a810482bfb1 # v0.4.0
-github.com/docker/go-metrics 4ea375f7759c82740c893fc030bc37088d2ec098
-github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
-github.com/coreos/go-systemd/v22 2d78030078ef61b3cae27f42ad6d0e46db51b339 # v22.0.0
-github.com/containerd/typeurl a93fcdb778cd272c6e9b3028b2f42d813e785d40
-github.com/containerd/ttrpc 92c8520ef9f86600c650dd540266a007bf03670f
-github.com/containerd/go-runc a5c2862aed5e6358b305b0e16bfce58e0549b1cd
-github.com/containerd/fifo bda0ff6ed73c67bfb5e62bc9c697f146b7fd7f13
-github.com/containerd/continuity f2a389ac0a02ce21c09edd7344677a601970f41c
-github.com/containerd/containerd e1221e69a824ce9aaca34c5bb603feb2f921b883
-github.com/containerd/console 8375c3424e4d7b114e8a90a4a40c8e1b40d1d4e6
-github.com/containerd/cgroups 7347743e5d1e8500d9f27c8e748e689ed991d92b
 github.com/beorn7/perks 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
-github.com/Microsoft/hcsshim b3f49c06ffaeef24d09c6c08ec8ec8425a0303e2 # v0.8.7
-github.com/Microsoft/go-winio 6c72808b55902eae4c5943626030429ff20f3b63 # v0.4.14
 github.com/BurntSushi/toml 3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005 # v0.3.1
+github.com/containerd/cgroups 7347743e5d1e8500d9f27c8e748e689ed991d92b
+github.com/containerd/console 8375c3424e4d7b114e8a90a4a40c8e1b40d1d4e6
+github.com/containerd/containerd e1221e69a824ce9aaca34c5bb603feb2f921b883
+github.com/containerd/continuity f2a389ac0a02ce21c09edd7344677a601970f41c
+github.com/containerd/fifo bda0ff6ed73c67bfb5e62bc9c697f146b7fd7f13
+github.com/containerd/go-runc a5c2862aed5e6358b305b0e16bfce58e0549b1cd
+github.com/containerd/ttrpc 92c8520ef9f86600c650dd540266a007bf03670f
+github.com/containerd/typeurl a93fcdb778cd272c6e9b3028b2f42d813e785d40
+github.com/coreos/go-systemd/v22 2d78030078ef61b3cae27f42ad6d0e46db51b339 # v22.0.0
 github.com/cpuguy83/go-md2man 7762f7e404f8416dfa1d9bb6a8c192aa9acb4d19 # v1.0.10
+github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
+github.com/docker/go-metrics 4ea375f7759c82740c893fc030bc37088d2ec098
+github.com/docker/go-units 519db1ee28dcc9fd2474ae59fca29a810482bfb1 # v0.4.0
+github.com/godbus/dbus/v5 37bf87eef99d69c4f1d3528bd66e3a87dc201472 # v5.0.3
+github.com/gogo/googleapis d31c731455cb061f42baff3bda55bad0118b126b # v1.2.0
+github.com/gogo/protobuf ba06b47c162d49f2af050fb4c75bcbc86a159d5c # v1.2.1
+github.com/golang/protobuf aa810b61a9c79d51363740d207bb46cf8e620ed5 # v1.2.0
+github.com/google/uuid 0cd6bf5da1e1c83f8b45653022c74f71af0538a4 # v1.1.1
+github.com/grpc-ecosystem/go-grpc-prometheus 6b7015e65d366bf3f19b2b2a000a831940f0f7e0
+github.com/hashicorp/golang-lru 7f827b33c0f158ec5dfbba01bb0b14a4541fd81d # v0.5.3
+github.com/imdario/mergo 7c29201646fa3de8506f701213473dd407f19646 # v0.3.7
+github.com/konsorten/go-windows-terminal-sequences 5c8c8bd35d3832f5d134ae1e1e375b69a4d25242 # v1.0.1
+github.com/matttproud/golang_protobuf_extensions c12348ce28de40eed0136aa2b644d0ee0650e56c # v1.0.1
+github.com/Microsoft/go-winio 6c72808b55902eae4c5943626030429ff20f3b63 # v0.4.14
+github.com/Microsoft/hcsshim b3f49c06ffaeef24d09c6c08ec8ec8425a0303e2 # v0.8.7
+github.com/opencontainers/go-digest c9281466c8b2f606084ac71339773efd177436e7
+github.com/opencontainers/image-spec d60099175f88c47cd379c4738d158884749ed235 # v1.0.1
+github.com/opencontainers/runc dc9208a3303feef5b3839f4323d9beb36df0a9dd # v1.0.0-rc10
+github.com/opencontainers/runtime-spec 29686dbc5559d93fb1ef402eeda3e35c38d75af4 # v1.0.1-59-g29686db
+github.com/pkg/errors ba968bfe8b2f7e042a574c888954fccecfa385b4 # v0.8.1
+github.com/prometheus/client_golang f4fb1b73fb099f396a7f0036bf86aa8def4ed823
+github.com/prometheus/client_model 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
+github.com/prometheus/common 89604d197083d4781071d3c65855d24ecfb0a563
+github.com/prometheus/procfs cb4147076ac75738c9a7d279075a253c0cc5acbd
 github.com/russross/blackfriday 05f3235734ad95d0016f6a23902f06461fcf567a # v1.5.2
+github.com/sirupsen/logrus 8bdbc7bcc01dcbb8ec23dc8a28e332258d25251f # v1.4.1
+github.com/syndtr/gocapability d98352740cb2c55f81556b63d4a1ec64c5a319c2
+github.com/urfave/cli bfe2e925cfb6d44b40ad3a779165ea7e8aff9212 # v1.22.0
+go.etcd.io/bbolt a0458a2b35708eef59eb5f620ceb3cd1c01a824d # v1.3.3
+go.opencensus.io v0.22.0
+golang.org/x/net f3200d17e092c607f615320ecaad13d87ad9a2b3
+golang.org/x/sync 42b317875d0fa942474b76e1b46a6060d720ae6e
+golang.org/x/sys 52ab431487773bc9dd1b0766228b1cf3944126bf https://github.com/golang/sys
+golang.org/x/text 19e51611da83d6be54ddafce4a4af510cb3e9ea4
+google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
+google.golang.org/grpc 39e8a7b072a67ca2a75f57fa2e0d50995f5b22f6 # v1.23.1
 
 # cgroups dependencies
 github.com/cilium/ebpf 60c3aa43f488292fe2ee50fb8b833b383ca8ebbb
 
 # kubernetes dependencies
-sigs.k8s.io/yaml fd68e9863619f6ec2fdd8625fe1f02e7c877e480 # v1.1.0
-k8s.io/utils e782cd3c129fc98ee807f3c889c0f26eb7c9daf5
-k8s.io/kubernetes v1.18.0-alpha.1
-k8s.io/klog v1.0.0
-k8s.io/cri-api kubernetes-1.18.0-alpha.1
-k8s.io/client-go kubernetes-1.18.0-alpha.1
-k8s.io/api kubernetes-1.18.0-alpha.1
-k8s.io/apiserver kubernetes-1.18.0-alpha.1
-k8s.io/apimachinery kubernetes-1.18.0-alpha.1
-gopkg.in/yaml.v2 53403b58ad1b561927d19068c655246f2db79d48 # v2.2.8
-gopkg.in/inf.v0 v0.9.1
-golang.org/x/time 9d24e82272b4f38b78bc8cff74fa936d31ccd8ef
-golang.org/x/oauth2 0f29369cfe4552d0e4bcddc57cc75f4d7e672a33
-golang.org/x/crypto 1d94cc7ab1c630336ab82ccb9c9cda72a875c382
-github.com/stretchr/testify v1.4.0
-github.com/seccomp/libseccomp-golang 689e3c1541a84461afc49c1c87352a6cedf72e9c # v0.9.1
-github.com/pmezard/go-difflib v1.0.0
-github.com/modern-go/reflect2 4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd # 1.0.1
-github.com/modern-go/concurrent bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94 # 1.0.3
-github.com/json-iterator/go v1.1.8
-github.com/google/gofuzz f140a6486e521aad38f5917de355cbf147cc0496 # v1.0.0
-github.com/emicklei/go-restful b993709ae1a4f6dd19cfa475232614441b11c9d5 # v2.9.5
-github.com/docker/spdystream 449fdfce4d962303d702fec724ef0ad181c92528
 github.com/davecgh/go-spew 8991bc29aa16c548c550c7ff78260e27b9ab7c73 # v1.1.1
+github.com/docker/spdystream 449fdfce4d962303d702fec724ef0ad181c92528
+github.com/emicklei/go-restful b993709ae1a4f6dd19cfa475232614441b11c9d5 # v2.9.5
+github.com/google/gofuzz f140a6486e521aad38f5917de355cbf147cc0496 # v1.0.0
+github.com/json-iterator/go v1.1.8
+github.com/modern-go/concurrent bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94 # 1.0.3
+github.com/modern-go/reflect2 4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd # 1.0.1
+github.com/pmezard/go-difflib v1.0.0
+github.com/seccomp/libseccomp-golang 689e3c1541a84461afc49c1c87352a6cedf72e9c # v0.9.1
+github.com/stretchr/testify v1.4.0
+golang.org/x/crypto 1d94cc7ab1c630336ab82ccb9c9cda72a875c382
+golang.org/x/oauth2 0f29369cfe4552d0e4bcddc57cc75f4d7e672a33
+golang.org/x/time 9d24e82272b4f38b78bc8cff74fa936d31ccd8ef
+gopkg.in/inf.v0 v0.9.1
+gopkg.in/yaml.v2 53403b58ad1b561927d19068c655246f2db79d48 # v2.2.8
+k8s.io/api kubernetes-1.18.0-alpha.1
+k8s.io/apimachinery kubernetes-1.18.0-alpha.1
+k8s.io/apiserver kubernetes-1.18.0-alpha.1
+k8s.io/client-go kubernetes-1.18.0-alpha.1
+k8s.io/cri-api kubernetes-1.18.0-alpha.1
+k8s.io/klog v1.0.0
+k8s.io/kubernetes v1.18.0-alpha.1
+k8s.io/utils e782cd3c129fc98ee807f3c889c0f26eb7c9daf5
+sigs.k8s.io/yaml fd68e9863619f6ec2fdd8625fe1f02e7c877e480 # v1.1.0
 
 # cni dependencies
-github.com/containernetworking/plugins 9f96827c7cabb03f21d86326000c00f61e181f6a # v0.7.6
-github.com/containernetworking/cni 4cfb7b568922a3c79a23e438dc52fe537fc9687e # v0.7.1
 github.com/containerd/go-cni 0d360c50b10b350b6bb23863fd4dfb1c232b01c9
+github.com/containernetworking/cni 4cfb7b568922a3c79a23e438dc52fe537fc9687e # v0.7.1
+github.com/containernetworking/plugins 9f96827c7cabb03f21d86326000c00f61e181f6a # v0.7.6
 
 # image decrypt depedencies
 github.com/containerd/imgcrypt v1.0.1
 github.com/containers/ocicrypt v1.0.1 # from containerd/imgcrypt
-gopkg.in/square/go-jose.v2 v2.3.1 https://github.com/square/go-jose.git # from containers/ocicrypt
 github.com/fullsailor/pkcs7 8306686428a5fe132eac8cb7c4848af725098bd4 # from containers/ocicrypt
+gopkg.in/square/go-jose.v2 v2.3.1 https://github.com/square/go-jose.git # from containers/ocicrypt

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,95 +1,95 @@
 # cri dependencies
-github.com/docker/distribution 0d3efadf0154c2b8a4e7b6621fff9809655cc580
-github.com/docker/docker d1d5f6476656c6aad457e2a91d3436e66b6f2251
-github.com/opencontainers/selinux 31f70552238c5e017d78c3f1ba65e85f593f48e0 # 1.3.3
-github.com/tchap/go-patricia 666120de432aea38ab06bd5c818f04f4129882c9 # v2.2.6
+github.com/docker/distribution                      0d3efadf0154c2b8a4e7b6621fff9809655cc580
+github.com/docker/docker                            d1d5f6476656c6aad457e2a91d3436e66b6f2251
+github.com/opencontainers/selinux                   31f70552238c5e017d78c3f1ba65e85f593f48e0 # v1.3.3
+github.com/tchap/go-patricia                        666120de432aea38ab06bd5c818f04f4129882c9 # v2.2.6
 
 # containerd dependencies
-github.com/beorn7/perks 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
-github.com/BurntSushi/toml 3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005 # v0.3.1
-github.com/containerd/cgroups 7347743e5d1e8500d9f27c8e748e689ed991d92b
-github.com/containerd/console 8375c3424e4d7b114e8a90a4a40c8e1b40d1d4e6
-github.com/containerd/containerd e1221e69a824ce9aaca34c5bb603feb2f921b883
-github.com/containerd/continuity f2a389ac0a02ce21c09edd7344677a601970f41c
-github.com/containerd/fifo bda0ff6ed73c67bfb5e62bc9c697f146b7fd7f13
-github.com/containerd/go-runc a5c2862aed5e6358b305b0e16bfce58e0549b1cd
-github.com/containerd/ttrpc 92c8520ef9f86600c650dd540266a007bf03670f
-github.com/containerd/typeurl a93fcdb778cd272c6e9b3028b2f42d813e785d40
-github.com/coreos/go-systemd/v22 2d78030078ef61b3cae27f42ad6d0e46db51b339 # v22.0.0
-github.com/cpuguy83/go-md2man 7762f7e404f8416dfa1d9bb6a8c192aa9acb4d19 # v1.0.10
-github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
-github.com/docker/go-metrics 4ea375f7759c82740c893fc030bc37088d2ec098
-github.com/docker/go-units 519db1ee28dcc9fd2474ae59fca29a810482bfb1 # v0.4.0
-github.com/godbus/dbus/v5 37bf87eef99d69c4f1d3528bd66e3a87dc201472 # v5.0.3
-github.com/gogo/googleapis d31c731455cb061f42baff3bda55bad0118b126b # v1.2.0
-github.com/gogo/protobuf ba06b47c162d49f2af050fb4c75bcbc86a159d5c # v1.2.1
-github.com/golang/protobuf aa810b61a9c79d51363740d207bb46cf8e620ed5 # v1.2.0
-github.com/google/uuid 0cd6bf5da1e1c83f8b45653022c74f71af0538a4 # v1.1.1
-github.com/grpc-ecosystem/go-grpc-prometheus 6b7015e65d366bf3f19b2b2a000a831940f0f7e0
-github.com/hashicorp/golang-lru 7f827b33c0f158ec5dfbba01bb0b14a4541fd81d # v0.5.3
-github.com/imdario/mergo 7c29201646fa3de8506f701213473dd407f19646 # v0.3.7
-github.com/konsorten/go-windows-terminal-sequences 5c8c8bd35d3832f5d134ae1e1e375b69a4d25242 # v1.0.1
-github.com/matttproud/golang_protobuf_extensions c12348ce28de40eed0136aa2b644d0ee0650e56c # v1.0.1
-github.com/Microsoft/go-winio 6c72808b55902eae4c5943626030429ff20f3b63 # v0.4.14
-github.com/Microsoft/hcsshim b3f49c06ffaeef24d09c6c08ec8ec8425a0303e2 # v0.8.7
-github.com/opencontainers/go-digest c9281466c8b2f606084ac71339773efd177436e7
-github.com/opencontainers/image-spec d60099175f88c47cd379c4738d158884749ed235 # v1.0.1
-github.com/opencontainers/runc dc9208a3303feef5b3839f4323d9beb36df0a9dd # v1.0.0-rc10
-github.com/opencontainers/runtime-spec 29686dbc5559d93fb1ef402eeda3e35c38d75af4 # v1.0.1-59-g29686db
-github.com/pkg/errors ba968bfe8b2f7e042a574c888954fccecfa385b4 # v0.8.1
-github.com/prometheus/client_golang f4fb1b73fb099f396a7f0036bf86aa8def4ed823
-github.com/prometheus/client_model 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
-github.com/prometheus/common 89604d197083d4781071d3c65855d24ecfb0a563
-github.com/prometheus/procfs cb4147076ac75738c9a7d279075a253c0cc5acbd
-github.com/russross/blackfriday 05f3235734ad95d0016f6a23902f06461fcf567a # v1.5.2
-github.com/sirupsen/logrus 8bdbc7bcc01dcbb8ec23dc8a28e332258d25251f # v1.4.1
-github.com/syndtr/gocapability d98352740cb2c55f81556b63d4a1ec64c5a319c2
-github.com/urfave/cli bfe2e925cfb6d44b40ad3a779165ea7e8aff9212 # v1.22.0
-go.etcd.io/bbolt a0458a2b35708eef59eb5f620ceb3cd1c01a824d # v1.3.3
-go.opencensus.io v0.22.0
-golang.org/x/net f3200d17e092c607f615320ecaad13d87ad9a2b3
-golang.org/x/sync 42b317875d0fa942474b76e1b46a6060d720ae6e
-golang.org/x/sys 52ab431487773bc9dd1b0766228b1cf3944126bf https://github.com/golang/sys
-golang.org/x/text 19e51611da83d6be54ddafce4a4af510cb3e9ea4
-google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
-google.golang.org/grpc 39e8a7b072a67ca2a75f57fa2e0d50995f5b22f6 # v1.23.1
+github.com/beorn7/perks                             4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+github.com/BurntSushi/toml                          3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005 # v0.3.1
+github.com/containerd/cgroups                       7347743e5d1e8500d9f27c8e748e689ed991d92b
+github.com/containerd/console                       8375c3424e4d7b114e8a90a4a40c8e1b40d1d4e6
+github.com/containerd/containerd                    e1221e69a824ce9aaca34c5bb603feb2f921b883
+github.com/containerd/continuity                    f2a389ac0a02ce21c09edd7344677a601970f41c
+github.com/containerd/fifo                          bda0ff6ed73c67bfb5e62bc9c697f146b7fd7f13
+github.com/containerd/go-runc                       a5c2862aed5e6358b305b0e16bfce58e0549b1cd
+github.com/containerd/ttrpc                         92c8520ef9f86600c650dd540266a007bf03670f
+github.com/containerd/typeurl                       a93fcdb778cd272c6e9b3028b2f42d813e785d40
+github.com/coreos/go-systemd/v22                    2d78030078ef61b3cae27f42ad6d0e46db51b339 # v22.0.0
+github.com/cpuguy83/go-md2man                       7762f7e404f8416dfa1d9bb6a8c192aa9acb4d19 # v1.0.10
+github.com/docker/go-events                         9461782956ad83b30282bf90e31fa6a70c255ba9
+github.com/docker/go-metrics                        4ea375f7759c82740c893fc030bc37088d2ec098
+github.com/docker/go-units                          519db1ee28dcc9fd2474ae59fca29a810482bfb1 # v0.4.0
+github.com/godbus/dbus/v5                           37bf87eef99d69c4f1d3528bd66e3a87dc201472 # v5.0.3
+github.com/gogo/googleapis                          d31c731455cb061f42baff3bda55bad0118b126b # v1.2.0
+github.com/gogo/protobuf                            ba06b47c162d49f2af050fb4c75bcbc86a159d5c # v1.2.1
+github.com/golang/protobuf                          aa810b61a9c79d51363740d207bb46cf8e620ed5 # v1.2.0
+github.com/google/uuid                              0cd6bf5da1e1c83f8b45653022c74f71af0538a4 # v1.1.1
+github.com/grpc-ecosystem/go-grpc-prometheus        6b7015e65d366bf3f19b2b2a000a831940f0f7e0
+github.com/hashicorp/golang-lru                     7f827b33c0f158ec5dfbba01bb0b14a4541fd81d # v0.5.3
+github.com/imdario/mergo                            7c29201646fa3de8506f701213473dd407f19646 # v0.3.7
+github.com/konsorten/go-windows-terminal-sequences  5c8c8bd35d3832f5d134ae1e1e375b69a4d25242 # v1.0.1
+github.com/matttproud/golang_protobuf_extensions    c12348ce28de40eed0136aa2b644d0ee0650e56c # v1.0.1
+github.com/Microsoft/go-winio                       6c72808b55902eae4c5943626030429ff20f3b63 # v0.4.14
+github.com/Microsoft/hcsshim                        b3f49c06ffaeef24d09c6c08ec8ec8425a0303e2 # v0.8.7
+github.com/opencontainers/go-digest                 c9281466c8b2f606084ac71339773efd177436e7
+github.com/opencontainers/image-spec                d60099175f88c47cd379c4738d158884749ed235 # v1.0.1
+github.com/opencontainers/runc                      dc9208a3303feef5b3839f4323d9beb36df0a9dd # v1.0.0-rc10
+github.com/opencontainers/runtime-spec              29686dbc5559d93fb1ef402eeda3e35c38d75af4 # v1.0.1-59-g29686db
+github.com/pkg/errors                               ba968bfe8b2f7e042a574c888954fccecfa385b4 # v0.8.1
+github.com/prometheus/client_golang                 f4fb1b73fb099f396a7f0036bf86aa8def4ed823
+github.com/prometheus/client_model                  99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
+github.com/prometheus/common                        89604d197083d4781071d3c65855d24ecfb0a563
+github.com/prometheus/procfs                        cb4147076ac75738c9a7d279075a253c0cc5acbd
+github.com/russross/blackfriday                     05f3235734ad95d0016f6a23902f06461fcf567a # v1.5.2
+github.com/sirupsen/logrus                          8bdbc7bcc01dcbb8ec23dc8a28e332258d25251f # v1.4.1
+github.com/syndtr/gocapability                      d98352740cb2c55f81556b63d4a1ec64c5a319c2
+github.com/urfave/cli                               bfe2e925cfb6d44b40ad3a779165ea7e8aff9212 # v1.22.0
+go.etcd.io/bbolt                                    a0458a2b35708eef59eb5f620ceb3cd1c01a824d # v1.3.3
+go.opencensus.io                                    9c377598961b706d1542bd2d84d538b5094d596e # v0.22.0
+golang.org/x/net                                    f3200d17e092c607f615320ecaad13d87ad9a2b3
+golang.org/x/sync                                   42b317875d0fa942474b76e1b46a6060d720ae6e
+golang.org/x/sys                                    52ab431487773bc9dd1b0766228b1cf3944126bf
+golang.org/x/text                                   19e51611da83d6be54ddafce4a4af510cb3e9ea4
+google.golang.org/genproto                          d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
+google.golang.org/grpc                              39e8a7b072a67ca2a75f57fa2e0d50995f5b22f6 # v1.23.1
 
 # cgroups dependencies
-github.com/cilium/ebpf 60c3aa43f488292fe2ee50fb8b833b383ca8ebbb
+github.com/cilium/ebpf                              60c3aa43f488292fe2ee50fb8b833b383ca8ebbb
 
 # kubernetes dependencies
-github.com/davecgh/go-spew 8991bc29aa16c548c550c7ff78260e27b9ab7c73 # v1.1.1
-github.com/docker/spdystream 449fdfce4d962303d702fec724ef0ad181c92528
-github.com/emicklei/go-restful b993709ae1a4f6dd19cfa475232614441b11c9d5 # v2.9.5
-github.com/google/gofuzz f140a6486e521aad38f5917de355cbf147cc0496 # v1.0.0
-github.com/json-iterator/go v1.1.8
-github.com/modern-go/concurrent bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94 # 1.0.3
-github.com/modern-go/reflect2 4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd # 1.0.1
-github.com/pmezard/go-difflib v1.0.0
-github.com/seccomp/libseccomp-golang 689e3c1541a84461afc49c1c87352a6cedf72e9c # v0.9.1
-github.com/stretchr/testify v1.4.0
-golang.org/x/crypto 1d94cc7ab1c630336ab82ccb9c9cda72a875c382
-golang.org/x/oauth2 0f29369cfe4552d0e4bcddc57cc75f4d7e672a33
-golang.org/x/time 9d24e82272b4f38b78bc8cff74fa936d31ccd8ef
-gopkg.in/inf.v0 v0.9.1
-gopkg.in/yaml.v2 53403b58ad1b561927d19068c655246f2db79d48 # v2.2.8
-k8s.io/api kubernetes-1.18.0-alpha.1
-k8s.io/apimachinery kubernetes-1.18.0-alpha.1
-k8s.io/apiserver kubernetes-1.18.0-alpha.1
-k8s.io/client-go kubernetes-1.18.0-alpha.1
-k8s.io/cri-api kubernetes-1.18.0-alpha.1
-k8s.io/klog v1.0.0
-k8s.io/kubernetes v1.18.0-alpha.1
-k8s.io/utils e782cd3c129fc98ee807f3c889c0f26eb7c9daf5
-sigs.k8s.io/yaml fd68e9863619f6ec2fdd8625fe1f02e7c877e480 # v1.1.0
+github.com/davecgh/go-spew                          8991bc29aa16c548c550c7ff78260e27b9ab7c73 # v1.1.1
+github.com/docker/spdystream                        449fdfce4d962303d702fec724ef0ad181c92528
+github.com/emicklei/go-restful                      b993709ae1a4f6dd19cfa475232614441b11c9d5 # v2.9.5
+github.com/google/gofuzz                            f140a6486e521aad38f5917de355cbf147cc0496 # v1.0.0
+github.com/json-iterator/go                         03217c3e97663914aec3faafde50d081f197a0a2 # v1.1.8
+github.com/modern-go/concurrent                     bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94 # 1.0.3
+github.com/modern-go/reflect2                       4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd # 1.0.1
+github.com/pmezard/go-difflib                       792786c7400a136282c1664665ae0a8db921c6c2 # v1.0.0
+github.com/seccomp/libseccomp-golang                689e3c1541a84461afc49c1c87352a6cedf72e9c # v0.9.1
+github.com/stretchr/testify                         221dbe5ed46703ee255b1da0dec05086f5035f62 # v1.4.0
+golang.org/x/crypto                                 1d94cc7ab1c630336ab82ccb9c9cda72a875c382
+golang.org/x/oauth2                                 0f29369cfe4552d0e4bcddc57cc75f4d7e672a33
+golang.org/x/time                                   9d24e82272b4f38b78bc8cff74fa936d31ccd8ef
+gopkg.in/inf.v0                                     d2d2541c53f18d2a059457998ce2876cc8e67cbf # v0.9.1
+gopkg.in/yaml.v2                                    53403b58ad1b561927d19068c655246f2db79d48 # v2.2.8
+k8s.io/api                                          0952862eca9e889f5aba1dd697ce331d7b126413 # v0.18.0-alpha.1
+k8s.io/apimachinery                                 0ee8b4573e3aecbab8ba0d539f919aa7c53365b2 # v0.18.0-alpha.1
+k8s.io/apiserver                                    ade7e88e6a1d51246811ce11e80c2c04b19b8e1e # v0.18.0-alpha.1
+k8s.io/client-go                                    161ce6706f89eb5d4b15829172b121fed995fa41 # v0.18.0-alpha.1
+k8s.io/cri-api                                      cb37f80103f4d88d4b0cc29542ee6fcfd7c1aa89 # v0.18.0-alpha.1
+k8s.io/klog                                         2ca9ad30301bf30a8a6e0fa2110db6b8df699a91 # v1.0.0
+k8s.io/kubernetes                                   ac4079a5cc22ced66c868f6fd26f8e2497765e51 # v1.18.0-alpha.1
+k8s.io/utils                                        e782cd3c129fc98ee807f3c889c0f26eb7c9daf5
+sigs.k8s.io/yaml                                    fd68e9863619f6ec2fdd8625fe1f02e7c877e480 # v1.1.0
 
 # cni dependencies
-github.com/containerd/go-cni 0d360c50b10b350b6bb23863fd4dfb1c232b01c9
-github.com/containernetworking/cni 4cfb7b568922a3c79a23e438dc52fe537fc9687e # v0.7.1
-github.com/containernetworking/plugins 9f96827c7cabb03f21d86326000c00f61e181f6a # v0.7.6
+github.com/containerd/go-cni                        0d360c50b10b350b6bb23863fd4dfb1c232b01c9
+github.com/containernetworking/cni                  4cfb7b568922a3c79a23e438dc52fe537fc9687e # v0.7.1
+github.com/containernetworking/plugins              9f96827c7cabb03f21d86326000c00f61e181f6a # v0.7.6
 
 # image decrypt depedencies
-github.com/containerd/imgcrypt v1.0.1
-github.com/containers/ocicrypt v1.0.1 # from containerd/imgcrypt
-github.com/fullsailor/pkcs7 8306686428a5fe132eac8cb7c4848af725098bd4 # from containers/ocicrypt
-gopkg.in/square/go-jose.v2 v2.3.1 https://github.com/square/go-jose.git # from containers/ocicrypt
+github.com/containerd/imgcrypt                      9e761ccd6069fb707ec9493435f31475b5524b38 # v1.0.1
+github.com/containers/ocicrypt                      0343cc6053fd65069df55bce6838096e09b4033a # v1.0.1 from containerd/imgcrypt
+github.com/fullsailor/pkcs7                         8306686428a5fe132eac8cb7c4848af725098bd4 #        from containers/ocicrypt
+gopkg.in/square/go-jose.v2                          730df5f748271903322feb182be83b43ebbbe27d # v2.3.1 from containers/ocicrypt


### PR DESCRIPTION
similar to https://github.com/containerd/containerd/pull/3858

Since it doesn't look like this repo will switch to using go mod yet, let's reformat this file to make comparing with other repositories slightly easier and to encourage pinning

Best to review individual commits (no dependencies were updated, so vendored files should stay unmodified)