### PR TITLE
Update to latest Windows SandboxImage

### DIFF
--- a/pkg/config/config_windows.go
+++ b/pkg/config/config_windows.go
@@ -54,7 +54,7 @@ func DefaultConfig() PluginConfig {
 			TLSKeyFile:  "",
 			TLSCertFile: "",
 		},
-		SandboxImage:            "mcr.microsoft.com/k8s/core/pause:1.2.0",
+		SandboxImage:            "mcr.microsoft.com/oss/kubernetes/pause:1.4.0",
 		StatsCollectPeriod:      10,
 		MaxContainerLogLineSize: 16 * 1024,
 		Registry: Registry{


### PR DESCRIPTION
The windows pause image was moved from `mcr.microsoft.com/k8s/core/pause` to `mcr.microsoft.com/oss/kubernetes/pause`.  The latest version `mcr.microsoft.com/oss/kubernetes/pause:1.4.0` of the pause image includes:

-  Windows versions 1809 (2019LTS), 1903, 1909, 2004 
- signed binaries from Microsoft built from https://github.com/kubernetes-sigs/windows-testing/tree/master/images/pause

This update is required to support 2004 in kubernetes upstream which sig-windows is supporting for k8s 1.19: https://github.com/kubernetes/website/pull/21652/files

This will enable folks to use `containerd.exe config default` without having to modify the config.