### PR TITLE
Remove the protocol filter from the HostPort management

### DIFF
--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -414,9 +414,6 @@ func toCNIPortMappings(criPortMappings []*runtime.PortMapping) []cni.PortMapping
 		if mapping.HostPort <= 0 {
 			continue
 		}
-		if mapping.Protocol != runtime.Protocol_TCP && mapping.Protocol != runtime.Protocol_UDP {
-			continue
-		}
 		portMappings = append(portMappings, cni.PortMapping{
 			HostPort:      mapping.HostPort,
 			ContainerPort: mapping.ContainerPort,

--- a/pkg/server/sandbox_run_test.go
+++ b/pkg/server/sandbox_run_test.go
@@ -175,6 +175,12 @@ func TestToCNIPortMappings(t *testing.T) {
 					HostPort:      8765,
 					HostIp:        "126.125.124.123",
 				},
+				{
+					Protocol:      runtime.Protocol_SCTP,
+					ContainerPort: 1234,
+					HostPort:      5678,
+					HostIp:        "123.124.125.126",
+				},
 			},
 			cniPortMappings: []cni.PortMapping{
 				{
@@ -188,6 +194,12 @@ func TestToCNIPortMappings(t *testing.T) {
 					ContainerPort: 4321,
 					Protocol:      "tcp",
 					HostIP:        "126.125.124.123",
+				},
+				{
+					HostPort:      5678,
+					ContainerPort: 1234,
+					Protocol:      "sctp",
+					HostIP:        "123.124.125.126",
 				},
 			},
 		},
@@ -216,12 +228,6 @@ func TestToCNIPortMappings(t *testing.T) {
 		},
 		"CRI port mapping with unsupported protocol should be skipped": {
 			criPortMappings: []*runtime.PortMapping{
-				{
-					Protocol:      runtime.Protocol_SCTP,
-					ContainerPort: 1234,
-					HostPort:      5678,
-					HostIp:        "123.124.125.126",
-				},
 				{
 					Protocol:      runtime.Protocol_TCP,
 					ContainerPort: 4321,


### PR DESCRIPTION
Reason: originally it was introduced to prevent the loading of the SCTP kernel module on the nodes. But iptables chain creation alone does not load the kernel module. The module would be loaded if an SCTP socket was created, but neither cri nor the portmap CNI plugin starts managing SCTP sockets if hostPort / portmappings are defined.

Trigger:
Failing SCTP HostPort e2e test in K8s: https://github.com/kubernetes/kubernetes/issues/92041

Containerd issue (if this one is merged containerd/vendor shall be updated):
https://github.com/containerd/containerd/issues/4321