### PR TITLE
add support for setting CRITOOL_VERSION

### DIFF
--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -17,7 +17,7 @@
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
 
 # Not from vendor.conf.
-CRITOOL_VERSION=89384cc13a27bb9128553c9fe75a7cc07c6a95bb
+CRITOOL_VERSION=${CRITOOL_VERSION:-89384cc13a27bb9128553c9fe75a7cc07c6a95bb}
 CRITOOL_PKG=github.com/kubernetes-sigs/cri-tools
 CRITOOL_REPO=github.com/kubernetes-sigs/cri-tools
 


### PR DESCRIPTION
the cri-tools guys need the ability to test containerd against various cri-tools branches

Yes, I know the variable is named critool :)

Signed-off-by: Mike Brown <brownwm@us.ibm.com>