### PR TITLE
vendor: containerd/go-cni 0553354f0046ccd41a02e724826040491a3d8998

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -87,7 +87,7 @@ sigs.k8s.io/structured-merge-diff/v3                877aee05330847a873a1a8998b40
 sigs.k8s.io/yaml                                    9fc95527decd95bb9d28cc2eab08179b2d0f6971 # v1.2.0
 
 # cni dependencies
-github.com/containerd/go-cni                        0d360c50b10b350b6bb23863fd4dfb1c232b01c9
+github.com/containerd/go-cni                        0553354f0046ccd41a02e724826040491a3d8998
 github.com/containernetworking/cni                  4cfb7b568922a3c79a23e438dc52fe537fc9687e # v0.7.1
 github.com/containernetworking/plugins              9f96827c7cabb03f21d86326000c00f61e181f6a # v0.7.6
 github.com/fsnotify/fsnotify                        4bf2d1fec78374803a39307bfb8d340688f4f28e # v1.4.8

--- a/vendor/github.com/containerd/go-cni/README.md
+++ b/vendor/github.com/containerd/go-cni/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/containerd/go-cni.svg?branch=master)](https://travis-ci.org/containerd/go-cni)
+[![Build Status](https://travis-ci.org/containerd/go-cni.svg?branch=master)](https://travis-ci.org/containerd/go-cni) [![GoDoc](https://godoc.org/github.com/containerd/go-cni?status.svg)](https://godoc.org/github.com/containerd/go-cni)
 
 # go-cni
 

--- a/vendor/github.com/containerd/go-cni/errors.go
+++ b/vendor/github.com/containerd/go-cni/errors.go
@@ -31,25 +31,25 @@ var (
 
 // IsCNINotInitialized returns true if the error is due to cni config not being initialized
 func IsCNINotInitialized(err error) bool {
-	return errors.Cause(err) == ErrCNINotInitialized
+	return errors.Is(err, ErrCNINotInitialized)
 }
 
 // IsInvalidConfig returns true if the error is invalid cni config
 func IsInvalidConfig(err error) bool {
-	return errors.Cause(err) == ErrInvalidConfig
+	return errors.Is(err, ErrInvalidConfig)
 }
 
 // IsNotFound returns true if the error is due to a missing config or result
 func IsNotFound(err error) bool {
-	return errors.Cause(err) == ErrNotFound
+	return errors.Is(err, ErrNotFound)
 }
 
 // IsReadFailure return true if the error is a config read failure
 func IsReadFailure(err error) bool {
-	return errors.Cause(err) == ErrRead
+	return errors.Is(err, ErrRead)
 }
 
 // IsInvalidResult return true if the error is due to invalid cni result
 func IsInvalidResult(err error) bool {
-	return errors.Cause(err) == ErrInvalidResult
+	return errors.Is(err, ErrInvalidResult)
 }

--- a/vendor/github.com/containerd/go-cni/go.mod
+++ b/vendor/github.com/containerd/go-cni/go.mod
@@ -1,0 +1,14 @@
+module github.com/containerd/go-cni
+
+require (
+	github.com/containernetworking/cni v0.7.1
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/onsi/ginkgo v1.10.3 // indirect
+	github.com/onsi/gomega v1.7.1 // indirect
+	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.0.0-20180129172003-8a3f7159479f // indirect
+	github.com/stretchr/testify v0.0.0-20180303142811-b89eecf5ca5d
+)
+
+go 1.13

--- a/vendor/github.com/containerd/go-cni/opts.go
+++ b/vendor/github.com/containerd/go-cni/opts.go
@@ -142,6 +142,24 @@ func WithConfFile(fileName string) CNIOpt {
 	}
 }
 
+// WithConfListBytes can be used to load network config list directly
+// from byte
+func WithConfListBytes(bytes []byte) CNIOpt {
+	return func(c *libcni) error {
+		confList, err := cnilibrary.ConfListFromBytes(bytes)
+		if err != nil {
+			return err
+		}
+		i := len(c.networks)
+		c.networks = append(c.networks, &Network{
+			cni:    c.cniConfig,
+			config: confList,
+			ifName: getIfName(c.prefix, i),
+		})
+		return nil
+	}
+}
+
 // WithConfListFile can be used to load network config
 // from an .conflist file. Supported with absolute fileName
 // with path only.

--- a/vendor/github.com/containerd/go-cni/vendor.conf
+++ b/vendor/github.com/containerd/go-cni/vendor.conf
@@ -1,6 +1,0 @@
-github.com/stretchr/testify b89eecf5ca5db6d3ba60b237ffe3df7bafb7662f
-github.com/davecgh/go-spew 8991bc29aa16c548c550c7ff78260e27b9ab7c73
-github.com/pmezard/go-difflib 792786c7400a136282c1664665ae0a8db921c6c2
-github.com/stretchr/objx 8a3f7159479fbc75b30357fbc48f380b7320f08e
-github.com/containernetworking/cni v0.7.1
-github.com/pkg/errors v0.8.0


### PR DESCRIPTION
full diff: https://github.com/containerd/go-cni/compare/0d360c50b10b350b6bb23863fd4dfb1c232b01c9...0553354f0046ccd41a02e724826040491a3d8998

- Add WithConfList opt for adding conf list from bytes
- Use Go modules instead of vndr
- Test on go1.13, 1.14, remove go1.12
- Update pkg/errors v0.9.1, switch to using errors.Is() instead of errors.Cause()
