### PR TITLE
CI: run apt-get update befor apt-get install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y \
             btrfs-tools \
             libseccomp2 \


### PR DESCRIPTION
`apt-get update` is always required before `apt-get install` to avoid 404 errors
