### PR TITLE
add default scheme when mirrors no scheme

### DIFF
--- a/pkg/server/image_pull.go
+++ b/pkg/server/image_pull.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -370,6 +371,19 @@ func defaultScheme(host string) string {
 	return "https"
 }
 
+// addDefaultScheme returns the endpoint with default scheme
+func addDefaultScheme(endpoint string) (string, error) {
+	if strings.Contains(endpoint, "://") {
+		return endpoint, nil
+	}
+	ue := "dummy://" + endpoint
+	u, err := url.Parse(ue)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s://%s", defaultScheme(u.Host), endpoint), nil
+}
+
 // registryEndpoints returns endpoints for a given host.
 // It adds default registry endpoint if it does not exist in the passed-in endpoint list.
 // It also supports wildcard host matching with `*`.
@@ -384,6 +398,13 @@ func (c *criService) registryEndpoints(host string) ([]string, error) {
 	defaultHost, err := docker.DefaultHost(host)
 	if err != nil {
 		return nil, errors.Wrap(err, "get default host")
+	}
+	for i := range endpoints {
+		en, err := addDefaultScheme(endpoints[i])
+		if err != nil {
+			return nil, errors.Wrap(err, "parse endpoint url")
+		}
+		endpoints[i] = en
 	}
 	for _, e := range endpoints {
 		u, err := url.Parse(e)

--- a/pkg/server/image_pull_test.go
+++ b/pkg/server/image_pull_test.go
@@ -227,6 +227,23 @@ func TestRegistryEndpoints(t *testing.T) {
 				"https://registry-3.io/path",
 			},
 		},
+		"miss scheme endpoint in list with path": {
+			mirrors: map[string]criconfig.Mirror{
+				"registry-3.io": {
+					Endpoints: []string{
+						"https://registry-3.io",
+						"registry-1.io",
+						"127.0.0.1:1234",
+					},
+				},
+			},
+			host: "registry-3.io",
+			expected: []string{
+				"https://registry-3.io",
+				"https://registry-1.io",
+				"http://127.0.0.1:1234",
+			},
+		},
 	} {
 		t.Logf("TestCase %q", desc)
 		c := newTestCRIService()


### PR DESCRIPTION
add default scheme on endpoints in mirrors. 
It is helpful in https://github.com/containerd/containerd/issues/4108 

Signed-off-by: yang yang yang8518296@163.com