### PR TITLE
ignore image_pull.go SA1019 tlsConfig.BuildNameToCertificate is deprecated

### DIFF
--- a/pkg/server/image_pull.go
+++ b/pkg/server/image_pull.go
@@ -284,7 +284,7 @@ func (c *criService) getTLSConfig(registryTLSConfig criconfig.TLSConfig) (*tls.C
 		if len(cert.Certificate) != 0 {
 			tlsConfig.Certificates = []tls.Certificate{cert}
 		}
-		tlsConfig.BuildNameToCertificate()
+		tlsConfig.BuildNameToCertificate() // nolint:staticcheck
 	}
 
 	if registryTLSConfig.CAFile != "" {


### PR DESCRIPTION
Resolves:

> Got an error that seems unrelated to my changes:
> 
> ```
> I0624 07:55:20.688] pkg/server/image_pull.go:287:3: SA1019: tlsConfig.BuildNameToCertificate is deprecated: NameToCertificate only allows associating a single certificate with a given name. Leave that field nil to let the library select the first compatible chain from Certificates.  (staticcheck)
> I0624 07:55:20.688] 		tlsConfig.BuildNameToCertificate()
> I0624 07:55:20.688] 		^
> ```

let's see... BuildNameToCertificate seems to have been deprecated in go 1.14.. and must've been cherry picked in the linter we are using so..

Signed-off-by: Mike Brown <brownwm@us.ibm.com>