### PR TITLE
Start docker unconditionally

### DIFF
--- a/test/e2e_node/init.yaml
+++ b/test/e2e_node/init.yaml
@@ -70,4 +70,4 @@ runcmd:
   - systemctl enable containerd.target
   - systemctl start containerd.target
   # Start docker after containerd is running. (for Docker 18.09+)
-  - systemctl is-enabled docker && (systemctl is-active docker || systemctl start docker)
+  - systemctl is-active docker || systemctl start docker


### PR DESCRIPTION
`systemctl is-enabled` is not a reliable indicator that the docker service should be started. Docker service may be running even if marked as disabled.