### PR TITLE
allow disabling hugepages

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -236,6 +236,10 @@ type PluginConfig struct {
 	// container requests with huge page limits if the cgroup controller for hugepages is not present.
 	// This helps with supporting Kubernetes <=1.18 out of the box. (default is `true`)
 	TolerateMissingHugetlbController bool `toml:"tolerate_missing_hugetlb_controller" json:"tolerateMissingHugetlbController"`
+	// DisableHugetlbController indicates to silently disable the hugetlb controller, even when it is
+	// present in /sys/fs/cgroup/cgroup.controllers.
+	// This helps with running rootless mode + cgroup v2 + systemd but without hugetlb delegation.
+	DisableHugetlbController bool `toml:"disable_hugetlb_controller" json:"disableHugetlbController"`
 	// IgnoreImageDefinedVolumes ignores volumes defined by the image. Useful for better resource
 	// isolation, security and early detection of issues in the mount configuration when using
 	// ReadOnlyRootFilesystem since containers won't silently mount a temporary volume.

--- a/pkg/config/config_unix.go
+++ b/pkg/config/config_unix.go
@@ -68,6 +68,7 @@ func DefaultConfig() PluginConfig {
 		MaxConcurrentDownloads:           3,
 		DisableProcMount:                 false,
 		TolerateMissingHugetlbController: true,
+		DisableHugetlbController:         true,
 		IgnoreImageDefinedVolumes:        false,
 	}
 }

--- a/pkg/server/container_create_unix.go
+++ b/pkg/server/container_create_unix.go
@@ -225,7 +225,7 @@ func (c *criService) containerSpec(id string, sandboxID string, sandboxPid uint3
 	if c.config.DisableCgroup {
 		specOpts = append(specOpts, customopts.WithDisabledCgroups)
 	} else {
-		specOpts = append(specOpts, customopts.WithResources(config.GetLinux().GetResources(), c.config.TolerateMissingHugetlbController))
+		specOpts = append(specOpts, customopts.WithResources(config.GetLinux().GetResources(), c.config.TolerateMissingHugetlbController, c.config.DisableHugetlbController))
 		if sandboxConfig.GetLinux().GetCgroupParent() != "" {
 			cgroupsPath := getCgroupsPath(sandboxConfig.GetLinux().GetCgroupParent(), id)
 			specOpts = append(specOpts, oci.WithCgroup(cgroupsPath))

--- a/pkg/server/container_update_resources_unix.go
+++ b/pkg/server/container_update_resources_unix.go
@@ -73,7 +73,7 @@ func (c *criService) updateContainerResources(ctx context.Context,
 		return errors.Wrap(err, "failed to get container spec")
 	}
 	newSpec, err := updateOCILinuxResource(ctx, oldSpec, resources,
-		c.config.TolerateMissingHugetlbController)
+		c.config.TolerateMissingHugetlbController, c.config.DisableHugetlbController)
 	if err != nil {
 		return errors.Wrap(err, "failed to update resource in spec")
 	}
@@ -134,7 +134,7 @@ func updateContainerSpec(ctx context.Context, cntr containerd.Container, spec *r
 
 // updateOCILinuxResource updates container resource limit.
 func updateOCILinuxResource(ctx context.Context, spec *runtimespec.Spec, new *runtime.LinuxContainerResources,
-	tolerateMissingHugetlbController bool) (*runtimespec.Spec, error) {
+	tolerateMissingHugetlbController, disableHugetlbController bool) (*runtimespec.Spec, error) {
 	// Copy to make sure old spec is not changed.
 	var cloned runtimespec.Spec
 	if err := util.DeepCopy(&cloned, spec); err != nil {
@@ -143,7 +143,7 @@ func updateOCILinuxResource(ctx context.Context, spec *runtimespec.Spec, new *ru
 	if cloned.Linux == nil {
 		cloned.Linux = &runtimespec.Linux{}
 	}
-	if err := opts.WithResources(new, tolerateMissingHugetlbController)(ctx, nil, nil, &cloned); err != nil {
+	if err := opts.WithResources(new, tolerateMissingHugetlbController, disableHugetlbController)(ctx, nil, nil, &cloned); err != nil {
 		return nil, errors.Wrap(err, "unable to set linux container resources")
 	}
 	return &cloned, nil

--- a/pkg/server/container_update_resources_unix_test.go
+++ b/pkg/server/container_update_resources_unix_test.go
@@ -153,7 +153,7 @@ func TestUpdateOCILinuxResource(t *testing.T) {
 		},
 	} {
 		t.Logf("TestCase %q", desc)
-		got, err := updateOCILinuxResource(context.Background(), test.spec, test.resources, false)
+		got, err := updateOCILinuxResource(context.Background(), test.spec, test.resources, false, false)
 		if test.expectErr {
 			assert.Error(t, err)
 		} else {


### PR DESCRIPTION
This helps with running rootless mode + cgroup v2 + systemd without hugetlb delegation.
Systemd does not (and will not, perhaps) support hugetlb delegation as of systemd v245. https://github.com/systemd/systemd/issues/14662

From https://github.com/rootless-containers/usernetes/blob/502bc5427e57236382db58a0af7996a145381803/src/patches/containerd/0001-DIRTY-VENDOR-cri-allow-disabling-hugepages.patch
