### PR TITLE
show runc options tag

### DIFF
--- a/pkg/config/config_unix.go
+++ b/pkg/config/config_unix.go
@@ -19,6 +19,7 @@
 package config
 
 import (
+	"github.com/BurntSushi/toml"
 	"github.com/containerd/containerd"
 	"github.com/containerd/cri/pkg/streaming"
 )
@@ -38,7 +39,8 @@ func DefaultConfig() PluginConfig {
 			NoPivot:            false,
 			Runtimes: map[string]Runtime{
 				"runc": {
-					Type: "io.containerd.runc.v2",
+					Type:    "io.containerd.runc.v2",
+					Options: new(toml.Primitive),
 				},
 			},
 		},


### PR DESCRIPTION
At least show users of / where runc.options should be added when they run containerd config default:

before
```
      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
          runtime_type = "io.containerd.runc.v2"
          runtime_engine = ""
          runtime_root = ""
          privileged_without_host_devices = false
          base_runtime_spec = ""
```
after
```
      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
          runtime_type = "io.containerd.runc.v2"
          runtime_engine = ""
          runtime_root = ""
          privileged_without_host_devices = false
          base_runtime_spec = ""
          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
```

Signed-off-by: Mike Brown <brownwm@us.ibm.com>