### PR TITLE
Running critest under windows using github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build-windows:
+    name: Build Windows amd64
+    runs-on: windows-latest
+    steps:
+      - name: Set up Go 1.13.10
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13.10
+
+      - name: Checkout cri repo
+        uses: actions/checkout@v2
+        with:
+          path: ${{github.workspace}}\\src\\github.com\\containerd\\cri
+
+      - name: Clone containerd repo
+        run: |
+          bash.exe -c "GO111MODULE=off go get github.com/containerd/containerd"
+
+      - name: Configure Windows environment variables
+        run: |
+          echo "::set-env name=GOPATH::$env:GITHUB_WORKSPACE"
+
+      - name: Build
+        run: |
+          bash.exe -c "pwd && ./test/windows/test.sh"
+        working-directory: ${{github.workspace}}\\src\\github.com\\containerd\\cri
+
+      - name: Upload containerd log file
+        uses: actions/upload-artifact@v1
+        with:
+          name: cadvisor.log
+          path: c:\\_artifacts\\containerd.log

--- a/hack/install/install-containerd.sh
+++ b/hack/install/install-containerd.sh
@@ -29,7 +29,7 @@ CHECKOUT_CONTAINERD=${CHECKOUT_CONTAINERD:-true}
 
 if ${CHECKOUT_CONTAINERD}; then
   # Create a temporary GOPATH for containerd installation.
-  GOPATH=$(mktemp -d /tmp/cri-install-containerd.XXXX)
+  export GOPATH=$(mktemp -d /tmp/cri-install-containerd.XXXX)
   from-vendor CONTAINERD github.com/containerd/containerd
   checkout_repo ${CONTAINERD_PKG} ${CONTAINERD_VERSION} ${CONTAINERD_REPO}
 fi

--- a/test/windows/test.sh
+++ b/test/windows/test.sh
@@ -19,15 +19,9 @@ set -o nounset
 set -o pipefail
 
 export PATH="/c/Program Files/Containerd:$PATH"
-REPO_TAR="${REPO_TAR:-"/c/cri.tar.gz"}"
 FOCUS="${FOCUS:-"Conformance"}"
 SKIP="${SKIP:-""}"
 REPORT_DIR="${REPORT_DIR:-"/c/_artifacts"}"
-
-repo="$GOPATH/src/github.com/containerd/cri"
-mkdir -p "${repo}"
-cd "${repo}"
-tar -xzf "${REPO_TAR}"
 
 make install.deps
 make install -e BINDIR="/c/Program Files/Containerd"


### PR DESCRIPTION
`pull-cri-containerd-windows-cri` is busted for a while now. We need to find another alternative.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>