### PR TITLE
Change "failed to stop sandbox" error message to use state name instead of numeric value

### DIFF
--- a/pkg/store/sandbox/status.go
+++ b/pkg/store/sandbox/status.go
@@ -17,8 +17,11 @@
 package sandbox
 
 import (
+	"strconv"
 	"sync"
 	"time"
+
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
 // The sandbox state machine in the CRI plugin:
@@ -63,7 +66,7 @@ type State uint32
 const (
 	// StateReady is ready state, it means sandbox container
 	// is running.
-	StateReady = iota
+	StateReady State = iota
 	// StateNotReady is notready state, it ONLY means sandbox
 	// container is not running.
 	// StopPodSandbox should still be called for NOTREADY sandbox to
@@ -74,6 +77,21 @@ const (
 	// into unknown state when its status fails to be loaded.
 	StateUnknown
 )
+
+// String returns the string representation of the state
+func (s State) String() string {
+	switch s {
+	case StateReady:
+		return runtime.PodSandboxState_SANDBOX_READY.String()
+	case StateNotReady:
+		return runtime.PodSandboxState_SANDBOX_NOTREADY.String()
+	case StateUnknown:
+		// PodSandboxState doesn't have an unknown state, but State does, so return a string using the same convention
+		return "SANDBOX_UNKNOWN"
+	default:
+		return "invalid sandbox state value: " + strconv.Itoa(int(s))
+	}
+}
 
 // Status is the status of a sandbox.
 type Status struct {

--- a/pkg/store/sandbox/status_test.go
+++ b/pkg/store/sandbox/status_test.go
@@ -18,6 +18,7 @@ package sandbox
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -58,4 +59,12 @@ func TestStatus(t *testing.T) {
 	})
 	assert.NoError(err)
 	assert.Equal(updateStatus, s.Get())
+}
+
+func TestStateStringConversion(t *testing.T) {
+	assert := assertlib.New(t)
+	assert.Equal("SANDBOX_READY", fmt.Sprintf("%s", StateReady))
+	assert.Equal("SANDBOX_NOTREADY", fmt.Sprintf("%s", StateNotReady))
+	assert.Equal("SANDBOX_UNKNOWN", fmt.Sprintf("%s", StateUnknown))
+	assert.Equal("invalid sandbox state value: 123", fmt.Sprintf("%s", State(123)))
 }


### PR DESCRIPTION
This PR changes the "failed to stop sandbox container" error message to show the state name instead of a numeric value, so it will look like this instead:

Old message example:
```
failed to stop sandbox container "91fc4d82d15624121520720bdf0c733bea8506bc129ea856bd6b2f0bb9d1c980" in '\x00' state
```

New message example:
```
failed to stop sandbox container "91fc4d82d15624121520720bdf0c733bea8506bc129ea856bd6b2f0bb9d1c980" in "StateReady" state
```
