### PR TITLE
vendor: opencontainers/selinux v1.5.2

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,6 +1,6 @@
 # cri dependencies
 github.com/docker/docker                            4634ce647cf2ce2c6031129ccd109e557244986f
-github.com/opencontainers/selinux                   v1.5.1
+github.com/opencontainers/selinux                   v1.5.2
 github.com/tchap/go-patricia                        v2.2.6
 
 # containerd dependencies

--- a/vendor/github.com/opencontainers/selinux/go-selinux/label/label.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/label/label.go
@@ -1,6 +1,8 @@
 package label
 
 import (
+	"fmt"
+
 	"github.com/opencontainers/selinux/go-selinux"
 )
 
@@ -46,7 +48,7 @@ var PidLabel = selinux.PidLabel
 
 // Init initialises the labeling system
 func Init() {
-	selinux.GetEnabled()
+	_ = selinux.GetEnabled()
 }
 
 // ClearLabels will clear all reserved labels
@@ -75,3 +77,21 @@ func ReleaseLabel(label string) error {
 // can be used to set duplicate labels on future container processes
 // Deprecated: use selinux.DupSecOpt
 var DupSecOpt = selinux.DupSecOpt
+
+// FormatMountLabel returns a string to be used by the mount command.
+// The format of this string will be used to alter the labeling of the mountpoint.
+// The string returned is suitable to be used as the options field of the mount command.
+// If you need to have additional mount point options, you can pass them in as
+// the first parameter.  Second parameter is the label that you wish to apply
+// to all content in the mount point.
+func FormatMountLabel(src, mountLabel string) string {
+	if mountLabel != "" {
+		switch src {
+		case "":
+			src = fmt.Sprintf("context=%q", mountLabel)
+		default:
+			src = fmt.Sprintf("%s,context=%q", src, mountLabel)
+		}
+	}
+	return src
+}

--- a/vendor/github.com/opencontainers/selinux/go-selinux/label/label_stub.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/label/label_stub.go
@@ -15,10 +15,6 @@ func GenLabels(options string) (string, string, error) {
 	return "", "", nil
 }
 
-func FormatMountLabel(src string, mountLabel string) string {
-	return src
-}
-
 func SetFileLabel(path string, fileLabel string) error {
 	return nil
 }


### PR DESCRIPTION
full diff: https://github.com/opencontainers/selinux/compare/v1.5.1...v1.5.2

- Implement FormatMountLabel unconditionally
  Implementing FormatMountLabel on situations built without selinux
  should be possible; the context will be ignored if no SELinux is available.
- Remote potential race condition, where mcs label is freed
  Theorectially if you do not change the MCS Label then we free it and two
  commands later reserve it. If some other process was grabbing MCS Labels
  at the same time, the other process could get the same label.
