### PR TITLE
Add version numbers for newly tagged repos

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -9,13 +9,13 @@ github.com/beorn7/perks                             37c8de3658fcb183f997c4e13e83
 github.com/BurntSushi/toml                          3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005 # v0.3.1
 github.com/cespare/xxhash/v2                        d7df74196a9e781ede915320c11c378c1b2f3a1f # v2.1.1
 github.com/containerd/cgroups                       7347743e5d1e8500d9f27c8e748e689ed991d92b
-github.com/containerd/console                       8375c3424e4d7b114e8a90a4a40c8e1b40d1d4e6
+github.com/containerd/console                       8375c3424e4d7b114e8a90a4a40c8e1b40d1d4e6 # v1.0.0
 github.com/containerd/containerd                    01310155947cb6eec37dcae29742a165e56acb4a
 github.com/containerd/continuity                    0ec596719c75bfd42908850990acea594b7593ac
 github.com/containerd/fifo                          bda0ff6ed73c67bfb5e62bc9c697f146b7fd7f13
 github.com/containerd/go-runc                       a5c2862aed5e6358b305b0e16bfce58e0549b1cd
-github.com/containerd/ttrpc                         92c8520ef9f86600c650dd540266a007bf03670f
-github.com/containerd/typeurl                       a93fcdb778cd272c6e9b3028b2f42d813e785d40
+github.com/containerd/ttrpc                         92c8520ef9f86600c650dd540266a007bf03670f # v1.0.0
+github.com/containerd/typeurl                       a93fcdb778cd272c6e9b3028b2f42d813e785d40 # v1.0.0
 github.com/coreos/go-systemd/v22                    2d78030078ef61b3cae27f42ad6d0e46db51b339 # v22.0.0
 github.com/cpuguy83/go-md2man                       7762f7e404f8416dfa1d9bb6a8c192aa9acb4d19 # v1.0.10
 github.com/docker/go-events                         9461782956ad83b30282bf90e31fa6a70c255ba9


### PR DESCRIPTION
The following repos have been tagged as v1.0.0:

- https://github.com/containerd/console/commit/8375c3424e4d7b114e8a90a4a40c8e1b40d1d4e6
- https://github.com/containerd/ttrpc/commit/92c8520ef9f86600c650dd540266a007bf03670f
- https://github.com/containerd/typeurl/commit/a93fcdb778cd272c6e9b3028b2f42d813e785d40

Signed-off-by: Davanum Srinivas <davanum@gmail.com>