### PR TITLE
Add option for ignoring volumes defined in images

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -45,6 +45,11 @@ version = 2
   # It generates a self-sign certificate unless the following x509_key_pair_streaming are both set.
   enable_tls_streaming = false
 
+  # ignore_image_defined_volumes ignores volumes defined by the image. Useful for better resource
+	# isolation, security and early detection of issues in the mount configuration when using
+	# ReadOnlyRootFilesystem since containers won't silently mount a temporary volume.
+  ignore_image_defined_volumes = false
+
   # 'plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming' contains a x509 valid key pair to stream with tls.
   [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
     # tls_cert_file is the filepath to the certificate paired with the "tls_key_file"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -234,6 +234,10 @@ type PluginConfig struct {
 	// container requests with huge page limits if the cgroup controller for hugepages is not present.
 	// This helps with supporting Kubernetes <=1.18 out of the box. (default is `true`)
 	TolerateMissingHugePagesCgroupController bool `toml:"tolerate_missing_hugepages_controller" json:"tolerateMissingHugePagesCgroupController"`
+	// IgnoreImageDefinedVolumes ignores volumes defined by the image. Useful for better resource
+	// isolation, security and early detection of issues in the mount configuration when using
+	// ReadOnlyRootFilesystem since containers won't silently mount a temporary volume.
+	IgnoreImageDefinedVolumes bool `toml:"ignore_image_defined_volumes" json:"ignoreImageDefinedVolumes"`
 }
 
 // X509KeyPairStreaming contains the x509 configuration for streaming

--- a/pkg/config/config_unix.go
+++ b/pkg/config/config_unix.go
@@ -66,5 +66,6 @@ func DefaultConfig() PluginConfig {
 		MaxConcurrentDownloads:                   3,
 		DisableProcMount:                         false,
 		TolerateMissingHugePagesCgroupController: true,
+		IgnoreImageDefinedVolumes:                false,
 	}
 }

--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -64,7 +64,8 @@ func DefaultConfig() PluginConfig {
 				},
 			},
 		},
-		MaxConcurrentDownloads: 3,
+		MaxConcurrentDownloads:    3,
+		IgnoreImageDefinedVolumes: false,
 		// TODO(windows): Add platform specific config, so that most common defaults can be shared.
 	}
 }

--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -137,8 +137,13 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 		}
 	}()
 
-	// Create container volumes mounts.
-	volumeMounts := c.volumeMounts(containerRootDir, config.GetMounts(), &image.ImageSpec.Config)
+	var volumeMounts []*runtime.Mount
+	if !c.config.IgnoreImageDefinedVolumes {
+		// Create container image volumes mounts.
+		volumeMounts = c.volumeMounts(containerRootDir, config.GetMounts(), &image.ImageSpec.Config)
+	} else if len(image.ImageSpec.Config.Volumes) != 0 {
+		log.G(ctx).Debugf("Ignoring volumes defined in image %v because IgnoreImageDefinedVolumes is set", image.ID)
+	}
 
 	// Generate container mounts.
 	mounts := c.containerMounts(sandboxID, config)


### PR DESCRIPTION
This adds a new config option for ignoring volumes defined in image metadata.

In Kubernetes volumes (even temporary ones) are generally specified in the pod configuration. Mapping the ones in the image metadata can lead to resource accounting/exhaustion issues (think writing an unlimited amount of inodes or data into the volume) and policy enforcement issues (a PSP cannot disable these).

Specifically for containers started with `ReadOnlyRootFilesystem` it can also lead to unexpected behavior, for example if there's a typo in the volume mount path the container will still start since the process can write to the data location, but the data ends up in the volume defined by the image which is ephemeral and subsequently gets lost when the pod gets descheduled. The user expected the process in the container to fail since there's no volume mounted at the data path and the root filesystem is readonly, but since the image volume is mounted there this works.