### PR TITLE
Create etcd user in cloud init.

### DIFF
--- a/cluster/gce/cloud-init/master.yaml
+++ b/cluster/gce/cloud-init/master.yaml
@@ -1,5 +1,11 @@
 #cloud-config
 
+users:
+- name: etcd
+  homedir: /var/etcd
+  lock_passwd: true
+  ssh_redirect_user: true
+
 write_files:
 # Setup containerd.
   - path: /etc/systemd/system/containerd-installation.service


### PR DESCRIPTION
Copied the change from https://github.com/kubernetes/kubernetes/pull/88856.

All Kubernetes containerd e2e tests are failing because of this.

See more details at https://github.com/kubernetes/kubernetes/issues/89847

@cheftako

Signed-off-by: Lantao Liu <lantaol@google.com>