### PR TITLE
add golang 1.14 to prepare for move

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,10 @@ git:
 language: go
 go:
   - 1.13.8
-  - tip
-
+  - 1.14
 
 matrix:
-  allow_failures:
-    - go: tip
+  - go: 1.14
 
 sudo: required
 


### PR DESCRIPTION
To move to go mod will require one of 1.13.8 or 1.14, can't use go mod vendoring for both at the same time.  Need to start testing 1.14 now in travis to get a feel for issues we'll have when moving up. Adding 1.14 to the optional list. Check that... it worked so well.. and tip (dev) has been so bad for so long let's scratch tip and add 1.14 as mandatory to pass. 

Signed-off-by: Mike Brown <brownwm@us.ibm.com>