### PR TITLE
Specify base OCI runtime spec

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -135,6 +135,11 @@ version = 2
       # i.e pass host devices through to privileged containers.
       privileged_without_host_devices = false
 
+      # base_runtime_spec is a file path to a JSON file with the OCI spec that will be used as the base spec
+      # that all container's are created from.
+      # Use containerd's `ctr oci default-spec > /etc/containerd/cri-base.json` to output initial spec file.
+      base_runtime_spec = ""
+
       # 'plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options' is options specific to
       # "io.containerd.runc.v1" and "io.containerd.runc.v2". Its corresponding options type is:
       #   https://github.com/containerd/containerd/blob/v1.3.2/runtime/v2/runc/options/oci.pb.go#L26 .

--- a/docs/config.md
+++ b/docs/config.md
@@ -135,9 +135,11 @@ version = 2
       # i.e pass host devices through to privileged containers.
       privileged_without_host_devices = false
 
-      # base_runtime_spec is a file path to a JSON file with the OCI spec that will be used as the base spec
-      # that all container's are created from.
-      # Use containerd's `ctr oci default-spec > /etc/containerd/cri-base.json` to output initial spec file.
+      # base_runtime_spec is a file path to a JSON file with the OCI spec that will be used as the base spec that all
+      # container's are created from.
+      # Use containerd's `ctr oci spec > /etc/containerd/cri-base.json` to output initial spec file.
+      # Spec files are loaded at launch, so containerd daemon must be restared on any changes to refresh default specs.
+      # Still running containers and restarted containers will still be using the original spec from which that container was created.
       base_runtime_spec = ""
 
       # 'plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options' is options specific to

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,6 +52,8 @@ type Runtime struct {
 	// PrivilegedWithoutHostDevices overloads the default behaviour for adding host devices to the
 	// runtime spec when the container is privileged. Defaults to false.
 	PrivilegedWithoutHostDevices bool `toml:"privileged_without_host_devices" json:"privileged_without_host_devices"`
+	// BaseRuntimeSpec is a json file with OCI spec to use as base spec that all container's will be created from.
+	BaseRuntimeSpec string `toml:"base_runtime_spec" json:"baseRuntimeSpec"`
 }
 
 // ContainerdConfig contains toml config related to containerd

--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -313,7 +313,10 @@ func (c *criService) runtimeSpec(id string, baseSpecFile string, opts ...oci.Spe
 			return nil, errors.Wrap(err, "failed to clone OCI spec")
 		}
 
-		if err := oci.ApplyOpts(ctx, nil, container, &spec, opts...); err != nil {
+		// Fix up cgroups path
+		applyOpts := append([]oci.SpecOpts{oci.WithNamespacedCgroup()}, opts...)
+
+		if err := oci.ApplyOpts(ctx, nil, container, &spec, applyOpts...); err != nil {
 			return nil, errors.Wrap(err, "failed to apply OCI options")
 		}
 

--- a/pkg/server/container_create_test.go
+++ b/pkg/server/container_create_test.go
@@ -29,6 +29,7 @@ import (
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 
 	"github.com/containerd/cri/pkg/config"
+	"github.com/containerd/cri/pkg/constants"
 	"github.com/containerd/cri/pkg/containerd/opts"
 )
 
@@ -401,4 +402,6 @@ func TestBaseRuntimeSpec(t *testing.T) {
 	// Make sure original base spec not changed
 	assert.NotEqual(t, out, c.baseOCISpecs["/etc/containerd/cri-base.json"])
 	assert.Equal(t, c.baseOCISpecs["/etc/containerd/cri-base.json"].Hostname, "old")
+
+	assert.Equal(t, filepath.Join("/", constants.K8sContainerdNamespace, "id1"), out.Linux.CgroupsPath)
 }

--- a/pkg/server/container_create_unix.go
+++ b/pkg/server/container_create_unix.go
@@ -262,7 +262,7 @@ func (c *criService) containerSpec(id string, sandboxID string, sandboxPid uint3
 				Type: runtimespec.CgroupNamespace,
 			}))
 	}
-	return runtimeSpec(id, specOpts...)
+	return c.runtimeSpec(id, ociRuntime.BaseRuntimeSpec, specOpts...)
 }
 
 func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageConfig *imagespec.ImageConfig) ([]oci.SpecOpts, error) {

--- a/pkg/server/container_create_windows.go
+++ b/pkg/server/container_create_windows.go
@@ -91,8 +91,7 @@ func (c *criService) containerSpec(id string, sandboxID string, sandboxPid uint3
 		customopts.WithAnnotation(annotations.SandboxID, sandboxID),
 		customopts.WithAnnotation(annotations.ContainerName, containerName),
 	)
-
-	return runtimeSpec(id, specOpts...)
+	return c.runtimeSpec(id, ociRuntime.BaseRuntimeSpec, specOpts...)
 }
 
 // No extra spec options needed for windows.

--- a/pkg/server/sandbox_run_unix.go
+++ b/pkg/server/sandbox_run_unix.go
@@ -156,7 +156,7 @@ func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 		customopts.WithAnnotation(annotations.SandboxLogDir, config.GetLogDirectory()),
 	)
 
-	return runtimeSpec(id, specOpts...)
+	return c.runtimeSpec(id, "", specOpts...)
 }
 
 // sandboxContainerSpecOpts generates OCI spec options for

--- a/pkg/server/sandbox_run_windows.go
+++ b/pkg/server/sandbox_run_windows.go
@@ -67,7 +67,7 @@ func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxC
 		customopts.WithAnnotation(annotations.SandboxLogDir, config.GetLogDirectory()),
 	)
 
-	return runtimeSpec(id, specOpts...)
+	return c.runtimeSpec(id, "", specOpts...)
 }
 
 // No sandbox container spec options for windows yet.


### PR DESCRIPTION
This PR adds `base_runtime_spec` to runtime config to use a file with base OCI spec.

Details: https://github.com/containerd/cri/issues/1488

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>