### PR TITLE
no longer need to skip /test header scan due to symlink

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,11 +63,10 @@ jobs:
           fi
           ../project/script/validate/dco
 
-      # TODO: (mikebrow) removed test/ due to ltag not working with test/e3e symlink
       - name: Headers
         working-directory: src/github.com/containerd/cri
         run:  |
-          ltag -t "../project/script/validate/template" --excludes "vendor test" --check -v
+          ltag -t "../project/script/validate/template" --check -v
 
       - name: Vendor
         working-directory: src/github.com/containerd/cri


### PR DESCRIPTION
Fix applied to ltag:
https://github.com/kunalkushwaha/ltag/pull/11/commits/5a99b302ff7cdc8a3fd78f238a1347b2442539e8

So we don't need to skip the /test directory due to the symlink error..

Also.. we don't need to explicitly skip /vendor because when reviewing the code I noted that ltag already skips vendor.

Signed-off-by: Mike Brown <brownwm@us.ibm.com>