### PR TITLE
Update to go 1.13 - experiment with go 1.15beta1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ environment:
   CGO_ENABLED: 1
   GO111MODULE: off
   matrix:
-    - GO_VERSION: 1.13.12
+    - GO_VERSION: 1.13
 
 install:
   # Install Mingw

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.12'
+          go-version: '1.13'
 
       - name: Set env
         shell: bash
@@ -82,7 +82,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.12'
+          go-version: '1.13'
 
       - name: Set env
         shell: bash
@@ -147,10 +147,10 @@ jobs:
     name: Build and CRI Test (Windows amd64)
     runs-on: windows-latest
     steps:
-      - name: Set up Go 1.13.12
+      - name: Set up Go 1.13 latest
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13.12
+          go-version: 1.13
 
       - name: Checkout cri repo
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,12 +77,16 @@ jobs:
   #
   linux-build-and-test:
     name: Build, Unit, Integration, and CRI (linux amd64)
-    runs-on: ubuntu-18.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-18.04 ]
+        go: [ '1.13', '1.15beta1' ]
     steps:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13'
+          go-version: ${{ matrix.go }}
 
       - name: Set env
         shell: bash
@@ -133,11 +137,13 @@ jobs:
           path: /tmp/test-integration/containerd.log
 
       - name: CRI Test
+        if: ${{ matrix.go != '1.15beta1' }} # TODO: mike remove skip critest for go1.15 when it starts passing
         run: |
           make test-cri
         working-directory: ${{github.workspace}}/src/github.com/containerd/cri
 
       - name: Upload CRI Test log file
+        if: ${{ matrix.go != '1.15beta1' }} # TODO: mike remove skip critest for go1.15 when it starts passing
         uses: actions/upload-artifact@v1
         with:
           name: cri-test-${{github.sha}}.log

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ specifications as appropriate.
 backport version of `libseccomp-dev` is required. See [travis.yml](.travis.yml) for an example on trusty.
 * **btrfs development library.** Required by containerd btrfs support. `btrfs-tools`(Ubuntu, Debian) / `btrfs-progs-devel`(Fedora, CentOS, RHEL)
 2. Install **`pkg-config`** (required for linking with `libseccomp`).
-3. Install and setup a Go 1.13.12 development environment.
+3. Install and setup a Go 1.13.12 or later development environment. Go 1.14 is not supported.
 4. Make a local clone of this repository.
 5. Install binary dependencies by running the following command from your cloned `cri/` project directory:
 ```bash


### PR DESCRIPTION
- first commit modifies to test on latest version of go1.13 as it moves along
  - also making a note in the readme that we will not be supporting go 1.14
- second commit adds experimental testing for go1.15beta1 (skipping critest for now for go1.15beta1 will push a PR later to fix critest on 1.15)
