### PR TITLE
Support for additional OCI annotations: 'container-name'

### DIFF
--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -44,4 +44,7 @@ const (
 	// UntrustedWorkload is the sandbox annotation for untrusted workload. Untrusted
 	// workload can only run on dedicated runtime for untrusted workload.
 	UntrustedWorkload = "io.kubernetes.cri.untrusted-workload"
+
+	// containerName is the name of the container in the pod
+	ContainerName = "io.kubernetes.cri.container-name"
 )

--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -68,6 +68,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	if metadata == nil {
 		return nil, errors.New("container config must include metadata")
 	}
+	containerName := metadata.Name
 	name := makeContainerName(metadata, sandboxConfig.GetMetadata())
 	log.G(ctx).Debugf("Generated id %q for container %q", id, name)
 	if err = c.containerNameIndex.Reserve(name, id); err != nil {
@@ -147,7 +148,7 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	}
 	log.G(ctx).Debugf("Use OCI runtime %+v for sandbox %q and container %q", ociRuntime, sandboxID, id)
 
-	spec, err := c.containerSpec(id, sandboxID, sandboxPid, sandbox.NetNSPath, config, sandboxConfig,
+	spec, err := c.containerSpec(id, sandboxID, sandboxPid, sandbox.NetNSPath, containerName, config, sandboxConfig,
 		&image.ImageSpec.Config, append(mounts, volumeMounts...), ociRuntime)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to generate container %q spec", id)

--- a/pkg/server/container_create_test.go
+++ b/pkg/server/container_create_test.go
@@ -57,7 +57,8 @@ func TestGeneralContainerSpec(t *testing.T) {
 	ociRuntime := config.Runtime{}
 	c := newTestCRIService()
 	testSandboxID := "sandbox-id"
-	spec, err := c.containerSpec(testID, testSandboxID, testPid, "", containerConfig, sandboxConfig, imageConfig, nil, ociRuntime)
+	testContainerName := "container-name"
+	spec, err := c.containerSpec(testID, testSandboxID, testPid, "", testContainerName, containerConfig, sandboxConfig, imageConfig, nil, ociRuntime)
 	require.NoError(t, err)
 	specCheck(t, testID, testSandboxID, testPid, spec)
 }
@@ -65,6 +66,7 @@ func TestGeneralContainerSpec(t *testing.T) {
 func TestPodAnnotationPassthroughContainerSpec(t *testing.T) {
 	testID := "test-id"
 	testSandboxID := "sandbox-id"
+	testContainerName := "container-name"
 	testPid := uint32(1234)
 
 	for desc, test := range map[string]struct {
@@ -120,7 +122,7 @@ func TestPodAnnotationPassthroughContainerSpec(t *testing.T) {
 			ociRuntime := config.Runtime{
 				PodAnnotations: test.podAnnotations,
 			}
-			spec, err := c.containerSpec(testID, testSandboxID, testPid, "",
+			spec, err := c.containerSpec(testID, testSandboxID, testPid, "", testContainerName,
 				containerConfig, sandboxConfig, imageConfig, nil, ociRuntime)
 			assert.NoError(t, err)
 			assert.NotNil(t, spec)
@@ -268,6 +270,7 @@ func TestVolumeMounts(t *testing.T) {
 func TestContainerAnnotationPassthroughContainerSpec(t *testing.T) {
 	testID := "test-id"
 	testSandboxID := "sandbox-id"
+	testContainerName := "container-name"
 	testPid := uint32(1234)
 
 	for desc, test := range map[string]struct {
@@ -367,7 +370,7 @@ func TestContainerAnnotationPassthroughContainerSpec(t *testing.T) {
 				PodAnnotations:       test.podAnnotations,
 				ContainerAnnotations: test.containerAnnotations,
 			}
-			spec, err := c.containerSpec(testID, testSandboxID, testPid, "",
+			spec, err := c.containerSpec(testID, testSandboxID, testPid, "", testContainerName,
 				containerConfig, sandboxConfig, imageConfig, nil, ociRuntime)
 			assert.NoError(t, err)
 			assert.NotNil(t, spec)

--- a/pkg/server/container_create_unix.go
+++ b/pkg/server/container_create_unix.go
@@ -104,7 +104,7 @@ func (c *criService) containerMounts(sandboxID string, config *runtime.Container
 	return mounts
 }
 
-func (c *criService) containerSpec(id string, sandboxID string, sandboxPid uint32, netNSPath string,
+func (c *criService) containerSpec(id string, sandboxID string, sandboxPid uint32, netNSPath string, containerName string,
 	config *runtime.ContainerConfig, sandboxConfig *runtime.PodSandboxConfig, imageConfig *imagespec.ImageConfig,
 	extraMounts []*runtime.Mount, ociRuntime config.Runtime) (*runtimespec.Spec, error) {
 
@@ -223,6 +223,7 @@ func (c *criService) containerSpec(id string, sandboxID string, sandboxPid uint3
 		customopts.WithSupplementalGroups(supplementalGroups),
 		customopts.WithAnnotation(annotations.ContainerType, annotations.ContainerTypeContainer),
 		customopts.WithAnnotation(annotations.SandboxID, sandboxID),
+		customopts.WithAnnotation(annotations.ContainerName, containerName),
 	)
 	// cgroupns is used for hiding /sys/fs/cgroup from containers.
 	// For compatibility, cgroupns is not used when running in cgroup v1 mode or in privileged.

--- a/pkg/server/container_create_windows.go
+++ b/pkg/server/container_create_windows.go
@@ -34,7 +34,7 @@ func (c *criService) containerMounts(sandboxID string, config *runtime.Container
 	return nil
 }
 
-func (c *criService) containerSpec(id string, sandboxID string, sandboxPid uint32, netNSPath string,
+func (c *criService) containerSpec(id string, sandboxID string, sandboxPid uint32, netNSPath string, containerName string,
 	config *runtime.ContainerConfig, sandboxConfig *runtime.PodSandboxConfig, imageConfig *imagespec.ImageConfig,
 	extraMounts []*runtime.Mount, ociRuntime config.Runtime) (*runtimespec.Spec, error) {
 	specOpts := []oci.SpecOpts{
@@ -89,6 +89,7 @@ func (c *criService) containerSpec(id string, sandboxID string, sandboxPid uint3
 	specOpts = append(specOpts,
 		customopts.WithAnnotation(annotations.ContainerType, annotations.ContainerTypeContainer),
 		customopts.WithAnnotation(annotations.SandboxID, sandboxID),
+		customopts.WithAnnotation(annotations.ContainerName, containerName),
 	)
 
 	return runtimeSpec(id, specOpts...)

--- a/pkg/server/container_create_windows_test.go
+++ b/pkg/server/container_create_windows_test.go
@@ -127,12 +127,13 @@ func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandbox
 func TestContainerWindowsNetworkNamespace(t *testing.T) {
 	testID := "test-id"
 	testSandboxID := "sandbox-id"
+	testContainerName := "container-name"
 	testPid := uint32(1234)
 	nsPath := "test-cni"
 	c := newTestCRIService()
 
 	containerConfig, sandboxConfig, imageConfig, specCheck := getCreateContainerTestData()
-	spec, err := c.containerSpec(testID, testSandboxID, testPid, nsPath, containerConfig, sandboxConfig, imageConfig, nil, config.Runtime{})
+	spec, err := c.containerSpec(testID, testSandboxID, testPid, nsPath, testContainerName, containerConfig, sandboxConfig, imageConfig, nil, config.Runtime{})
 	assert.NoError(t, err)
 	assert.NotNil(t, spec)
 	specCheck(t, testID, testSandboxID, testPid, spec)
@@ -144,6 +145,7 @@ func TestContainerWindowsNetworkNamespace(t *testing.T) {
 func TestMountCleanPath(t *testing.T) {
 	testID := "test-id"
 	testSandboxID := "sandbox-id"
+	testContainerName := "container-name"
 	testPid := uint32(1234)
 	nsPath := "test-cni"
 	c := newTestCRIService()
@@ -153,7 +155,7 @@ func TestMountCleanPath(t *testing.T) {
 		ContainerPath: "c:/test/container-path",
 		HostPath:      "c:/test/host-path",
 	})
-	spec, err := c.containerSpec(testID, testSandboxID, testPid, nsPath, containerConfig, sandboxConfig, imageConfig, nil, config.Runtime{})
+	spec, err := c.containerSpec(testID, testSandboxID, testPid, nsPath, testContainerName, containerConfig, sandboxConfig, imageConfig, nil, config.Runtime{})
 	assert.NoError(t, err)
 	assert.NotNil(t, spec)
 	specCheck(t, testID, testSandboxID, testPid, spec)


### PR DESCRIPTION
Whenever a container is launched in K8s sandbox, currently there are two OCI annotations added
- type (Container or Sandbox)
- sandbox name

It's sometimes required to perform per container operations based on pass through annotations mentioned in pod metadata. (eg setting up per container hooks: [oci-ftrace-syscall-analyzer](https://github.com/KentaTada/oci-ftrace-syscall-analyzer))

Therefore, along with type(Sandbox or Container) and Sandbox name annotations provide support for additional annotation:
- Container name

**Consider the following example** 
* Example pod config:
```bash
# cat pod.yaml
apiVersion: v1
kind: Pod
metadata:
  name: pod-test
  "annotations": {
    "com.something.con1": "true",
    "com.something.con2": "false",
  }
spec:
  containers:
  - name: con1
    image: busybox
    command: ['sh', '-c', 'echo Hello Kubernetes! && sleep 3600']
  - name: con2
    image: busybox
    command: ['sh', '-c', 'echo Hello Kubernetes! && sleep 3600']
```
* `com.something.*` is added in `pod_annotations` in `config.toml` as pass through annotations
* Based on changes in this PR, we can get `container-name` in the OCI spec. Therefore the runtime or shim can perform any per container operations before creating container by comparing `container-name` and `com.something.*`
```bash
# jq .annotations /run/containerd/io.containerd.runtime.v2.task/k8s.io/<containerID>/config.json 
{
  "com.something.con1": "true",
  "com.something.con2": "false",
  "io.kubernetes.cri.container-name": "con1",
  "io.kubernetes.cri.container-type": "container",
  "io.kubernetes.cri.sandbox-id": "2aa321cf47ab6b2a65ee3dd2b95ca35bc1a806f202ea9fe9159fb6690f5efeb5"
}
```
* This will help us achieve fine grained operations per container.