### PR TITLE
Containerd-Cri with supports multi-architectures

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -42,6 +42,8 @@ OFFICIAL_RELEASE=${OFFICIAL_RELEASE:-false}
 # LOCAL_RELEASE indicates that containerd has been built and released
 # locally.
 LOCAL_RELEASE=${LOCAL_RELEASE:-false}
+GOOS=$(go env GOOS)
+GOARCH=$(go env GOARCH)
 
 
 destdir=${BUILD_DIR}/release-stage
@@ -66,7 +68,7 @@ download_containerd() {
 
 # copy_local_containerd copies local containerd release.
 copy_local_containerd() {
-  local -r tarball="${GOPATH}/src/github.com/containerd/containerd/releases/containerd-${VERSION}.linux-amd64.tar.gz"
+  local -r tarball="${GOPATH}/src/github.com/containerd/containerd/releases/containerd-${VERSION}.${GOOS}-${GOARCH}.tar.gz"
   if [[ ! -e "${tarball}" ]]; then
     echo "Containerd release is not built"
     exit 1

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -42,8 +42,14 @@ OFFICIAL_RELEASE=${OFFICIAL_RELEASE:-false}
 # LOCAL_RELEASE indicates that containerd has been built and released
 # locally.
 LOCAL_RELEASE=${LOCAL_RELEASE:-false}
-GOOS=$(go env GOOS)
-GOARCH=$(go env GOARCH)
+if [ -z "${GOOS:-}" ]
+then
+    GOOS=$(go env GOOS)
+fi
+if [ -z "${GOARCH:-}" ]
+then
+    GOARCH=$(go env GOARCH)
+fi
 
 
 destdir=${BUILD_DIR}/release-stage


### PR DESCRIPTION
While the containerd build a file getting information about the architecture and the operating system it is running on. The cri assumes that you are using a Linux computer with x86. This commit makes the CRI adapt to the system and architecture of the computer on which it is being used.