### PR TITLE
Tolerate missing HugeTLB cgroups controller

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -230,6 +230,10 @@ type PluginConfig struct {
 	// UnsetSeccompProfile is the profile containerd/cri will use If the provided seccomp profile is
 	// unset (`""`) for a container (default is `unconfined`)
 	UnsetSeccompProfile string `toml:"unset_seccomp_profile" json:"unsetSeccompProfile"`
+	// TolerateMissingHugePagesCgroupController if set to false will error out on create/update
+	// container requests with huge page limits if the cgroup controller for hugepages is not present.
+	// This helps with supporting Kubernetes <=1.18 out of the box. (default is `true`)
+	TolerateMissingHugePagesCgroupController bool `toml:"tolerate_missing_hugepages_controller" json:"tolerateMissingHugePagesCgroupController"`
 }
 
 // X509KeyPairStreaming contains the x509 configuration for streaming

--- a/pkg/config/config_unix.go
+++ b/pkg/config/config_unix.go
@@ -63,7 +63,8 @@ func DefaultConfig() PluginConfig {
 				},
 			},
 		},
-		MaxConcurrentDownloads: 3,
-		DisableProcMount:       false,
+		MaxConcurrentDownloads:                   3,
+		DisableProcMount:                         false,
+		TolerateMissingHugePagesCgroupController: true,
 	}
 }

--- a/pkg/containerd/opts/spec_unix.go
+++ b/pkg/containerd/opts/spec_unix.go
@@ -27,6 +27,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
+	"syscall"
 
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/log"
@@ -36,6 +38,7 @@ import (
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 
@@ -405,7 +408,7 @@ func WithSelinuxLabels(process, mount string) oci.SpecOpts {
 }
 
 // WithResources sets the provided resource restrictions
-func WithResources(resources *runtime.LinuxContainerResources) oci.SpecOpts {
+func WithResources(resources *runtime.LinuxContainerResources, tolerateMissingHugePagesCgroupController bool) oci.SpecOpts {
 	return func(ctx context.Context, client oci.Client, c *containers.Container, s *runtimespec.Spec) (err error) {
 		if resources == nil {
 			return nil
@@ -448,14 +451,91 @@ func WithResources(resources *runtime.LinuxContainerResources) oci.SpecOpts {
 		if limit != 0 {
 			s.Linux.Resources.Memory.Limit = &limit
 		}
-		for _, limit := range hugepages {
-			s.Linux.Resources.HugepageLimits = append(s.Linux.Resources.HugepageLimits, runtimespec.LinuxHugepageLimit{
-				Pagesize: limit.PageSize,
-				Limit:    limit.Limit,
-			})
+		if isHugePagesControllerPresent() {
+			for _, limit := range hugepages {
+				s.Linux.Resources.HugepageLimits = append(s.Linux.Resources.HugepageLimits, runtimespec.LinuxHugepageLimit{
+					Pagesize: limit.PageSize,
+					Limit:    limit.Limit,
+				})
+			}
+		} else {
+			if !tolerateMissingHugePagesCgroupController {
+				return errors.Errorf("huge pages limits are specified but hugetlb cgroup controller is missing. " +
+					"Please set tolerate_missing_hugepages_controller to `true` to ignore this error")
+			}
+			logrus.Warn("hugetlb cgroup controller is absent. skipping huge pages limits")
 		}
 		return nil
 	}
+}
+
+var (
+	supportsHugetlbOnce sync.Once
+	supportsHugetlb     bool
+)
+
+func isHugePagesControllerPresent() bool {
+	supportsHugetlbOnce.Do(func() {
+		supportsHugetlb = false
+		if IsCgroup2UnifiedMode() {
+			supportsHugetlb, _ = cgroupv2HasHugetlb()
+		} else {
+			supportsHugetlb, _ = cgroupv1HasHugetlb()
+		}
+	})
+	return supportsHugetlb
+}
+
+var (
+	_cgroupv1HasHugetlbOnce sync.Once
+	_cgroupv1HasHugetlb     bool
+	_cgroupv1HasHugetlbErr  error
+	_cgroupv2HasHugetlbOnce sync.Once
+	_cgroupv2HasHugetlb     bool
+	_cgroupv2HasHugetlbErr  error
+	isUnifiedOnce           sync.Once
+	isUnified               bool
+)
+
+// cgroupv1HasHugetlb returns whether the hugetlb controller is present on
+// cgroup v1.
+func cgroupv1HasHugetlb() (bool, error) {
+	_cgroupv1HasHugetlbOnce.Do(func() {
+		if _, err := ioutil.ReadDir("/sys/fs/cgroup/hugetlb"); err != nil {
+			_cgroupv1HasHugetlbErr = errors.Wrap(err, "readdir /sys/fs/cgroup/hugetlb")
+			_cgroupv1HasHugetlb = false
+		} else {
+			_cgroupv1HasHugetlbErr = nil
+			_cgroupv1HasHugetlb = true
+		}
+	})
+	return _cgroupv1HasHugetlb, _cgroupv1HasHugetlbErr
+}
+
+// cgroupv2HasHugetlb returns whether the hugetlb controller is present on
+// cgroup v2.
+func cgroupv2HasHugetlb() (bool, error) {
+	_cgroupv2HasHugetlbOnce.Do(func() {
+		controllers, err := ioutil.ReadFile("/sys/fs/cgroup/cgroup.controllers")
+		if err != nil {
+			_cgroupv2HasHugetlbErr = errors.Wrap(err, "read /sys/fs/cgroup/cgroup.controllers")
+			return
+		}
+		_cgroupv2HasHugetlb = strings.Contains(string(controllers), "hugetlb")
+	})
+	return _cgroupv2HasHugetlb, _cgroupv2HasHugetlbErr
+}
+
+// IsCgroup2UnifiedMode returns whether we are running in cgroup v2 unified mode.
+func IsCgroup2UnifiedMode() bool {
+	isUnifiedOnce.Do(func() {
+		var st syscall.Statfs_t
+		if err := syscall.Statfs("/sys/fs/cgroup", &st); err != nil {
+			panic("cannot statfs cgroup root")
+		}
+		isUnified = st.Type == unix.CGROUP2_SUPER_MAGIC
+	})
+	return isUnified
 }
 
 // WithOOMScoreAdj sets the oom score

--- a/pkg/server/container_create_unix.go
+++ b/pkg/server/container_create_unix.go
@@ -225,7 +225,7 @@ func (c *criService) containerSpec(id string, sandboxID string, sandboxPid uint3
 	if c.config.DisableCgroup {
 		specOpts = append(specOpts, customopts.WithDisabledCgroups)
 	} else {
-		specOpts = append(specOpts, customopts.WithResources(config.GetLinux().GetResources()))
+		specOpts = append(specOpts, customopts.WithResources(config.GetLinux().GetResources(), c.config.TolerateMissingHugePagesCgroupController))
 		if sandboxConfig.GetLinux().GetCgroupParent() != "" {
 			cgroupsPath := getCgroupsPath(sandboxConfig.GetLinux().GetCgroupParent(), id)
 			specOpts = append(specOpts, oci.WithCgroup(cgroupsPath))

--- a/pkg/server/container_update_resources_unix_test.go
+++ b/pkg/server/container_update_resources_unix_test.go
@@ -153,7 +153,7 @@ func TestUpdateOCILinuxResource(t *testing.T) {
 		},
 	} {
 		t.Logf("TestCase %q", desc)
-		got, err := updateOCILinuxResource(context.Background(), test.spec, test.resources)
+		got, err := updateOCILinuxResource(context.Background(), test.spec, test.resources, false)
 		if test.expectErr {
 			assert.Error(t, err)
 		} else {


### PR DESCRIPTION
Kubernetes has been sending hugepage limits for a few releases now. Things used to work because containerd-cri failed to honor them. 

However starting in the following [diff](https://github.com/containerd/containerd/compare/97ca1be0..7a5fcf61#diff-85b069277b32de3389720de87247f54eR451-R456) we noticed that k8s failed hard with the following error:

```
 ay 31 02:47:12 kind-control-plane containerd[133]: time="2020-05-31T02:47:12.295625667Z" level=error msg="StartContainer for \"6426531767995db591ea89b05e52ebfa8887d2cd23c095ddf8e1727d1d6ec8cb\" failed" error="failed to create containerd task: OCI runtime create failed: container_linux.go:346: starting container process caused \"process_linux.go:449: container init caused \\\"process_linux.go:415: setting cgroup config for procHooks process caused \\\\\\\"cannot set hugetlb limit: container could not join or create cgroup\\\\\\\"\\\"\": unknown"
```
We tracked it down to the following commit:
https://github.com/containerd/cri/commit/c02c24847f191ea5d38bb3917ec5c54222ba5501

Essentially, containerd was trying to set hugepages limits when the cgroup controller (`hugeTLB`) was absent. So this failed in a variety of legacy environments. So in this PR we detect this situation and have a toggle to keep the old behavior until we can patch/fix k8s in the wild somehow. Since CRI-O is ignoring the hugepage limit in the same exact situation and this was the previous behavior, let's please do the same.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>