### PR TITLE
Enable to pass additional handler on pull for stargz-based remote snapshots

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -73,6 +73,11 @@ type ContainerdConfig struct {
 	// NoPivot disables pivot-root (linux only), required when running a container in a RamDisk with runc
 	// This only works for runtime type "io.containerd.runtime.v1.linux".
 	NoPivot bool `toml:"no_pivot" json:"noPivot"`
+
+	// DisableSnapshotAnnotations disables to pass additional annotations (image
+	// related information) to snapshotters. These annotations are required by
+	// stargz snapshotter (https://github.com/containerd/stargz-snapshotter).
+	DisableSnapshotAnnotations bool `toml:"disable_snapshot_annotations" json:"disableSnapshotAnnotations"`
 }
 
 // CniConfig contains toml config related to cni

--- a/pkg/server/image_pull.go
+++ b/pkg/server/image_pull.go
@@ -120,6 +120,10 @@ func (c *criService) PullImage(ctx context.Context, r *runtime.PullImageRequest)
 	}
 
 	pullOpts = append(pullOpts, c.encryptedImagesPullOpts()...)
+	if !c.config.ContainerdConfig.DisableSnapshotAnnotations {
+		pullOpts = append(pullOpts,
+			containerd.WithImageHandlerWrapper(appendInfoHandlerWrapper(ref)))
+	}
 
 	image, err := c.client.Pull(ctx, ref, pullOpts...)
 	if err != nil {
@@ -421,4 +425,43 @@ func (c *criService) encryptedImagesPullOpts() []containerd.RemoteOpt {
 		return []containerd.RemoteOpt{opt}
 	}
 	return nil
+}
+
+const (
+	// targetRefLabel is a label which contains image reference and will be passed
+	// to snapshotters.
+	targetRefLabel = "containerd.io/snapshot/cri.image-ref"
+	// targetDigestLabel is a label which contains layer digest and will be passed
+	// to snapshotters.
+	targetDigestLabel = "containerd.io/snapshot/cri.layer-digest"
+)
+
+// appendInfoHandlerWrapper makes a handler which appends some basic information
+// of images to each layer descriptor as annotations during unpack. These
+// annotations will be passed to snapshotters as labels. These labels will be
+// used mainly by stargz-based snapshotters for querying image contents from the
+// registry.
+func appendInfoHandlerWrapper(ref string) func(f containerdimages.Handler) containerdimages.Handler {
+	return func(f containerdimages.Handler) containerdimages.Handler {
+		return containerdimages.HandlerFunc(func(ctx context.Context, desc imagespec.Descriptor) ([]imagespec.Descriptor, error) {
+			children, err := f.Handle(ctx, desc)
+			if err != nil {
+				return nil, err
+			}
+			switch desc.MediaType {
+			case imagespec.MediaTypeImageManifest, containerdimages.MediaTypeDockerSchema2Manifest:
+				for i := range children {
+					c := &children[i]
+					if containerdimages.IsLayerType(c.MediaType) {
+						if c.Annotations == nil {
+							c.Annotations = make(map[string]string)
+						}
+						c.Annotations[targetRefLabel] = ref
+						c.Annotations[targetDigestLabel] = c.Digest.String()
+					}
+				}
+			}
+			return children, nil
+		})
+	}
 }


### PR DESCRIPTION
Recently, we started a non-core subproject [stargz-snapshotter](https://github.com/containerd/stargz-snapshotter) aiming to speed up pull operation and we are seeing performance improvement on `containerd.Client`'s `Pull` operation as the following (measured on [Github Actions with Docker Hub](https://github.com/containerd/stargz-snapshotter/actions?query=workflow%3ABenchmark+branch%3Amaster). please also see [README](https://github.com/containerd/stargz-snapshotter/blob/master/README.md#stargz-snapshotter) for more details).

<img src="https://raw.githubusercontent.com/containerd/stargz-snapshotter/f572467b06155ae0a0e011c7f7374149a2b91436/docs/images/benchmarking-result-288c338.png" width="400" alt="The benchmarking result on 288c338">

We've implemented the fundamental features and stargz snapshotter [passes](https://github.com/containerd/stargz-snapshotter/pull/69) [`critest`](https://github.com/kubernetes-sigs/cri-tools/blob/master/docs/validation.md) with a patched version of CRI plugin. Now it's ready for being experimentally used on k8s-based workloads and seeking adoptabilities on it.

Stargz snapshotter is implemented as a standard proxy plugin but because it queries layer contents to the registry it requires containerd clients (including CRI plugin) to pass additional information (image ref and layer digest) for each pull operation through an [image handler](https://github.com/containerd/stargz-snapshotter/blob/19f8fab97dc462d000012d43d73c1dbe2eadd117/stargz/handler/handler.go).

This commit enables to use stargz-based remote snapshots through CRI optionally, by integrating the image handler with CRI. You can test this patch with [this node image](https://github.com/ktock/stargz-snapshotter/blob/test-cri/Dockerfile), which is [tested using critest](https://github.com/ktock/stargz-snapshotter/runs/569924590?check_suite_focus=true).

