### PR TITLE
backport release/1.3: Fix integration test for golang 1.13

### DIFF
--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"fmt"
 	"net"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -63,11 +64,12 @@ var criRoot = flag.String("cri-root", "/var/lib/containerd/io.containerd.grpc.v1
 var runtimeHandler = flag.String("runtime-handler", "", "The runtime handler to use in the test.")
 var containerdBin = flag.String("containerd-bin", "containerd", "The containerd binary name. The name is used to restart containerd during test.")
 
-func init() {
+func TestMain(m *testing.M) {
 	flag.Parse()
 	if err := ConnectDaemons(); err != nil {
 		logrus.WithError(err).Fatalf("Failed to connect daemons")
 	}
+	os.Exit(m.Run())
 }
 
 // ConnectDaemons connect cri plugin and containerd, and initialize the clients.


### PR DESCRIPTION
Hi, 
while trying to run containerd/cri tests on branch 1.3, I got error: `flag provided but not defined: -test.run`. This is already fixed in master, but wanted to backport it to `release/1.3` as it is the branch used for `containerd/containerd` 1.3.x releases, which is the one we currently [use ](https://github.com/kata-containers/runtime/blob/master/versions.yaml#L197-L202)for kata containers testing.

Signed-off-by: Lantao Liu <lantaol@google.com>