### PR TITLE
Clarify that plugin names are long in version = 2

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -10,6 +10,7 @@ The explanation and default value of each configuration item are as follows:
 ```toml
 # Use config version 2 to enable new configuration fields.
 # Config file is parsed as version 1 by default.
+# Version 2 uses long plugin names, i.e. "io.containerd.grpc.v1.cri" vs "cri".
 version = 2
 
 # The 'plugins."io.containerd.grpc.v1.cri"' table contains all of the server options.

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -6,6 +6,8 @@ With containerd, `docker.io` is the default image registry. You can also set up 
 
 To configure image registries create/modify the `/etc/containerd/config.toml` as follows:
 ```toml
+# Config file is parsed as version 1 by default.
+# To use the long form of plugin names set "version = 2"
 [plugins.cri.registry.mirrors]
   [plugins.cri.registry.mirrors."docker.io"]
     endpoint = ["https://registry-1.docker.io"]


### PR DESCRIPTION
Otherwise it's confusing for readers who just need quick reference
for plugin configurations.

Fixes #1460