### PR TITLE
set dco check to verbose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: DCO
         env:
           GITHUB_COMMIT_URL: ${{ github.event.pull_request.commits_url }}
-          DCO_VERBOSITY: "-q"
+          DCO_VERBOSITY: "-v"
           DCO_RANGE: ""
         working-directory: src/github.com/containerd/cri
         run: |


### PR DESCRIPTION
Hard to see why PRs are failing dco with -q(quiet) option..

Signed-off-by: Mike Brown <brownwm@us.ibm.com>