### PR TITLE
Increase port-forward timeout to 1s to fix e2e test

### DIFF
--- a/pkg/server/sandbox_portforward_unix.go
+++ b/pkg/server/sandbox_portforward_unix.go
@@ -100,9 +100,9 @@ func (c *criService) portForward(ctx context.Context, id string, port int32, str
 			return ctx.Err()
 		}
 		// give a chance to terminate gracefully or timeout
-		// 0.5s is the default timeout used in socat
+		// after 1s
 		// https://linux.die.net/man/1/socat
-		timeout := time.Duration(500) * time.Millisecond
+		const timeout = time.Second
 		select {
 		case e := <-errCh:
 			if errFwd == nil {


### PR DESCRIPTION
We encountered two failing end-to-end tests after the adoption of https://github.com/containerd/cri/pull/1470 in https://github.com/cri-o/cri-o/pull/3749:

```
Summarizing 2 Failures:
[Fail] [sig-cli] Kubectl Port forwarding With a server listening on 0.0.0.0 that expects a client request [It] should support a client that connects,
sends DATA, and disconnects
test/e2e/kubectl/portforward.go:343

[Fail] [sig-cli] Kubectl Port forwarding With a server listening on localhost that expects a client request [It] should support a client that connects
, sends DATA, and disconnects
test/e2e/kubectl/portforward.go:343
```

Increasing the timeout to 1s fixes the issue.

cc @aojea 