### PR TITLE
Add config for registry http headers

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -209,6 +209,10 @@ version = 2
   # 'plugins."io.containerd.grpc.v1.cri".registry' contains config related to the registry
   [plugins."io.containerd.grpc.v1.cri".registry]
 
+    # 'plugins."io.containerd.grpc.v1.cri.registry.headers sets the http request headers to send for all registry requests
+    [plugins."io.containerd.grpc.v1.cri".registry.headers]
+        Foo = ["bar"]
+
     # 'plugins."io.containerd.grpc.v1.cri".registry.mirrors' are namespace to mirror mapping for all namespaces.
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
       [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -149,6 +149,8 @@ type Registry struct {
 	// be a valid url with host specified.
 	// DEPRECATED: Use Configs instead. Remove in containerd 1.4.
 	Auths map[string]AuthConfig `toml:"auths" json:"auths"`
+	// Headers adds additional HTTP headers that get sent to all registries
+	Headers map[string][]string `toml:"headers" json:"headers"`
 }
 
 // RegistryConfig contains configuration used to communicate with the registry.

--- a/pkg/server/image_pull.go
+++ b/pkg/server/image_pull.go
@@ -98,7 +98,8 @@ func (c *criService) PullImage(ctx context.Context, r *runtime.PullImageRequest)
 	}
 	var (
 		resolver = docker.NewResolver(docker.ResolverOptions{
-			Hosts: c.registryHosts(r.GetAuth()),
+			Headers: c.config.Registry.Headers,
+			Hosts:   c.registryHosts(r.GetAuth()),
 		})
 		isSchema1    bool
 		imageHandler containerdimages.HandlerFunc = func(_ context.Context,


### PR DESCRIPTION
This adds a configuration knob for adding request headers to all
registry requests. It is not namespaced to a registry.

Relates to #1400

Usage:

```toml
version = 2
[plugins."io.containerd.grpc.v1.cri".registry.headers]
Foo = ["bar"]
```