### PR TITLE
introduce managed namespaces

### DIFF
--- a/integration/namespace_lifecycle_test.go
+++ b/integration/namespace_lifecycle_test.go
@@ -1,0 +1,86 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
+	ctrdutil "github.com/containerd/cri/pkg/containerd/util"
+)
+
+const (
+	created   = "created.test.dev"
+	updated   = "updated.test.dev"
+	unmanaged = "unmanaged.test.dev"
+)
+
+func TestManagedNamespaceLifecycle(t *testing.T) {
+	ctx, crt, _, err := NamespaceContextAndRawClients(unmanaged)
+	assert.NoError(t, err)
+
+	t.Run(unmanaged, func(t *testing.T) {
+		t.Log("status from unmanaged namespace should fail")
+		_, err := crt.Status(ctx, &runtime.StatusRequest{Verbose: true})
+		assert.Error(t, err)
+	})
+
+	t.Run(created, testCreateManagedNamespace(created, crt, func(ctx context.Context, ns string) error {
+		return containerdClient.NamespaceService().Create(ctx, ns, map[string]string{"io.cri-containerd": "managed"})
+	}))
+
+	t.Run(updated, testCreateManagedNamespace(updated, crt, func(ctx context.Context, ns string) error {
+		return containerdClient.NamespaceService().SetLabel(ctx, ns, "io.cri-containerd", "managed")
+	}))
+}
+
+type createManagedNamespaceFn func(context.Context, string) error
+
+func testCreateManagedNamespace(ns string, runtimeServiceClient runtime.RuntimeServiceClient, create createManagedNamespaceFn) func(*testing.T) {
+	return func(t *testing.T) {
+		ctx := ctrdutil.NamespacedContext(ns)
+		defer containerdClient.NamespaceService().Delete(ctx, ns)
+
+		t.Logf("manage namespace %q", ns)
+		require.NoError(t, create(ctx, ns))
+
+		// give it a chance to start
+		time.Sleep(5 * time.Second)
+
+		t.Log("status from managed namespace should succeed")
+		res, err := runtimeServiceClient.Status(ctx, &runtime.StatusRequest{Verbose: true})
+		assert.NoError(t, err)
+		assert.NotEmpty(t, res)
+
+		t.Log("delete managed namespace")
+		assert.NoError(t,
+			containerdClient.NamespaceService().Delete(ctx, ns),
+		)
+
+		// give it a chance to stop
+		time.Sleep(5 * time.Second)
+
+		t.Log("status from deleted namespace should fail")
+		res, err = runtimeServiceClient.Status(ctx, &runtime.StatusRequest{})
+		assert.Error(t, err)
+	}
+}

--- a/integration/namespace_test.go
+++ b/integration/namespace_test.go
@@ -1,0 +1,96 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"path/filepath"
+	"time"
+
+	"github.com/containerd/cri/pkg/constants"
+
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	kubeletutil "k8s.io/kubernetes/pkg/kubelet/util"
+
+	criconfig "github.com/containerd/cri/pkg/config"
+	ctrdutil "github.com/containerd/cri/pkg/containerd/util"
+)
+
+func NamespaceContextAndRawClients(ns string) (context.Context, runtime.RuntimeServiceClient, runtime.ImageServiceClient, error) {
+	addr, dialer, err := kubeletutil.GetAddressAndDialer(*criEndpoint)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to get dialer")
+	}
+	ctx, cancel := context.WithTimeout(ctrdutil.NamespacedContext(ns), timeout)
+	defer cancel()
+	conn, err := grpc.DialContext(ctx, addr, grpc.WithInsecure(), grpc.WithContextDialer(dialer))
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to connect cri endpoint")
+	}
+	return ctrdutil.NamespacedContext(ns), runtime.NewRuntimeServiceClient(conn), runtime.NewImageServiceClient(conn), nil
+}
+
+func NamespacedConfig(ns string, crt runtime.RuntimeServiceClient) (*criconfig.PluginConfig, error) {
+	resp, err := crt.Status(ctrdutil.NamespacedContext(ns), &runtime.StatusRequest{Verbose: true})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get status")
+	}
+	config := &criconfig.PluginConfig{}
+	if err := json.Unmarshal([]byte(resp.Info["config"]), config); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal config")
+	}
+	return config, nil
+}
+
+func StartManagedNamespace(ns string, crt runtime.RuntimeServiceClient) error {
+	ctx := ctrdutil.NamespacedContext(ns)
+	err := containerdClient.NamespaceService().SetLabel(ctx, ns, "io.cri-containerd", "managed")
+	if err != nil {
+		return err
+	}
+	defaultConfig, err := NamespacedConfig(constants.K8sContainerdNamespace, crt)
+	if err != nil {
+		return err
+	}
+	time.Sleep(5 * time.Second)
+	namespaceConfig, err := NamespacedConfig(ns, crt)
+	if err != nil {
+		return err
+	}
+	info, err := ioutil.ReadDir(defaultConfig.NetworkPluginConfDir)
+	if err != nil {
+		return err
+	}
+	for i := range info {
+		inf := info[i]
+		if !inf.IsDir() {
+			b, err := ioutil.ReadFile(filepath.Join(defaultConfig.NetworkPluginConfDir, inf.Name()))
+			if err != nil {
+				return err
+			}
+			err = ioutil.WriteFile(filepath.Join(namespaceConfig.NetworkPluginConfDir, inf.Name()), b, inf.Mode())
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/integration/namespaced_image_load_test.go
+++ b/integration/namespaced_image_load_test.go
@@ -1,0 +1,131 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/namespaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func TestImageLoadNamespaced(t *testing.T) {
+	const ns = "test.dev"
+	ctx, crt, img, err := NamespaceContextAndRawClients(ns)
+	assert.NoError(t, err)
+	assert.NoError(t, StartManagedNamespace(ns, crt))
+	t.Run(ns, testImageLoad(ctx, crt, img))
+}
+
+func testImageLoad(ctx context.Context, crt runtime.RuntimeServiceClient, img runtime.ImageServiceClient) func(*testing.T) {
+	return func(t *testing.T) {
+		ns, err := namespaces.NamespaceRequired(ctx)
+		require.NoError(t, err)
+
+		testImage := "busybox:latest"
+		loadedImage := "docker.io/library/" + testImage
+		_, err = exec.LookPath("docker")
+		if err != nil {
+			t.Skipf("Docker is not available: %v", err)
+		}
+		t.Logf("docker save image into tarball")
+		output, err := exec.Command("docker", "pull", testImage).CombinedOutput()
+		require.NoError(t, err, "output: %q", output)
+		tarF, err := ioutil.TempFile("", "image-load")
+		tar := tarF.Name()
+		require.NoError(t, err)
+		defer func() {
+			assert.NoError(t, os.RemoveAll(tar))
+		}()
+		output, err = exec.Command("docker", "save", testImage, "-o", tar).CombinedOutput()
+		require.NoError(t, err, "output: %q", output)
+
+		t.Logf("make sure no such image in cri")
+		res, err := img.ImageStatus(ctx, &runtime.ImageStatusRequest{Image: &runtime.ImageSpec{Image: testImage}})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		if res.Image != nil {
+			_, err = img.RemoveImage(ctx, &runtime.RemoveImageRequest{Image: &runtime.ImageSpec{Image: testImage}})
+			require.NoError(t, err)
+		}
+
+		t.Logf("load image in cri")
+		ctr, err := exec.LookPath("ctr")
+		require.NoError(t, err, "ctr should be installed, make sure you've run `make install.deps`")
+		output, err = exec.Command(ctr, "-address="+containerdEndpoint,
+			"-n="+ns, "images", "import", tar).CombinedOutput()
+		require.NoError(t, err, "output: %q", output)
+
+		t.Logf("make sure image is loaded")
+		// Use Eventually because the cri plugin needs a short period of time
+		// to pick up images imported into containerd directly.
+		require.NoError(t, Eventually(func() (bool, error) {
+			res, err = img.ImageStatus(ctx, &runtime.ImageStatusRequest{Image: &runtime.ImageSpec{Image: testImage}})
+			if err != nil {
+				return false, err
+			}
+			return res != nil, nil
+		}, 100*time.Millisecond, 10*time.Second))
+		require.Equal(t, []string{loadedImage}, res.Image.RepoTags)
+
+		t.Logf("create a container with the loaded image")
+		sbConfig := PodSandboxConfig("sandbox", Randomize("image-load"))
+		pbr, err := crt.RunPodSandbox(ctx, &runtime.RunPodSandboxRequest{
+			Config: sbConfig, RuntimeHandler: *runtimeHandler,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, pbr)
+		defer func() {
+			_, err = crt.StopPodSandbox(ctx, &runtime.StopPodSandboxRequest{PodSandboxId: pbr.PodSandboxId})
+			assert.NoError(t, err)
+			_, err = crt.RemovePodSandbox(ctx, &runtime.RemovePodSandboxRequest{PodSandboxId: pbr.PodSandboxId})
+			assert.NoError(t, err)
+		}()
+		containerConfig := ContainerConfig(
+			"container",
+			testImage,
+			WithCommand("tail", "-f", "/dev/null"),
+		)
+		// Rely on sandbox clean to do container cleanup.
+		ctc, err := crt.CreateContainer(ctx, &runtime.CreateContainerRequest{
+			PodSandboxId: pbr.PodSandboxId, Config: containerConfig, SandboxConfig: sbConfig,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, ctc)
+
+		cts, err := crt.StartContainer(ctx, &runtime.StartContainerRequest{
+			ContainerId: ctc.ContainerId,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, cts)
+
+		t.Logf("make sure container is running")
+		ctx, err := crt.ContainerStatus(ctx, &runtime.ContainerStatusRequest{
+			ContainerId: ctc.ContainerId,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, ctx)
+		require.Equal(t, runtime.ContainerState_CONTAINER_RUNNING, ctx.Status.State)
+	}
+}

--- a/pkg/config/config_unix.go
+++ b/pkg/config/config_unix.go
@@ -19,16 +19,27 @@
 package config
 
 import (
+	"path/filepath"
+
 	"github.com/containerd/containerd"
 	"k8s.io/kubernetes/pkg/kubelet/server/streaming"
+
+	"github.com/containerd/cri/pkg/constants"
+)
+
+var (
+	// DefaultNetworkPluginBinDir is the default CNI directory for binaries
+	DefaultNetworkPluginBinDir = "/opt/cni/bin"
+	// DefaultNetworkPluginConfDir is the default CNI directory for configuration
+	DefaultNetworkPluginConfDir = "/etc/cni/net.d"
 )
 
 // DefaultConfig returns default configurations of cri plugin.
 func DefaultConfig() PluginConfig {
 	return PluginConfig{
 		CniConfig: CniConfig{
-			NetworkPluginBinDir:       "/opt/cni/bin",
-			NetworkPluginConfDir:      "/etc/cni/net.d",
+			NetworkPluginBinDir:       DefaultNetworkPluginBinDir,
+			NetworkPluginConfDir:      DefaultNetworkPluginConfDir,
 			NetworkPluginMaxConfNum:   1, // only one CNI plugin config file will be loaded
 			NetworkPluginConfTemplate: "",
 		},
@@ -66,4 +77,13 @@ func DefaultConfig() PluginConfig {
 		MaxConcurrentDownloads: 3,
 		DisableProcMount:       false,
 	}
+}
+
+// DefaultServiceConfig returns default configurations for a namespace.
+func DefaultServiceConfig(ns string) PluginConfig {
+	config := DefaultConfig()
+	if ns != constants.K8sContainerdNamespace {
+		config.NetworkPluginConfDir = filepath.Join("/opt/cri", ns, DefaultNetworkPluginConfDir)
+	}
+	return config
 }

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -24,15 +24,24 @@ import (
 
 	"github.com/containerd/containerd"
 	"k8s.io/kubernetes/pkg/kubelet/server/streaming"
+
+	"github.com/containerd/cri/pkg/constants"
+)
+
+var (
+	// DefaultNetworkPluginBinDir is the default CNI directory for binaries
+	DefaultNetworkPluginBinDir = filepath.Join(os.Getenv("ProgramFiles"), "containerd", "cni", "bin")
+	// DefaultNetworkPluginConfDir is the default CNI directory for configuration
+	DefaultNetworkPluginConfDir = filepath.Join(os.Getenv("ProgramFiles"), "containerd", "cni", "conf")
 )
 
 // DefaultConfig returns default configurations of cri plugin.
 func DefaultConfig() PluginConfig {
 	return PluginConfig{
 		CniConfig: CniConfig{
-			NetworkPluginBinDir:       filepath.Join(os.Getenv("ProgramFiles"), "containerd", "cni", "bin"),
-			NetworkPluginConfDir:      filepath.Join(os.Getenv("ProgramFiles"), "containerd", "cni", "conf"),
-			NetworkPluginMaxConfNum:   1,
+			NetworkPluginBinDir:       DefaultNetworkPluginBinDir,
+			NetworkPluginConfDir:      DefaultNetworkPluginConfDir,
+			NetworkPluginMaxConfNum:   1, // only one CNI plugin config file will be loaded
 			NetworkPluginConfTemplate: "",
 		},
 		ContainerdConfig: ContainerdConfig{
@@ -67,4 +76,13 @@ func DefaultConfig() PluginConfig {
 		MaxConcurrentDownloads: 3,
 		// TODO(windows): Add platform specific config, so that most common defaults can be shared.
 	}
+}
+
+// DefaultServiceConfig returns default configurations for a namespace.
+func DefaultServiceConfig(ns string) PluginConfig {
+	config := DefaultConfig()
+	if ns != constants.K8sContainerdNamespace {
+		config.NetworkPluginConfDir = filepath.Join(os.Getenv("ProgramFiles"), "containerd", "cri", ns, "cni", "conf")
+	}
+	return config
 }

--- a/pkg/containerd/util/util.go
+++ b/pkg/containerd/util/util.go
@@ -19,6 +19,7 @@ package util
 import (
 	"time"
 
+	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/namespaces"
 	"golang.org/x/net/context"
 
@@ -31,16 +32,25 @@ const deferCleanupTimeout = 1 * time.Minute
 
 // DeferContext returns a context for containerd cleanup operations in defer.
 // A default timeout is applied to avoid cleanup operation pending forever.
-func DeferContext() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(NamespacedContext(), deferCleanupTimeout)
+func DeferContext(ns string) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(NamespacedContext(ns), deferCleanupTimeout)
 }
 
 // NamespacedContext returns a context with kubernetes namespace set.
-func NamespacedContext() context.Context {
-	return WithNamespace(context.Background())
+func NamespacedContext(ns string) context.Context {
+	return namespaces.WithNamespace(
+		log.WithLogger(context.Background(), log.L.WithField("ns", ns)), ns,
+	)
 }
 
 // WithNamespace adds kubernetes namespace to the context.
 func WithNamespace(ctx context.Context) context.Context {
-	return namespaces.WithNamespace(ctx, constants.K8sContainerdNamespace)
+	_, ok := namespaces.Namespace(ctx)
+	if !ok {
+		ns := constants.K8sContainerdNamespace
+		ctx = namespaces.WithNamespace(
+			log.WithLogger(ctx, log.L.WithField("ns", ns)), ns,
+		)
+	}
+	return ctx
 }

--- a/pkg/server/container_create_test.go
+++ b/pkg/server/container_create_test.go
@@ -55,10 +55,10 @@ func TestGeneralContainerSpec(t *testing.T) {
 	testPid := uint32(1234)
 	containerConfig, sandboxConfig, imageConfig, specCheck := getCreateContainerTestData()
 	ociRuntime := config.Runtime{}
-	c := newTestCRIService()
+	c, ctx := newTestCRIService()
 	testSandboxID := "sandbox-id"
 	testContainerName := "container-name"
-	spec, err := c.containerSpec(testID, testSandboxID, testPid, "", testContainerName, containerConfig, sandboxConfig, imageConfig, nil, ociRuntime)
+	spec, err := c.containerSpec(ctx, testID, testSandboxID, testPid, "", testContainerName, containerConfig, sandboxConfig, imageConfig, nil, ociRuntime)
 	require.NoError(t, err)
 	specCheck(t, testID, testSandboxID, testPid, spec)
 }
@@ -113,7 +113,7 @@ func TestPodAnnotationPassthroughContainerSpec(t *testing.T) {
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {
-			c := newTestCRIService()
+			c, ctx := newTestCRIService()
 			containerConfig, sandboxConfig, imageConfig, specCheck := getCreateContainerTestData()
 			if test.configChange != nil {
 				test.configChange(sandboxConfig)
@@ -122,7 +122,7 @@ func TestPodAnnotationPassthroughContainerSpec(t *testing.T) {
 			ociRuntime := config.Runtime{
 				PodAnnotations: test.podAnnotations,
 			}
-			spec, err := c.containerSpec(testID, testSandboxID, testPid, "", testContainerName,
+			spec, err := c.containerSpec(ctx, testID, testSandboxID, testPid, "", testContainerName,
 				containerConfig, sandboxConfig, imageConfig, nil, ociRuntime)
 			assert.NoError(t, err)
 			assert.NotNil(t, spec)
@@ -248,7 +248,7 @@ func TestVolumeMounts(t *testing.T) {
 		config := &imagespec.ImageConfig{
 			Volumes: test.imageVolumes,
 		}
-		c := newTestCRIService()
+		c, _ := newTestCRIService()
 		got := c.volumeMounts(testContainerRootDir, test.criMounts, config)
 		assert.Len(t, got, len(test.expectedMountDest))
 		for _, dest := range test.expectedMountDest {
@@ -358,7 +358,7 @@ func TestContainerAnnotationPassthroughContainerSpec(t *testing.T) {
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {
-			c := newTestCRIService()
+			c, ctx := newTestCRIService()
 			containerConfig, sandboxConfig, imageConfig, specCheck := getCreateContainerTestData()
 			if test.configChange != nil {
 				test.configChange(containerConfig)
@@ -370,7 +370,7 @@ func TestContainerAnnotationPassthroughContainerSpec(t *testing.T) {
 				PodAnnotations:       test.podAnnotations,
 				ContainerAnnotations: test.containerAnnotations,
 			}
-			spec, err := c.containerSpec(testID, testSandboxID, testPid, "", testContainerName,
+			spec, err := c.containerSpec(ctx, testID, testSandboxID, testPid, "", testContainerName,
 				containerConfig, sandboxConfig, imageConfig, nil, ociRuntime)
 			assert.NoError(t, err)
 			assert.NotNil(t, spec)

--- a/pkg/server/container_create_unix.go
+++ b/pkg/server/container_create_unix.go
@@ -20,6 +20,7 @@ package server
 
 import (
 	"bufio"
+	"context"
 	"io"
 	"os"
 	"strconv"
@@ -107,7 +108,7 @@ func (c *criService) containerMounts(sandboxID string, config *runtime.Container
 	return mounts
 }
 
-func (c *criService) containerSpec(id string, sandboxID string, sandboxPid uint32, netNSPath string, containerName string,
+func (c *criService) containerSpec(ctx context.Context, id string, sandboxID string, sandboxPid uint32, netNSPath string, containerName string,
 	config *runtime.ContainerConfig, sandboxConfig *runtime.PodSandboxConfig, imageConfig *imagespec.ImageConfig,
 	extraMounts []*runtime.Mount, ociRuntime config.Runtime) (*runtimespec.Spec, error) {
 
@@ -241,7 +242,7 @@ func (c *criService) containerSpec(id string, sandboxID string, sandboxPid uint3
 				Type: runtimespec.CgroupNamespace,
 			}))
 	}
-	return runtimeSpec(id, specOpts...)
+	return runtimeSpec(ctx, id, specOpts...)
 }
 
 func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageConfig *imagespec.ImageConfig) ([]oci.SpecOpts, error) {

--- a/pkg/server/container_create_windows.go
+++ b/pkg/server/container_create_windows.go
@@ -19,6 +19,8 @@
 package server
 
 import (
+	"context"
+
 	"github.com/containerd/containerd/oci"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
@@ -34,7 +36,7 @@ func (c *criService) containerMounts(sandboxID string, config *runtime.Container
 	return nil
 }
 
-func (c *criService) containerSpec(id string, sandboxID string, sandboxPid uint32, netNSPath string, containerName string,
+func (c *criService) containerSpec(ctx context.Context, id string, sandboxID string, sandboxPid uint32, netNSPath string, containerName string,
 	config *runtime.ContainerConfig, sandboxConfig *runtime.PodSandboxConfig, imageConfig *imagespec.ImageConfig,
 	extraMounts []*runtime.Mount, ociRuntime config.Runtime) (*runtimespec.Spec, error) {
 	specOpts := []oci.SpecOpts{
@@ -92,7 +94,7 @@ func (c *criService) containerSpec(id string, sandboxID string, sandboxPid uint3
 		customopts.WithAnnotation(annotations.ContainerName, containerName),
 	)
 
-	return runtimeSpec(id, specOpts...)
+	return runtimeSpec(ctx, id, specOpts...)
 }
 
 // No extra spec options needed for windows.

--- a/pkg/server/container_create_windows_test.go
+++ b/pkg/server/container_create_windows_test.go
@@ -130,10 +130,10 @@ func TestContainerWindowsNetworkNamespace(t *testing.T) {
 	testContainerName := "container-name"
 	testPid := uint32(1234)
 	nsPath := "test-cni"
-	c := newTestCRIService()
+	c, ctx := newTestCRIService()
 
 	containerConfig, sandboxConfig, imageConfig, specCheck := getCreateContainerTestData()
-	spec, err := c.containerSpec(testID, testSandboxID, testPid, nsPath, testContainerName, containerConfig, sandboxConfig, imageConfig, nil, config.Runtime{})
+	spec, err := c.containerSpec(ctx, testID, testSandboxID, testPid, nsPath, testContainerName, containerConfig, sandboxConfig, imageConfig, nil, config.Runtime{})
 	assert.NoError(t, err)
 	assert.NotNil(t, spec)
 	specCheck(t, testID, testSandboxID, testPid, spec)
@@ -148,14 +148,14 @@ func TestMountCleanPath(t *testing.T) {
 	testContainerName := "container-name"
 	testPid := uint32(1234)
 	nsPath := "test-cni"
-	c := newTestCRIService()
+	c, ctx := newTestCRIService()
 
 	containerConfig, sandboxConfig, imageConfig, specCheck := getCreateContainerTestData()
 	containerConfig.Mounts = append(containerConfig.Mounts, &runtime.Mount{
 		ContainerPath: "c:/test/container-path",
 		HostPath:      "c:/test/host-path",
 	})
-	spec, err := c.containerSpec(testID, testSandboxID, testPid, nsPath, testContainerName, containerConfig, sandboxConfig, imageConfig, nil, config.Runtime{})
+	spec, err := c.containerSpec(ctx, testID, testSandboxID, testPid, nsPath, testContainerName, containerConfig, sandboxConfig, imageConfig, nil, config.Runtime{})
 	assert.NoError(t, err)
 	assert.NotNil(t, spec)
 	specCheck(t, testID, testSandboxID, testPid, spec)

--- a/pkg/server/container_execsync.go
+++ b/pkg/server/container_execsync.go
@@ -117,7 +117,7 @@ func (c *criService) execInternal(ctx context.Context, container containerd.Cont
 		return nil, errors.Wrapf(err, "failed to create exec %q", execID)
 	}
 	defer func() {
-		deferCtx, deferCancel := ctrdutil.DeferContext()
+		deferCtx, deferCancel := ctrdutil.DeferContext(c.name)
 		defer deferCancel()
 		if _, err := process.Delete(deferCtx, containerd.WithProcessKill); err != nil {
 			log.G(ctx).WithError(err).Errorf("Failed to delete exec process %q for container %q", execID, id)

--- a/pkg/server/container_list_test.go
+++ b/pkg/server/container_list_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 
 	containerstore "github.com/containerd/cri/pkg/store/container"
@@ -77,7 +76,7 @@ func TestToCRIContainer(t *testing.T) {
 }
 
 func TestFilterContainers(t *testing.T) {
-	c := newTestCRIService()
+	c, _ := newTestCRIService()
 
 	testContainers := []*runtime.Container{
 		{
@@ -168,7 +167,7 @@ func (c containerForTest) toContainer() (containerstore.Container, error) {
 }
 
 func TestListContainers(t *testing.T) {
-	c := newTestCRIService()
+	c, ctx := newTestCRIService()
 	sandboxesInStore := []sandboxstore.Sandbox{
 		sandboxstore.NewSandbox(
 			sandboxstore.Metadata{
@@ -333,7 +332,7 @@ func TestListContainers(t *testing.T) {
 		},
 	} {
 		t.Logf("TestCase: %s", testdesc)
-		resp, err := c.ListContainers(context.Background(), &runtime.ListContainersRequest{Filter: testdata.filter})
+		resp, err := c.ListContainers(ctx, &runtime.ListContainersRequest{Filter: testdata.filter})
 		assert.NoError(t, err)
 		require.NotNil(t, resp)
 		containers := resp.GetContainers()

--- a/pkg/server/container_status_test.go
+++ b/pkg/server/container_status_test.go
@@ -195,7 +195,7 @@ func TestContainerStatus(t *testing.T) {
 		},
 	} {
 		t.Logf("TestCase %q", desc)
-		c := newTestCRIService()
+		c, ctx := newTestCRIService()
 		metadata, status, image, expected := getContainerStatusTestData()
 		// Update status with test case.
 		status.FinishedAt = test.finishedAt
@@ -212,7 +212,7 @@ func TestContainerStatus(t *testing.T) {
 			c.imageStore, err = imagestore.NewFakeStore([]imagestore.Image{*image})
 			assert.NoError(t, err)
 		}
-		resp, err := c.ContainerStatus(context.Background(), &runtime.ContainerStatusRequest{ContainerId: container.ID})
+		resp, err := c.ContainerStatus(ctx, &runtime.ContainerStatusRequest{ContainerId: container.ID})
 		if test.expectErr {
 			assert.Error(t, err)
 			assert.Nil(t, resp)

--- a/pkg/server/container_stop.go
+++ b/pkg/server/container_stop.go
@@ -77,7 +77,7 @@ func (c *criService) stopContainer(ctx context.Context, container containerstore
 	// Handle unknown state.
 	if state == runtime.ContainerState_CONTAINER_UNKNOWN {
 		// Start an exit handler for containers in unknown state.
-		waitCtx, waitCancel := context.WithCancel(ctrdutil.NamespacedContext())
+		waitCtx, waitCancel := context.WithCancel(ctrdutil.NamespacedContext(c.name))
 		defer waitCancel()
 		exitCh, err := task.Wait(waitCtx)
 		if err != nil {
@@ -87,7 +87,7 @@ func (c *criService) stopContainer(ctx context.Context, container containerstore
 			return cleanupUnknownContainer(ctx, id, container)
 		}
 
-		exitCtx, exitCancel := context.WithCancel(context.Background())
+		exitCtx, exitCancel := context.WithCancel(ctrdutil.NamespacedContext(c.name))
 		stopCh := c.eventMonitor.startExitMonitor(exitCtx, id, task.Pid(), exitCh)
 		defer func() {
 			exitCancel()

--- a/pkg/server/container_stop_test.go
+++ b/pkg/server/container_stop_test.go
@@ -61,14 +61,13 @@ func TestWaitContainerStop(t *testing.T) {
 			expectErr: false,
 		},
 	} {
-		c := newTestCRIService()
+		c, ctx := newTestCRIService()
 		container, err := containerstore.NewContainer(
 			containerstore.Metadata{ID: id},
 			containerstore.WithFakeStatus(*test.status),
 		)
 		assert.NoError(t, err)
 		assert.NoError(t, c.containerStore.Add(container))
-		ctx := context.Background()
 		if test.cancel {
 			cancelledCtx, cancel := context.WithCancel(ctx)
 			cancel()

--- a/pkg/server/container_update_resources_unix.go
+++ b/pkg/server/container_update_resources_unix.go
@@ -82,7 +82,7 @@ func (c *criService) updateContainerResources(ctx context.Context,
 	}
 	defer func() {
 		if retErr != nil {
-			deferCtx, deferCancel := ctrdutil.DeferContext()
+			deferCtx, deferCancel := ctrdutil.DeferContext(c.name)
 			defer deferCancel()
 			// Reset spec on error.
 			if err := updateContainerSpec(deferCtx, cntr.Container, oldSpec); err != nil {

--- a/pkg/server/helpers.go
+++ b/pkg/server/helpers.go
@@ -67,6 +67,8 @@ const (
 	containersDir = "containers"
 	// Delimiter used to construct container/sandbox names.
 	nameDelimiter = "_"
+	// namespacesDir contains namespace configuration (toml), containers (dir), and sandboxes (dir)
+	namespacesDir = "namespaces"
 
 	// criContainerdPrefix is common prefix for cri-containerd
 	criContainerdPrefix = "io.cri-containerd"
@@ -79,11 +81,14 @@ const (
 	// imageLabelKey is the label key indicating the image is managed by cri plugin.
 	imageLabelKey = criContainerdPrefix + ".image"
 	// imageLabelValue is the label value indicating the image is managed by cri plugin.
-	imageLabelValue = "managed"
+	imageLabelValue = managedLabelValue
 	// sandboxMetadataExtension is an extension name that identify metadata of sandbox in CreateContainerRequest
 	sandboxMetadataExtension = criContainerdPrefix + ".sandbox.metadata"
 	// containerMetadataExtension is an extension name that identify metadata of container in CreateContainerRequest
 	containerMetadataExtension = criContainerdPrefix + ".container.metadata"
+
+	// managedLabelValue is the label value set for criContainerdPrefix labels indicating the resource is managed by cri
+	managedLabelValue = "managed"
 
 	// defaultIfName is the default network interface for the pods
 	defaultIfName = "eth0"
@@ -297,7 +302,7 @@ func parseImageReferences(refs []string) ([]string, []string) {
 }
 
 // generateRuntimeOptions generates runtime options from cri plugin config.
-func generateRuntimeOptions(r criconfig.Runtime, c criconfig.Config) (interface{}, error) {
+func generateRuntimeOptions(r criconfig.Runtime, c criconfig.PluginConfig) (interface{}, error) {
 	if r.Options == nil {
 		if r.Type != plugin.RuntimeLinuxV1 {
 			return nil, nil

--- a/pkg/server/helpers_test.go
+++ b/pkg/server/helpers_test.go
@@ -157,7 +157,7 @@ func TestLocalResolve(t *testing.T) {
 		},
 		Size: 10,
 	}
-	c := newTestCRIService()
+	c, _ := newTestCRIService()
 	var err error
 	c.imageStore, err = imagestore.NewFakeStore([]imagestore.Image{image})
 	assert.NoError(t, err)
@@ -280,7 +280,7 @@ systemd_cgroup = true
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {
-			opts, err := generateRuntimeOptions(test.r, test.c)
+			opts, err := generateRuntimeOptions(test.r, test.c.PluginConfig)
 			assert.NoError(t, err)
 			assert.Equal(t, test.expectedOptions, opts)
 		})

--- a/pkg/server/helpers_unix.go
+++ b/pkg/server/helpers_unix.go
@@ -136,6 +136,10 @@ func checkSelinuxLevel(level string) (bool, error) {
 	return true, nil
 }
 
+func (c *criServiceManager) apparmorEnabled() bool {
+	return runcapparmor.IsEnabled() && !c.config.DisableApparmor
+}
+
 func (c *criService) apparmorEnabled() bool {
 	return runcapparmor.IsEnabled() && !c.config.DisableApparmor
 }

--- a/pkg/server/image_list_test.go
+++ b/pkg/server/image_list_test.go
@@ -22,14 +22,13 @@ import (
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 
 	imagestore "github.com/containerd/cri/pkg/store/image"
 )
 
 func TestListImages(t *testing.T) {
-	c := newTestCRIService()
+	c, ctx := newTestCRIService()
 	imagesInStore := []imagestore.Image{
 		{
 			ID:      "sha256:1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
@@ -102,7 +101,7 @@ func TestListImages(t *testing.T) {
 	c.imageStore, err = imagestore.NewFakeStore(imagesInStore)
 	assert.NoError(t, err)
 
-	resp, err := c.ListImages(context.Background(), &runtime.ListImagesRequest{})
+	resp, err := c.ListImages(ctx, &runtime.ListImagesRequest{})
 	assert.NoError(t, err)
 	require.NotNil(t, resp)
 	images := resp.GetImages()

--- a/pkg/server/image_pull_test.go
+++ b/pkg/server/image_pull_test.go
@@ -246,7 +246,7 @@ func TestRegistryEndpoints(t *testing.T) {
 		},
 	} {
 		t.Logf("TestCase %q", desc)
-		c := newTestCRIService()
+		c, _ := newTestCRIService()
 		c.config.Registry.Mirrors = test.mirrors
 		got, err := c.registryEndpoints(test.host)
 		assert.NoError(t, err)
@@ -321,7 +321,7 @@ func TestEncryptedImagePullOpts(t *testing.T) {
 		},
 	} {
 		t.Logf("TestCase %q", desc)
-		c := newTestCRIService()
+		c, _ := newTestCRIService()
 		c.config.ImageDecryption.KeyModel = test.keyModel
 		got := len(c.encryptedImagesPullOpts())
 		assert.Equal(t, test.expectedOpts, got)

--- a/pkg/server/image_status_test.go
+++ b/pkg/server/image_status_test.go
@@ -22,7 +22,6 @@ import (
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 
 	imagestore "github.com/containerd/cri/pkg/store/image"
@@ -52,9 +51,9 @@ func TestImageStatus(t *testing.T) {
 		Username:    "user",
 	}
 
-	c := newTestCRIService()
+	c, ctx := newTestCRIService()
 	t.Logf("should return nil image spec without error for non-exist image")
-	resp, err := c.ImageStatus(context.Background(), &runtime.ImageStatusRequest{
+	resp, err := c.ImageStatus(ctx, &runtime.ImageStatusRequest{
 		Image: &runtime.ImageSpec{Image: testID},
 	})
 	assert.NoError(t, err)
@@ -65,7 +64,7 @@ func TestImageStatus(t *testing.T) {
 	assert.NoError(t, err)
 
 	t.Logf("should return correct image status for exist image")
-	resp, err = c.ImageStatus(context.Background(), &runtime.ImageStatusRequest{
+	resp, err = c.ImageStatus(ctx, &runtime.ImageStatusRequest{
 		Image: &runtime.ImageSpec{Image: testID},
 	})
 	assert.NoError(t, err)

--- a/pkg/server/imagefs_info_test.go
+++ b/pkg/server/imagefs_info_test.go
@@ -22,14 +22,13 @@ import (
 	snapshot "github.com/containerd/containerd/snapshots"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 
 	snapshotstore "github.com/containerd/cri/pkg/store/snapshot"
 )
 
 func TestImageFsInfo(t *testing.T) {
-	c := newTestCRIService()
+	c, ctx := newTestCRIService()
 	snapshots := []snapshotstore.Snapshot{
 		{
 			Key:       "key1",
@@ -62,7 +61,7 @@ func TestImageFsInfo(t *testing.T) {
 	for _, sn := range snapshots {
 		c.snapshotStore.Add(sn)
 	}
-	resp, err := c.ImageFsInfo(context.Background(), &runtime.ImageFsInfoRequest{})
+	resp, err := c.ImageFsInfo(ctx, &runtime.ImageFsInfoRequest{})
 	require.NoError(t, err)
 	stats := resp.GetImageFilesystems()
 	assert.Len(t, stats, 1)

--- a/pkg/server/restart.go
+++ b/pkg/server/restart.go
@@ -278,7 +278,7 @@ func (c *criService) loadContainer(ctx context.Context, cntr containerd.Containe
 				}
 				// Wait for the task for exit monitor.
 				// wait is a long running background request, no timeout needed.
-				exitCh, err := t.Wait(ctrdutil.NamespacedContext())
+				exitCh, err := t.Wait(ctrdutil.NamespacedContext(c.name))
 				if err != nil {
 					if !errdefs.IsNotFound(err) {
 						return errors.Wrap(err, "failed to wait for task")
@@ -290,7 +290,7 @@ func (c *criService) loadContainer(ctx context.Context, cntr containerd.Containe
 					status.Reason = unknownExitReason
 				} else {
 					// Start exit monitor.
-					c.eventMonitor.startExitMonitor(context.Background(), id, status.Pid, exitCh)
+					c.eventMonitor.startExitMonitor(ctrdutil.NamespacedContext(c.name), id, status.Pid, exitCh)
 				}
 			case containerd.Stopped:
 				// Task is stopped. Updata status and delete the task.
@@ -379,7 +379,7 @@ func (c *criService) loadSandbox(ctx context.Context, cntr containerd.Container)
 			if taskStatus.Status == containerd.Running {
 				// Wait for the task for sandbox monitor.
 				// wait is a long running background request, no timeout needed.
-				exitCh, err := t.Wait(ctrdutil.NamespacedContext())
+				exitCh, err := t.Wait(ctrdutil.NamespacedContext(c.name))
 				if err != nil {
 					if !errdefs.IsNotFound(err) {
 						return status, errors.Wrap(err, "failed to wait for task")
@@ -389,7 +389,7 @@ func (c *criService) loadSandbox(ctx context.Context, cntr containerd.Container)
 					// Task is running, set sandbox state as READY.
 					status.State = sandboxstore.StateReady
 					status.Pid = t.Pid()
-					c.eventMonitor.startExitMonitor(context.Background(), meta.ID, status.Pid, exitCh)
+					c.eventMonitor.startExitMonitor(ctrdutil.NamespacedContext(c.name), meta.ID, status.Pid, exitCh)
 				}
 			} else {
 				// Task is not running. Delete the task and set sandbox state as NOTREADY.

--- a/pkg/server/sandbox_list_test.go
+++ b/pkg/server/sandbox_list_test.go
@@ -81,7 +81,7 @@ func TestToCRISandbox(t *testing.T) {
 }
 
 func TestFilterSandboxes(t *testing.T) {
-	c := newTestCRIService()
+	c, _ := newTestCRIService()
 	sandboxes := []sandboxstore.Sandbox{
 		sandboxstore.NewSandbox(
 			sandboxstore.Metadata{

--- a/pkg/server/sandbox_portforward_unix.go
+++ b/pkg/server/sandbox_portforward_unix.go
@@ -28,7 +28,6 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
@@ -93,10 +92,10 @@ func (c *criService) portForward(ctx context.Context, id string, port int32, str
 		}
 		go func() {
 			if _, err := io.Copy(in, stream); err != nil {
-				logrus.WithError(err).Errorf("Failed to copy port forward input for %q port %d", id, port)
+				log.G(ctx).WithError(err).Errorf("Failed to copy port forward input for %q port %d", id, port)
 			}
 			in.Close()
-			logrus.Debugf("Finish copying port forward input for %q port %d", id, port)
+			log.G(ctx).Debugf("Finish copying port forward input for %q port %d", id, port)
 		}()
 
 		if err := cmd.Run(); err != nil {

--- a/pkg/server/sandbox_run_test.go
+++ b/pkg/server/sandbox_run_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/containerd/cri/pkg/annotations"
 	criconfig "github.com/containerd/cri/pkg/config"
+	"github.com/containerd/cri/pkg/constants"
 	sandboxstore "github.com/containerd/cri/pkg/store/sandbox"
 )
 
@@ -87,7 +88,7 @@ func TestSandboxContainerSpec(t *testing.T) {
 		},
 	} {
 		t.Logf("TestCase %q", desc)
-		c := newTestCRIService()
+		c, ctx := newTestCRIService()
 		config, imageConfig, specCheck := getRunPodSandboxTestData()
 		if test.configChange != nil {
 			test.configChange(config)
@@ -96,7 +97,7 @@ func TestSandboxContainerSpec(t *testing.T) {
 		if test.imageConfigChange != nil {
 			test.imageConfigChange(imageConfig)
 		}
-		spec, err := c.sandboxContainerSpec(testID, config, imageConfig, nsPath,
+		spec, err := c.sandboxContainerSpec(ctx, testID, config, imageConfig, nsPath,
 			test.podAnnotations)
 		if test.expectErr {
 			assert.Error(t, err)
@@ -480,10 +481,8 @@ func TestGetSandboxRuntime(t *testing.T) {
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {
-			cri := newTestCRIService()
-			cri.config = criconfig.Config{
-				PluginConfig: criconfig.DefaultConfig(),
-			}
+			cri, _ := newTestCRIService()
+			cri.config.PluginConfig = criconfig.DefaultServiceConfig(constants.K8sContainerdNamespace)
 			cri.config.ContainerdConfig.DefaultRuntimeName = criconfig.RuntimeDefault
 			cri.config.ContainerdConfig.Runtimes = test.runtimes
 			r, err := cri.getSandboxRuntime(test.sandboxConfig, test.runtimeHandler)

--- a/pkg/server/sandbox_run_unix.go
+++ b/pkg/server/sandbox_run_unix.go
@@ -19,6 +19,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -37,7 +38,7 @@ import (
 	osinterface "github.com/containerd/cri/pkg/os"
 )
 
-func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxConfig,
+func (c *criService) sandboxContainerSpec(ctx context.Context, id string, config *runtime.PodSandboxConfig,
 	imageConfig *imagespec.ImageConfig, nsPath string, runtimePodAnnotations []string) (*runtimespec.Spec, error) {
 	// Creates a spec Generator with the default spec.
 	// TODO(random-liu): [P1] Compare the default settings with docker and containerd default.
@@ -151,7 +152,7 @@ func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 		customopts.WithAnnotation(annotations.SandboxLogDir, config.GetLogDirectory()),
 	)
 
-	return runtimeSpec(id, specOpts...)
+	return runtimeSpec(ctx, id, specOpts...)
 }
 
 // sandboxContainerSpecOpts generates OCI spec options for

--- a/pkg/server/sandbox_run_unix_test.go
+++ b/pkg/server/sandbox_run_unix_test.go
@@ -148,12 +148,12 @@ func TestLinuxSandboxContainerSpec(t *testing.T) {
 		},
 	} {
 		t.Logf("TestCase %q", desc)
-		c := newTestCRIService()
+		c, ctx := newTestCRIService()
 		config, imageConfig, specCheck := getRunPodSandboxTestData()
 		if test.configChange != nil {
 			test.configChange(config)
 		}
-		spec, err := c.sandboxContainerSpec(testID, config, imageConfig, nsPath, nil)
+		spec, err := c.sandboxContainerSpec(ctx, testID, config, imageConfig, nsPath, nil)
 		if test.expectErr {
 			assert.Error(t, err)
 			assert.Nil(t, spec)
@@ -337,7 +337,7 @@ options timeout:1
 		},
 	} {
 		t.Logf("TestCase %q", desc)
-		c := newTestCRIService()
+		c, _ := newTestCRIService()
 		c.os.(*ostesting.FakeOS).HostnameFn = func() (string, error) {
 			return realhostname, nil
 		}
@@ -410,9 +410,9 @@ options timeout:1
 
 func TestSandboxDisableCgroup(t *testing.T) {
 	config, imageConfig, _ := getRunPodSandboxTestData()
-	c := newTestCRIService()
+	c, ctx := newTestCRIService()
 	c.config.DisableCgroup = true
-	spec, err := c.sandboxContainerSpec("test-id", config, imageConfig, "test-cni", []string{})
+	spec, err := c.sandboxContainerSpec(ctx, "test-id", config, imageConfig, "test-cni", []string{})
 	require.NoError(t, err)
 
 	t.Log("resource limit should not be set")

--- a/pkg/server/sandbox_run_windows.go
+++ b/pkg/server/sandbox_run_windows.go
@@ -19,6 +19,8 @@
 package server
 
 import (
+	"context"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -30,7 +32,7 @@ import (
 	customopts "github.com/containerd/cri/pkg/containerd/opts"
 )
 
-func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxConfig,
+func (c *criService) sandboxContainerSpec(ctx context.Context, id string, config *runtime.PodSandboxConfig,
 	imageConfig *imagespec.ImageConfig, nsPath string, runtimePodAnnotations []string) (*runtimespec.Spec, error) {
 	// Creates a spec Generator with the default spec.
 	specOpts := []oci.SpecOpts{
@@ -67,7 +69,7 @@ func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 		customopts.WithAnnotation(annotations.SandboxLogDir, config.GetLogDirectory()),
 	)
 
-	return runtimeSpec(id, specOpts...)
+	return runtimeSpec(ctx, id, specOpts...)
 }
 
 // No sandbox container spec options for windows yet.

--- a/pkg/server/sandbox_run_windows_test.go
+++ b/pkg/server/sandbox_run_windows_test.go
@@ -73,10 +73,10 @@ func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConf
 func TestSandboxWindowsNetworkNamespace(t *testing.T) {
 	testID := "test-id"
 	nsPath := "test-cni"
-	c := newTestCRIService()
+	c, ctx := newTestCRIService()
 
 	config, imageConfig, specCheck := getRunPodSandboxTestData()
-	spec, err := c.sandboxContainerSpec(testID, config, imageConfig, nsPath, nil)
+	spec, err := c.sandboxContainerSpec(ctx, testID, config, imageConfig, nsPath, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, spec)
 	specCheck(t, testID, spec)

--- a/pkg/server/sandbox_stop.go
+++ b/pkg/server/sandbox_stop.go
@@ -114,7 +114,7 @@ func (c *criService) stopSandboxContainer(ctx context.Context, sandbox sandboxst
 	// The cleanup logic is the same with container unknown state.
 	if state == sandboxstore.StateUnknown {
 		// Start an exit handler for containers in unknown state.
-		waitCtx, waitCancel := context.WithCancel(ctrdutil.NamespacedContext())
+		waitCtx, waitCancel := context.WithCancel(ctrdutil.NamespacedContext(c.name))
 		defer waitCancel()
 		exitCh, err := task.Wait(waitCtx)
 		if err != nil {
@@ -124,7 +124,7 @@ func (c *criService) stopSandboxContainer(ctx context.Context, sandbox sandboxst
 			return cleanupUnknownSandbox(ctx, id, sandbox)
 		}
 
-		exitCtx, exitCancel := context.WithCancel(context.Background())
+		exitCtx, exitCancel := context.WithCancel(ctrdutil.NamespacedContext(c.name))
 		stopCh := c.eventMonitor.startExitMonitor(exitCtx, id, task.Pid(), exitCh)
 		defer func() {
 			exitCancel()

--- a/pkg/server/sandbox_stop_test.go
+++ b/pkg/server/sandbox_stop_test.go
@@ -51,12 +51,11 @@ func TestWaitSandboxStop(t *testing.T) {
 			expectErr: false,
 		},
 	} {
-		c := newTestCRIService()
+		c, ctx := newTestCRIService()
 		sandbox := sandboxstore.NewSandbox(
 			sandboxstore.Metadata{ID: id},
 			sandboxstore.Status{State: test.state},
 		)
-		ctx := context.Background()
 		if test.cancel {
 			cancelledCtx, cancel := context.WithCancel(ctx)
 			cancel()

--- a/pkg/server/service_manager.go
+++ b/pkg/server/service_manager.go
@@ -1,0 +1,287 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"sync"
+
+	"github.com/BurntSushi/toml"
+	"github.com/containerd/containerd"
+	eventtypes "github.com/containerd/containerd/api/events"
+	"github.com/containerd/containerd/events/exchange"
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"github.com/containerd/cri/pkg/atomic"
+	criconfig "github.com/containerd/cri/pkg/config"
+	"github.com/containerd/cri/pkg/constants"
+	osinterface "github.com/containerd/cri/pkg/os"
+	"github.com/containerd/cri/pkg/registrar"
+	containerstore "github.com/containerd/cri/pkg/store/container"
+	imagestore "github.com/containerd/cri/pkg/store/image"
+	sandboxstore "github.com/containerd/cri/pkg/store/sandbox"
+	snapshotstore "github.com/containerd/cri/pkg/store/snapshot"
+)
+
+var _ CRIService = &criServiceManager{}
+
+// criServiceManager implements CRIService.
+type criServiceManager struct {
+	// config contains all configurations.
+	config criconfig.Config
+	// client is an instance of the containerd client
+	client *containerd.Client
+	// os is an interface for all required os operations.
+	os osinterface.OS
+	// ex is an event exchange for container runtime events
+	ex *exchange.Exchange
+	// ns is a map of criServices keyed by namespace, protected by a mutex
+	ns sync.Map
+}
+
+func (c *criServiceManager) namespaceRequired(ctx context.Context) (*criService, error) {
+	nsName, err := namespaces.NamespaceRequired(ctx)
+	if err != nil {
+		return nil, err
+	}
+	nsService, ok := c.ns.Load(nsName)
+	if !ok {
+		return nil, errors.Errorf("unmanaged namespace: %s", nsName)
+	}
+	return nsService.(*criService), nil
+}
+
+// Run the CRI service.
+func (c *criServiceManager) Run(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	log.G(ctx).Info("Start subscribing containerd events")
+	// filter on container events to handle across all namespaces
+	envCh, errCh := c.client.Subscribe(ctx, `topic=="/tasks/oom"`, `topic~="/images/"`, `topic~="/namespaces/"`)
+
+	// setup managed namespaces
+	namespaceNames, err := c.client.NamespaceService().List(ctx)
+	if err != nil {
+		return errors.Wrap(err, "Failed to list namespaces")
+	}
+	if len(namespaceNames) == 0 {
+		log.G(ctx).Infof("Namespaces list from containerd is empty, establishing default %q", constants.K8sContainerdNamespace)
+		namespaceNames = []string{constants.K8sContainerdNamespace}
+	}
+	for _, nsn := range namespaceNames {
+		labels, err := c.client.NamespaceService().Labels(ctx, nsn)
+		if err != nil {
+			log.G(ctx).WithError(err).Errorf("Failed to list labels for namespace %q, assuming managed", nsn)
+			labels = map[string]string{
+				criContainerdPrefix: managedLabelValue,
+			}
+		}
+		managed, ok := labels[criContainerdPrefix]
+		switch {
+		case !ok && nsn == constants.K8sContainerdNamespace:
+			// special case for the default namespace: if it isn't marked as managed, mark it as such
+			fallthrough
+		case managed == managedLabelValue:
+			nsx := namespaces.WithNamespace(log.WithLogger(ctx, log.L.WithField("ns", nsn)), nsn)
+			if err := c.client.NamespaceService().SetLabel(nsx, nsn, criContainerdPrefix, managedLabelValue); err != nil {
+				return errors.Wrapf(err, "Failed to label namespace %q", nsn)
+			}
+		}
+	}
+
+	// start the event exchange
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case err := <-errCh:
+			return err
+		case env, ok := <-envCh:
+			if ok {
+				name, evt, err := convertEvent(env.Event)
+				if err != nil {
+					log.G(ctx).Error(err)
+				}
+				switch e := evt.(type) {
+				case *eventtypes.NamespaceCreate:
+					if err := c.handleNamespaceUpdate(ctx, name, e.Labels); err != nil {
+						log.G(ctx).Error(err)
+					}
+				case *eventtypes.NamespaceUpdate:
+					if err := c.handleNamespaceUpdate(ctx, name, e.Labels); err != nil {
+						log.G(ctx).Error(err)
+					}
+				case *eventtypes.NamespaceDelete:
+					if err := c.handleNamespaceUpdate(ctx, name, map[string]string{}); err != nil {
+						log.G(ctx).Error(err)
+					}
+				}
+				if err := c.ex.Forward(ctx, env); err != nil {
+					return err
+				}
+			}
+		}
+	}
+}
+
+// Close stops the CRI service.
+func (c *criServiceManager) Close() error {
+	logrus.Info("Stop CRI service")
+	c.ns.Range(func(nsn interface{}, nsv interface{}) bool {
+		defer c.ns.Delete(nsn)
+		ns := nsv.(*criService)
+		if err := ns.Close(); err != nil {
+			logrus.WithField("ns", ns.name).WithError(err).Warn("Failed to stop CRI namespace")
+		}
+		return true
+	})
+	return nil
+}
+
+func (c *criServiceManager) newNamespacedService(ctx context.Context, name string) (_ context.Context, svc *criService, err error) {
+	ctx = namespaces.WithNamespace(log.WithLogger(ctx, log.L.WithField("ns", name)), name)
+	svc = &criService{
+		name:               name,
+		os:                 c.os,
+		client:             c.client,
+		imageStore:         imagestore.NewStore(c.client),
+		sandboxStore:       sandboxstore.NewStore(),
+		sandboxNameIndex:   registrar.NewRegistrar(),
+		containerStore:     containerstore.NewStore(),
+		containerNameIndex: registrar.NewRegistrar(),
+		snapshotStore:      snapshotstore.NewStore(),
+		initialized:        atomic.NewBool(false),
+	}
+
+	return ctx, svc, func() error {
+		if svc.name == constants.K8sContainerdNamespace {
+			svc.config.RootDir = c.config.RootDir
+			svc.config.StateDir = c.config.StateDir
+			svc.config.PluginConfig = c.config.PluginConfig
+		} else {
+			svc.config.RootDir = c.getNamespacesRootDir(svc.name)
+			svc.config.StateDir = c.getNamespacesStateDir(svc.name)
+			if err := c.loadNamespacedServiceConfig(svc.name, &svc.config); err != nil {
+				log.G(ctx).WithError(err).Warnf("Using default config for namespace")
+				svc.config.PluginConfig = criconfig.DefaultServiceConfig(svc.name)
+			}
+		}
+
+		if svc.config.Snapshotter == "" {
+			svc.config.Snapshotter = c.config.Snapshotter
+		}
+		if svc.config.Snapshotter == "" {
+			svc.config.Snapshotter = containerd.DefaultSnapshotter
+		}
+		if snapshotter := svc.client.SnapshotService(svc.config.Snapshotter); snapshotter == nil {
+			return errors.Errorf("failed to find snapshotter %q", svc.config.Snapshotter)
+		}
+		svc.imageFSPath = imageFSPath(c.config.ContainerdRootDir, svc.config.Snapshotter)
+
+		return nil
+	}()
+}
+
+func (c *criServiceManager) startNamespacedService(ctx context.Context, svc *criService) error {
+	err := svc.initNetworking()
+	if err != nil {
+		return errors.Wrap(err, "failed to initialize networking")
+	}
+
+	svc.cniNetConfMonitor, err = newCNINetConfSyncer(svc.config.NetworkPluginConfDir, svc.netPlugin, svc.cniLoadOptions())
+	if err != nil {
+		return errors.Wrap(err, "failed to create cni conf monitor")
+	}
+
+	// prepare streaming server
+	svc.streamServer, err = newStreamServer(svc)
+	if err != nil {
+		return errors.Wrap(err, "failed to create stream server")
+	}
+
+	svc.eventMonitor = newEventMonitor(ctx, svc)
+
+	go svc.Run(ctx, c.ex)
+
+	return nil
+}
+
+func (c *criServiceManager) handleNamespaceUpdate(ctx context.Context, ns string, labels map[string]string) error {
+	managed, ok := labels[criContainerdPrefix]
+	if ok && managed == managedLabelValue {
+		ctx, svc, err := c.newNamespacedService(ctx, ns)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to handle namespace update %q", ns)
+		}
+		if _, loaded := c.ns.LoadOrStore(ns, svc); !loaded {
+			if err := c.saveNamespacedServiceConfig(ns, &svc.config); err != nil {
+				log.G(ctx).WithError(err).Warn("Unable to persist namespace config")
+			}
+			if err := c.startNamespacedService(ctx, svc); err != nil {
+				log.G(ctx).WithError(err).Error("Unable to start namespace service")
+				c.ns.Delete(ns)
+			}
+		}
+		return nil
+	} else if v, ok := c.ns.Load(ns); ok {
+		defer c.ns.Delete(ns)
+		return v.(*criService).Close()
+	}
+	return nil
+}
+
+// getNamespacesRootDir returns the root directory for managing namespace persistent state and configuration.
+func (m *criServiceManager) getNamespacesRootDir(id string) string {
+	return filepath.Join(m.config.RootDir, namespacesDir, id)
+}
+
+// getNamespacesStateDir returns the root directory for managing namespace ephemeral state.
+func (m *criServiceManager) getNamespacesStateDir(id string) string {
+	return filepath.Join(m.config.StateDir, namespacesDir, id)
+}
+
+// loadNamespacedServiceConfig for a namespace
+func (m *criServiceManager) loadNamespacedServiceConfig(ns string, config *serviceConfig) error {
+	path := filepath.Join(m.getNamespacesRootDir(ns), "config.toml")
+	_, err := toml.DecodeFile(path, &config.PluginConfig)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to load service config for namespace %q", ns)
+	}
+	return nil
+}
+
+// saveNamespacedServiceConfig for a namespace
+func (m *criServiceManager) saveNamespacedServiceConfig(ns string, config *serviceConfig) error {
+	path := filepath.Join(m.getNamespacesRootDir(ns), "config.toml")
+	if err := m.os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return errors.Wrapf(err, "Failed to save service config for namespace %q", ns)
+	}
+	buffer := &bytes.Buffer{}
+	if err := toml.NewEncoder(buffer).Encode(&config.PluginConfig); err != nil {
+		return errors.Wrapf(err, "Failed to save service config for namespace %q", ns)
+	}
+	if err := m.os.WriteFile(path, buffer.Bytes(), 0600); err != nil {
+		return errors.Wrapf(err, "Failed to save service config for namespace %q", ns)
+	}
+	return nil
+}

--- a/pkg/server/service_test.go
+++ b/pkg/server/service_test.go
@@ -17,7 +17,12 @@
 package server
 
 import (
+	"context"
+
+	"github.com/containerd/containerd/namespaces"
+
 	criconfig "github.com/containerd/cri/pkg/config"
+	"github.com/containerd/cri/pkg/constants"
 	ostesting "github.com/containerd/cri/pkg/os/testing"
 	"github.com/containerd/cri/pkg/registrar"
 	servertesting "github.com/containerd/cri/pkg/server/testing"
@@ -38,9 +43,9 @@ const (
 )
 
 // newTestCRIService creates a fake criService for test.
-func newTestCRIService() *criService {
+func newTestCRIService() (*criService, context.Context) {
 	return &criService{
-		config: criconfig.Config{
+		config: serviceConfig{
 			RootDir:  testRootDir,
 			StateDir: testStateDir,
 			PluginConfig: criconfig.PluginConfig{
@@ -56,5 +61,5 @@ func newTestCRIService() *criService {
 		containerStore:     containerstore.NewStore(),
 		containerNameIndex: registrar.NewRegistrar(),
 		netPlugin:          servertesting.NewFakeCNIPlugin(),
-	}
+	}, namespaces.WithNamespace(context.Background(), constants.K8sContainerdNamespace)
 }

--- a/pkg/server/service_unix.go
+++ b/pkg/server/service_unix.go
@@ -31,9 +31,7 @@ import (
 const networkAttachCount = 2
 
 // initPlatform handles linux specific initialization for the CRI service.
-func (c *criService) initPlatform() error {
-	var err error
-
+func (c *criServiceManager) initPlatform() error {
 	if runcsystem.RunningInUserNS() {
 		if !(c.config.DisableCgroup && !c.apparmorEnabled() && c.config.RestrictOOMScoreAdj) {
 			logrus.Warn("Running containerd in a user namespace typically requires disable_cgroup, disable_apparmor, restrict_oom_score_adj set to be true")
@@ -48,6 +46,12 @@ func (c *criService) initPlatform() error {
 		selinux.SetDisabled()
 	}
 
+	return nil
+}
+
+// initNetworking handles linux specific initialization for the CNI plugin.
+func (c *criService) initNetworking() error {
+	var err error
 	// Pod needs to attach to at least loopback network and a non host network,
 	// hence networkAttachCount is 2. If there are more network configs the
 	// pod will be attached to all the networks but we will only use the ip

--- a/pkg/server/service_windows.go
+++ b/pkg/server/service_windows.go
@@ -28,7 +28,12 @@ import (
 const windowsNetworkAttachCount = 1
 
 // initPlatform handles linux specific initialization for the CRI service.
-func (c *criService) initPlatform() error {
+func (c *criServiceManager) initPlatform() error {
+	return nil
+}
+
+// initNetworking handles windows specific initialization for the CNI plugin.
+func (c *criService) initNetworking() error {
 	var err error
 	// For windows, the loopback network is added as default.
 	// There is no need to explicitly add one hence networkAttachCount is 1.

--- a/pkg/server/streaming.go
+++ b/pkg/server/streaming.go
@@ -66,23 +66,23 @@ func getStreamListenerMode(c *criService) (streamListenerMode, error) {
 	return withoutTLS, nil
 }
 
-func newStreamServer(c *criService, addr, port, streamIdleTimeout string) (streaming.Server, error) {
-	if addr == "" {
+func newStreamServer(c *criService) (streaming.Server, error) {
+	if c.config.StreamServerAddress == "" {
 		a, err := k8snet.ResolveBindAddress(nil)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get stream server address")
 		}
-		addr = a.String()
+		c.config.StreamServerAddress = a.String()
 	}
 	config := streaming.DefaultConfig
-	if streamIdleTimeout != "" {
+	if c.config.StreamIdleTimeout != "" {
 		var err error
-		config.StreamIdleTimeout, err = time.ParseDuration(streamIdleTimeout)
+		config.StreamIdleTimeout, err = time.ParseDuration(c.config.StreamIdleTimeout)
 		if err != nil {
 			return nil, errors.Wrap(err, "invalid stream idle timeout")
 		}
 	}
-	config.Addr = net.JoinHostPort(addr, port)
+	config.Addr = net.JoinHostPort(c.config.StreamServerAddress, c.config.StreamServerPort)
 	run := newStreamRuntime(c)
 	tlsMode, err := getStreamListenerMode(c)
 	if err != nil {
@@ -127,7 +127,7 @@ func newStreamRuntime(c *criService) streaming.Runtime {
 // returns non-zero exit code.
 func (s *streamRuntime) Exec(containerID string, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser,
 	tty bool, resize <-chan remotecommand.TerminalSize) error {
-	exitCode, err := s.c.execInContainer(ctrdutil.NamespacedContext(), containerID, execOptions{
+	exitCode, err := s.c.execInContainer(ctrdutil.NamespacedContext(s.c.name), containerID, execOptions{
 		cmd:    cmd,
 		stdin:  stdin,
 		stdout: stdout,
@@ -149,15 +149,14 @@ func (s *streamRuntime) Exec(containerID string, cmd []string, stdin io.Reader, 
 
 func (s *streamRuntime) Attach(containerID string, in io.Reader, out, err io.WriteCloser, tty bool,
 	resize <-chan remotecommand.TerminalSize) error {
-	return s.c.attachContainer(ctrdutil.NamespacedContext(), containerID, in, out, err, tty, resize)
+	return s.c.attachContainer(ctrdutil.NamespacedContext(s.c.name), containerID, in, out, err, tty, resize)
 }
 
 func (s *streamRuntime) PortForward(podSandboxID string, port int32, stream io.ReadWriteCloser) error {
 	if port <= 0 || port > math.MaxUint16 {
 		return errors.Errorf("invalid port %d", port)
 	}
-	ctx := ctrdutil.NamespacedContext()
-	return s.c.portForward(ctx, podSandboxID, port, stream)
+	return s.c.portForward(ctrdutil.NamespacedContext(s.c.name), podSandboxID, port, stream)
 }
 
 // handleResizing spawns a goroutine that processes the resize channel, calling resizeFunc for each

--- a/pkg/server/streaming_test.go
+++ b/pkg/server/streaming_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/containerd/cri/pkg/config"
+	"github.com/containerd/cri/pkg/constants"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,8 +32,8 @@ func TestValidateStreamServer(t *testing.T) {
 	}{
 		"should pass with default withoutTLS": {
 			criService: &criService{
-				config: config.Config{
-					PluginConfig: config.DefaultConfig(),
+				config: serviceConfig{
+					PluginConfig: config.DefaultServiceConfig(constants.K8sContainerdNamespace),
 				},
 			},
 			tlsMode:   withoutTLS,
@@ -40,7 +41,7 @@ func TestValidateStreamServer(t *testing.T) {
 		},
 		"should pass with x509KeyPairTLS": {
 			criService: &criService{
-				config: config.Config{
+				config: serviceConfig{
 					PluginConfig: config.PluginConfig{
 						EnableTLSStreaming: true,
 						X509KeyPairStreaming: config.X509KeyPairStreaming{
@@ -55,7 +56,7 @@ func TestValidateStreamServer(t *testing.T) {
 		},
 		"should pass with selfSign": {
 			criService: &criService{
-				config: config.Config{
+				config: serviceConfig{
 					PluginConfig: config.PluginConfig{
 						EnableTLSStreaming: true,
 					},
@@ -66,7 +67,7 @@ func TestValidateStreamServer(t *testing.T) {
 		},
 		"should return error with X509 keypair but not EnableTLSStreaming": {
 			criService: &criService{
-				config: config.Config{
+				config: serviceConfig{
 					PluginConfig: config.PluginConfig{
 						EnableTLSStreaming: false,
 						X509KeyPairStreaming: config.X509KeyPairStreaming{
@@ -81,7 +82,7 @@ func TestValidateStreamServer(t *testing.T) {
 		},
 		"should return error with X509 TLSCertFile empty": {
 			criService: &criService{
-				config: config.Config{
+				config: serviceConfig{
 					PluginConfig: config.PluginConfig{
 						EnableTLSStreaming: true,
 						X509KeyPairStreaming: config.X509KeyPairStreaming{
@@ -96,7 +97,7 @@ func TestValidateStreamServer(t *testing.T) {
 		},
 		"should return error with X509 TLSKeyFile empty": {
 			criService: &criService{
-				config: config.Config{
+				config: serviceConfig{
 					PluginConfig: config.PluginConfig{
 						EnableTLSStreaming: true,
 						X509KeyPairStreaming: config.X509KeyPairStreaming{
@@ -111,7 +112,7 @@ func TestValidateStreamServer(t *testing.T) {
 		},
 		"should return error without EnableTLSStreaming and only TLSCertFile set": {
 			criService: &criService{
-				config: config.Config{
+				config: serviceConfig{
 					PluginConfig: config.PluginConfig{
 						EnableTLSStreaming: false,
 						X509KeyPairStreaming: config.X509KeyPairStreaming{
@@ -126,7 +127,7 @@ func TestValidateStreamServer(t *testing.T) {
 		},
 		"should return error without EnableTLSStreaming and only TLSKeyFile set": {
 			criService: &criService{
-				config: config.Config{
+				config: serviceConfig{
 					PluginConfig: config.PluginConfig{
 						EnableTLSStreaming: false,
 						X509KeyPairStreaming: config.X509KeyPairStreaming{

--- a/pkg/server/update_runtime_config_test.go
+++ b/pkg/server/update_runtime_config_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 
 	criconfig "github.com/containerd/cri/pkg/config"
@@ -103,7 +102,7 @@ func TestUpdateRuntimeConfig(t *testing.T) {
 			confDir := filepath.Join(testDir, "net.d")
 			confName := filepath.Join(confDir, cniConfigFileName)
 
-			c := newTestCRIService()
+			c, ctx := newTestCRIService()
 			c.config.CniConfig = criconfig.CniConfig{
 				NetworkPluginConfDir:      confDir,
 				NetworkPluginConfTemplate: templateName,
@@ -125,7 +124,7 @@ func TestUpdateRuntimeConfig(t *testing.T) {
 				c.netPlugin.(*servertesting.FakeCNIPlugin).StatusErr = errors.New("random error")
 				c.netPlugin.(*servertesting.FakeCNIPlugin).LoadErr = errors.New("random error")
 			}
-			_, err = c.UpdateRuntimeConfig(context.Background(), req)
+			_, err = c.UpdateRuntimeConfig(ctx, req)
 			assert.NoError(t, err)
 			if !test.expectCNIConfig {
 				_, err := os.Stat(confName)


### PR DESCRIPTION
CRI clients are containerd clients. containerd supports multi-tenancy
via containerd namespaces. Clients interact with resources in non-default
namespaces by specifying a namespace name in the client invocation that
is curried to the server via gRPC. This means that the basic building
blocks for a client-directed (aka honor-system) multi-tenancy are ready
to be leveraged.

Introducing "managed namespaces" for containerd/cri. This change-set is
largely concerned with allowing for multi-tenant CRI to coexist and
enabling interactions with CRI resources in non-default (aka not
"k8s.io") namespaces by NOT overriding the client-provided namespace.
This means that the default CRI namespace, "k8s.io", is only enforced
for clients that have not specified a namespace. A CRI namespace is one
that is labeled with "io.cri-containerd=managed". Invoking the CRI with
a namespace that either does not exist or isn't properly labeled will
return an "unmanaged namespace" error.

How was this implemented?
    
- the plugin initialization aspect of `criService` and the check/logging of `instrumentedService` have been merged into `criServiceManager`
- the `criServiceManager` maintains an event exchange that is subscribed to containerd events (filtering on task and image events, as before)
- the `criServiceManager` manages `criService` instances in a sync.Map keyed by namespace name
- all `criService` instances are subscribed to the `criServiceManager` event exchange filtering on their namespace name
- all `criService` instances are currently created and started on NamespaceCreate/NamespaceUpdate having the label "io.cri-containerd == managed"
  - managed `criService` instances are stopped on NamespaceDelete or NamespaceUpdate when "io.cri-containerd != managed"
- the `DeferContext` and `NamespacedContext` in ./pkg/containerd/util have been changed to accept a namespace name
- the default CRI namespace, k8s.io, is configured, as before, by the CRI plugin TOML
- all other namespaces are configured by TOML that is the standard, aka "version 1", emitted by serializing a `config.PluginConfig`
  - located at `${containerd.root_dir}/io.containerd.grpc.v1.cri/namespaces/${namespace.name}/config.toml`
  - this config is serialized for all namespaces, including k8s.io, at the same (parameterized) location
  - non-default namespaces lacking a config file will be started with a "default" having:
    - `cni.conf_dir = /opt/cri/${namespace.name}/etc/cni/net.d` instead of the usual default `/etc/cni/net.d`

/cc @mikebrow @Random-Liu @ibuildthecloud

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>