### PR TITLE
hard set kubernetes version not in vendor.conf anymore

### DIFF
--- a/hack/test-e2e-node.sh
+++ b/hack/test-e2e-node.sh
@@ -62,12 +62,7 @@ fi
 GOPATH=${GOPATH%%:*}
 
 # Get kubernetes
-from-vendor KUBERNETES k8s.io/kubernetes
-# k8s.io is actually a redirect, but we do not handle the go-import
-# metadata which `go get` and `vndr` etc do. Handle it manually here.
-if [ x"$KUBERNETES_REPO" = "xk8s.io" ] ; then
-  KUBERNETES_REPO="https://github.com/kubernetes/kubernetes"
-fi
+KUBERNETES_REPO="https://github.com/kubernetes/kubernetes"
 KUBERNETES_PATH="${GOPATH}/src/k8s.io/kubernetes"
 if [ ! -d "${KUBERNETES_PATH}" ]; then
   mkdir -p ${KUBERNETES_PATH}

--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -17,6 +17,7 @@
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
 
 # Not from vendor.conf.
+KUBERNETES_VERSION="v1.19.0-beta.2"
 CRITOOL_VERSION=${CRITOOL_VERSION:-75ef33dc2b4ecb08e0237d91de1b664909d262de}
 CRITOOL_PKG=github.com/kubernetes-sigs/cri-tools
 CRITOOL_REPO=github.com/kubernetes-sigs/cri-tools

--- a/pkg/server/image_pull.go
+++ b/pkg/server/image_pull.go
@@ -284,7 +284,7 @@ func (c *criService) getTLSConfig(registryTLSConfig criconfig.TLSConfig) (*tls.C
 		if len(cert.Certificate) != 0 {
 			tlsConfig.Certificates = []tls.Certificate{cert}
 		}
-		tlsConfig.BuildNameToCertificate()
+		tlsConfig.BuildNameToCertificate() // nolint:staticcheck
 	}
 
 	if registryTLSConfig.CAFile != "" {


### PR DESCRIPTION
1st commit fixes pull-cri-containerd-node-e2e bucket:  kubernetes version removed from vendor.conf in #1463 

2nd commit fixes pull-cri-containerd-verify to  ignore image_pull.go SA1019 tlsConfig.BuildNameToCertificate is deprecated from #1516 

Signed-off-by: Mike Brown <brownwm@us.ibm.com>