### PR TITLE
Add support for registry configuration directory

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -144,18 +144,27 @@ type TLSConfig struct {
 
 // Registry is registry settings configured
 type Registry struct {
+	// ConfigPath is a path to the root directory containing registry-specific
+	// configurations
+	ConfigPath string `toml:"config_path" json:"config_path"`
+
+	// Headers adds additional HTTP headers that get sent to all registries
+	Headers map[string][]string `toml:"headers" json:"headers"`
+
 	// Mirrors are namespace to mirror mapping for all namespaces.
+	// This option will not be used when ConfigPath is provided.
+	// DEPRECATED: Use ConfigPath instead. Remove in containerd 1.6.
 	Mirrors map[string]Mirror `toml:"mirrors" json:"mirrors"`
+
 	// Configs are configs for each registry.
 	// The key is the domain name or IP of the registry.
+	// This option will be fully deprecated for ConfigPath in the future.
 	Configs map[string]RegistryConfig `toml:"configs" json:"configs"`
 
 	// Auths are registry endpoint to auth config mapping. The registry endpoint must
 	// be a valid url with host specified.
-	// DEPRECATED: Use Configs instead. Remove in containerd 1.4.
+	// DEPRECATED: Use ConfigPath instead. Remove in containerd 1.5.
 	Auths map[string]AuthConfig `toml:"auths" json:"auths"`
-	// Headers adds additional HTTP headers that get sent to all registries
-	Headers map[string][]string `toml:"headers" json:"headers"`
 }
 
 // RegistryConfig contains configuration used to communicate with the registry.
@@ -164,6 +173,8 @@ type RegistryConfig struct {
 	Auth *AuthConfig `toml:"auth" json:"auth"`
 	// TLS is a pair of CA/Cert/Key which then are used when creating the transport
 	// that communicates with the registry.
+	// This field will not be used when ConfigPath is provided.
+	// DEPRECATED: Use ConfigPath instead. Remove in containerd 1.6.
 	TLS *TLSConfig `toml:"tls" json:"tls"`
 }
 
@@ -346,6 +357,28 @@ func ValidatePluginConfig(ctx context.Context, c *PluginConfig) error {
 		}
 	}
 
+	useConfigPath := c.Registry.ConfigPath != ""
+	if len(c.Registry.Mirrors) > 0 {
+		if useConfigPath {
+			return errors.Errorf("`mirrors` cannot be set when `config_path` is provided")
+		}
+		log.G(ctx).Warning("`mirrors` is deprecated, please use `config_path` instead")
+	}
+
+	var hasDeprecatedTLS bool
+	for _, r := range c.Registry.Configs {
+		if r.TLS != nil {
+			hasDeprecatedTLS = true
+			break
+		}
+	}
+	if hasDeprecatedTLS {
+		if useConfigPath {
+			return errors.Errorf("`configs.tls` cannot be set when `config_path` is provided")
+		}
+		log.G(ctx).Warning("`configs.tls` is deprecated, please use `config_path` instead")
+	}
+
 	// Validation for deprecated auths options and mapping it to configs.
 	if len(c.Registry.Auths) != 0 {
 		if c.Registry.Configs == nil {
@@ -356,7 +389,7 @@ func ValidatePluginConfig(ctx context.Context, c *PluginConfig) error {
 			config.Auth = &auth
 			c.Registry.Configs[endpoint] = config
 		}
-		log.G(ctx).Warning("`auths` is deprecated, please use registry`configs` instead")
+		log.G(ctx).Warning("`auths` is deprecated, please use `configs` instead")
 	}
 
 	// Validation for stream_idle_timeout

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -320,6 +320,46 @@ func TestValidateConfig(t *testing.T) {
 			},
 			expectedErr: "invalid stream idle timeout",
 		},
+		"conflicting mirror registry config": {
+			config: &PluginConfig{
+				ContainerdConfig: ContainerdConfig{
+					DefaultRuntimeName: RuntimeDefault,
+					Runtimes: map[string]Runtime{
+						RuntimeDefault: {
+							Type: "default",
+						},
+					},
+				},
+				Registry: Registry{
+					ConfigPath: "/etc/containerd/conf.d",
+					Mirrors: map[string]Mirror{
+						"something.io": {},
+					},
+				},
+			},
+			expectedErr: "`mirrors` cannot be set when `config_path` is provided",
+		},
+		"conflicting tls registry config": {
+			config: &PluginConfig{
+				ContainerdConfig: ContainerdConfig{
+					DefaultRuntimeName: RuntimeDefault,
+					Runtimes: map[string]Runtime{
+						RuntimeDefault: {
+							Type: "default",
+						},
+					},
+				},
+				Registry: Registry{
+					ConfigPath: "/etc/containerd/conf.d",
+					Configs: map[string]RegistryConfig{
+						"something.io": {
+							TLS: &TLSConfig{},
+						},
+					},
+				},
+			},
+			expectedErr: "`configs.tls` cannot be set when `config_path` is provided",
+		},
 	} {
 		t.Run(desc, func(t *testing.T) {
 			err := ValidatePluginConfig(context.Background(), test.config)

--- a/pkg/server/image_pull.go
+++ b/pkg/server/image_pull.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -34,6 +35,7 @@ import (
 	"github.com/containerd/containerd/log"
 	distribution "github.com/containerd/containerd/reference/docker"
 	"github.com/containerd/containerd/remotes/docker"
+	"github.com/containerd/containerd/remotes/docker/config"
 	"github.com/containerd/imgcrypt"
 	"github.com/containerd/imgcrypt/images/encryption"
 	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -99,7 +101,7 @@ func (c *criService) PullImage(ctx context.Context, r *runtime.PullImageRequest)
 	var (
 		resolver = docker.NewResolver(docker.ResolverOptions{
 			Headers: c.config.Registry.Headers,
-			Hosts:   c.registryHosts(r.GetAuth()),
+			Hosts:   c.registryHosts(ctx, r.GetAuth()),
 		})
 		isSchema1    bool
 		imageHandler containerdimages.HandlerFunc = func(_ context.Context,
@@ -310,8 +312,41 @@ func (c *criService) getTLSConfig(registryTLSConfig criconfig.TLSConfig) (*tls.C
 	return tlsConfig, nil
 }
 
+func hostDirFromRoots(roots []string) func(string) (string, error) {
+	rootfn := make([]func(string) (string, error), len(roots))
+	for i := range roots {
+		rootfn[i] = config.HostDirFromRoot(roots[i])
+	}
+	return func(host string) (dir string, err error) {
+		for _, fn := range rootfn {
+			dir, err = fn(host)
+			if (err != nil && !errdefs.IsNotFound(err)) || (dir != "") {
+				break
+			}
+		}
+		return
+	}
+}
+
 // registryHosts is the registry hosts to be used by the resolver.
-func (c *criService) registryHosts(auth *runtime.AuthConfig) docker.RegistryHosts {
+func (c *criService) registryHosts(ctx context.Context, auth *runtime.AuthConfig) docker.RegistryHosts {
+	paths := filepath.SplitList(c.config.Registry.ConfigPath)
+	if len(paths) > 0 {
+		hostOptions := config.HostOptions{}
+		hostOptions.Credentials = func(host string) (string, string, error) {
+			hostauth := auth
+			if hostauth == nil {
+				config := c.config.Registry.Configs[host]
+				if config.Auth != nil {
+					hostauth = toRuntimeAuthConfig(*config.Auth)
+				}
+			}
+			return ParseAuth(hostauth, host)
+		}
+		hostOptions.HostDir = hostDirFromRoots(paths)
+
+		return config.ConfigureHosts(ctx, hostOptions)
+	}
 	return func(host string) ([]docker.RegistryHost, error) {
 		var registries []docker.RegistryHost
 

--- a/vendor/github.com/containerd/containerd/remotes/docker/config/config_unix.go
+++ b/vendor/github.com/containerd/containerd/remotes/docker/config/config_unix.go
@@ -1,0 +1,40 @@
+// +build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package config
+
+import (
+	"crypto/x509"
+	"path/filepath"
+)
+
+func hostPaths(root, host string) []string {
+	ch := hostDirectory(host)
+	if ch == host {
+		return []string{filepath.Join(root, host)}
+	}
+
+	return []string{
+		filepath.Join(root, ch),
+		filepath.Join(root, host),
+	}
+}
+
+func rootSystemPool() (*x509.CertPool, error) {
+	return x509.SystemCertPool()
+}

--- a/vendor/github.com/containerd/containerd/remotes/docker/config/config_windows.go
+++ b/vendor/github.com/containerd/containerd/remotes/docker/config/config_windows.go
@@ -1,0 +1,41 @@
+// +build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package config
+
+import (
+	"crypto/x509"
+	"path/filepath"
+	"strings"
+)
+
+func hostPaths(root, host string) []string {
+	ch := hostDirectory(host)
+	if ch == host {
+		return []string{filepath.Join(root, host)}
+	}
+
+	return []string{
+		filepath.Join(root, strings.Replace(ch, ":", "", -1)),
+		filepath.Join(root, strings.Replace(host, ":", "", -1)),
+	}
+}
+
+func rootSystemPool() (*x509.CertPool, error) {
+	return x509.NewCertPool(), nil
+}

--- a/vendor/github.com/containerd/containerd/remotes/docker/config/hosts.go
+++ b/vendor/github.com/containerd/containerd/remotes/docker/config/hosts.go
@@ -1,0 +1,514 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// config package containers utilities for helping configure the Docker resolver
+package config
+
+import (
+	"context"
+	"crypto/tls"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/BurntSushi/toml"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/remotes/docker"
+	"github.com/pkg/errors"
+)
+
+type hostConfig struct {
+	scheme string
+	host   string
+	path   string
+
+	capabilities docker.HostCapabilities
+
+	caCerts     []string
+	clientPairs [][2]string
+	skipVerify  *bool
+
+	header http.Header
+
+	// TODO: API ("docker" or "oci")
+	// TODO: API Version ("v1", "v2")
+	// TODO: Add credential configuration (domain alias, username)
+}
+
+// HostOptions is used to configure registry hosts
+type HostOptions struct {
+	HostDir       func(string) (string, error)
+	Credentials   func(host string) (string, string, error)
+	DefaultTLS    *tls.Config
+	DefaultScheme string
+}
+
+// ConfigureHosts creates a registry hosts function from the provided
+// host creation options. The host directory can read hosts.toml or
+// certificate files laid out in the Docker specific layout.
+// If a `HostDir` function is not required, defaults are used.
+func ConfigureHosts(ctx context.Context, options HostOptions) docker.RegistryHosts {
+	return func(host string) ([]docker.RegistryHost, error) {
+		var hosts []hostConfig
+		if options.HostDir != nil {
+			dir, err := options.HostDir(host)
+			if err != nil && !errdefs.IsNotFound(err) {
+				return nil, err
+			}
+			if dir != "" {
+				log.G(ctx).WithField("dir", dir).Debug("loading host directory")
+				hosts, err = loadHostDir(ctx, dir)
+				if err != nil {
+					return nil, err
+				}
+			}
+
+		}
+
+		// If hosts was not set, add a default host
+		// NOTE: Check nil here and not empty, the host may be
+		// intentionally configured to not have any endpoints
+		if hosts == nil {
+			hosts = make([]hostConfig, 1)
+		}
+		if len(hosts) > 0 && hosts[len(hosts)-1].host == "" {
+			if host == "docker.io" {
+				hosts[len(hosts)-1].scheme = "https"
+				hosts[len(hosts)-1].host = "registry-1.docker.io"
+			} else {
+				hosts[len(hosts)-1].host = host
+				if options.DefaultScheme != "" {
+					hosts[len(hosts)-1].scheme = options.DefaultScheme
+				} else {
+					hosts[len(hosts)-1].scheme = "https"
+				}
+			}
+			hosts[len(hosts)-1].path = "/v2"
+			hosts[len(hosts)-1].capabilities = docker.HostCapabilityPull | docker.HostCapabilityResolve | docker.HostCapabilityPush
+		}
+
+		var defaultTLSConfig *tls.Config
+		if options.DefaultTLS != nil {
+			defaultTLSConfig = options.DefaultTLS
+		} else {
+			defaultTLSConfig = &tls.Config{}
+		}
+
+		defaultTransport := &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:       30 * time.Second,
+				KeepAlive:     30 * time.Second,
+				FallbackDelay: 300 * time.Millisecond,
+			}).DialContext,
+			MaxIdleConns:          10,
+			IdleConnTimeout:       30 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			TLSClientConfig:       defaultTLSConfig,
+			ExpectContinueTimeout: 5 * time.Second,
+		}
+
+		client := &http.Client{
+			Transport: defaultTransport,
+		}
+
+		authOpts := []docker.AuthorizerOpt{docker.WithAuthClient(client)}
+		if options.Credentials != nil {
+			authOpts = append(authOpts, docker.WithAuthCreds(options.Credentials))
+		}
+		authorizer := docker.NewDockerAuthorizer(authOpts...)
+
+		rhosts := make([]docker.RegistryHost, len(hosts))
+		for i, host := range hosts {
+
+			rhosts[i].Scheme = host.scheme
+			rhosts[i].Host = host.host
+			rhosts[i].Path = host.path
+			rhosts[i].Capabilities = host.capabilities
+			rhosts[i].Header = host.header
+
+			if host.caCerts != nil || host.clientPairs != nil || host.skipVerify != nil {
+				tr := defaultTransport.Clone()
+				tlsConfig := tr.TLSClientConfig
+				if host.skipVerify != nil {
+					tlsConfig.InsecureSkipVerify = *host.skipVerify
+				}
+				if host.caCerts != nil {
+					if tlsConfig.RootCAs == nil {
+						rootPool, err := rootSystemPool()
+						if err != nil {
+							return nil, errors.Wrap(err, "unable to initialize cert pool")
+						}
+						tlsConfig.RootCAs = rootPool
+					}
+					for _, f := range host.caCerts {
+						data, err := ioutil.ReadFile(f)
+						if err != nil {
+							return nil, errors.Wrapf(err, "unable to read CA cert %q", f)
+						}
+						if !tlsConfig.RootCAs.AppendCertsFromPEM(data) {
+							return nil, errors.Errorf("unable to load CA cert %q", f)
+						}
+					}
+				}
+
+				if host.clientPairs != nil {
+					for _, pair := range host.clientPairs {
+						certPEMBlock, err := ioutil.ReadFile(pair[0])
+						if err != nil {
+							return nil, errors.Wrapf(err, "unable to read CERT file %q", pair[0])
+						}
+						var keyPEMBlock []byte
+						if pair[1] != "" {
+							keyPEMBlock, err = ioutil.ReadFile(pair[1])
+							if err != nil {
+								return nil, errors.Wrapf(err, "unable to read CERT file %q", pair[1])
+							}
+						} else {
+							// Load key block from same PEM file
+							keyPEMBlock = certPEMBlock
+						}
+						cert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
+						if err != nil {
+							return nil, errors.Wrap(err, "failed to load X509 key pair")
+						}
+
+						tlsConfig.Certificates = append(tlsConfig.Certificates, cert)
+					}
+				}
+
+				c := *client
+				c.Transport = tr
+
+				rhosts[i].Client = &c
+				rhosts[i].Authorizer = docker.NewDockerAuthorizer(append(authOpts, docker.WithAuthClient(&c))...)
+			} else {
+				rhosts[i].Client = client
+				rhosts[i].Authorizer = authorizer
+			}
+		}
+
+		return rhosts, nil
+	}
+
+}
+
+// HostDirFromRoot returns a function which finds a host directory
+// based at the given root.
+func HostDirFromRoot(root string) func(string) (string, error) {
+	return func(host string) (string, error) {
+		for _, p := range hostPaths(root, host) {
+			if _, err := os.Stat(p); err == nil {
+				return p, nil
+			} else if !os.IsNotExist(err) {
+				return "", err
+			}
+		}
+		return "", errdefs.ErrNotFound
+	}
+}
+
+// hostDirectory converts ":port" to "_port_" in directory names
+func hostDirectory(host string) string {
+	idx := strings.LastIndex(host, ":")
+	if idx > 0 {
+		return host[:idx] + "_" + host[idx+1:] + "_"
+	}
+	return host
+}
+
+func loadHostDir(ctx context.Context, hostsDir string) ([]hostConfig, error) {
+	b, err := ioutil.ReadFile(filepath.Join(hostsDir, "hosts.toml"))
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	if len(b) == 0 {
+		// If hosts.toml does not exist, fallback to checking for
+		// certificate files based on Docker's certificate file
+		// pattern (".crt", ".cert", ".key" files)
+		return loadCertFiles(ctx, hostsDir)
+	}
+
+	hosts, err := parseHostsFile(ctx, hostsDir, b)
+	if err != nil {
+		log.G(ctx).WithError(err).Error("failed to decode hosts.toml")
+		// Fallback to checking certificate files
+		return loadCertFiles(ctx, hostsDir)
+	}
+
+	return hosts, nil
+}
+
+type hostFileConfig struct {
+	// Capabilities determine what operations a host is
+	// capable of performing. Allowed values
+	//  - pull
+	//  - resolve
+	//  - push
+	Capabilities []string `toml:"capabilities"`
+
+	// CACert can be a string or an array of strings
+	CACert toml.Primitive `toml:"ca"`
+
+	// TODO: Make this an array (two key types, one for pairs (multiple files), one for single file?)
+	Client toml.Primitive `toml:"client"`
+
+	SkipVerify *bool `toml:"skip_verify"`
+
+	Header map[string]toml.Primitive `toml:"header"`
+
+	// API (default: "docker")
+	// API Version (default: "v2")
+	// Credentials: helper? name? username? alternate domain? token?
+}
+
+type configFile struct {
+	// hostConfig holds defaults for all hosts as well as
+	// for the default server
+	hostFileConfig
+
+	// Server specifies the default server. When `host` is
+	// also specified, those hosts are tried first.
+	Server string `toml:"server"`
+
+	// HostConfigs store the per-host configuration
+	HostConfigs map[string]hostFileConfig `toml:"host"`
+}
+
+func parseHostsFile(ctx context.Context, baseDir string, b []byte) ([]hostConfig, error) {
+	var c configFile
+	md, err := toml.Decode(string(b), &c)
+	if err != nil {
+		return nil, err
+	}
+
+	var orderedHosts []string
+	for _, key := range md.Keys() {
+		if len(key) >= 2 {
+			if key[0] == "host" && (len(orderedHosts) == 0 || orderedHosts[len(orderedHosts)-1] != key[1]) {
+				orderedHosts = append(orderedHosts, key[1])
+			}
+		}
+	}
+
+	if c.HostConfigs == nil {
+		c.HostConfigs = map[string]hostFileConfig{}
+	}
+	if c.Server != "" {
+		c.HostConfigs[c.Server] = c.hostFileConfig
+		orderedHosts = append(orderedHosts, c.Server)
+	} else if len(orderedHosts) == 0 {
+		c.HostConfigs[""] = c.hostFileConfig
+		orderedHosts = append(orderedHosts, "")
+	}
+	hosts := make([]hostConfig, len(orderedHosts))
+	for i, server := range orderedHosts {
+		hostConfig := c.HostConfigs[server]
+
+		if server != "" {
+			if !strings.HasPrefix(server, "http") {
+				server = "https://" + server
+			}
+			u, err := url.Parse(server)
+			if err != nil {
+				return nil, errors.Errorf("unable to parse server %v", server)
+			}
+			hosts[i].scheme = u.Scheme
+			hosts[i].host = u.Host
+
+			// TODO: Handle path based on registry protocol
+			// Define a registry protocol type
+			//   OCI v1    - Always use given path as is
+			//   Docker v2 - Always ensure ends with /v2/
+			if len(u.Path) > 0 {
+				u.Path = path.Clean(u.Path)
+				if !strings.HasSuffix(u.Path, "/v2") {
+					u.Path = u.Path + "/v2"
+				}
+			} else {
+				u.Path = "/v2"
+			}
+			hosts[i].path = u.Path
+		}
+		hosts[i].skipVerify = hostConfig.SkipVerify
+
+		if len(hostConfig.Capabilities) > 0 {
+			for _, c := range hostConfig.Capabilities {
+				switch strings.ToLower(c) {
+				case "pull":
+					hosts[i].capabilities |= docker.HostCapabilityPull
+				case "resolve":
+					hosts[i].capabilities |= docker.HostCapabilityResolve
+				case "push":
+					hosts[i].capabilities |= docker.HostCapabilityPush
+				default:
+					return nil, errors.Errorf("unknown capability %v", c)
+				}
+			}
+		} else {
+			hosts[i].capabilities = docker.HostCapabilityPull | docker.HostCapabilityResolve | docker.HostCapabilityPush
+		}
+
+		baseKey := []string{}
+		if server != "" && server != c.Server {
+			baseKey = append(baseKey, "host", server)
+		}
+		caKey := append(baseKey, "ca")
+		if md.IsDefined(caKey...) {
+			switch t := md.Type(caKey...); t {
+			case "String":
+				var caCert string
+				if err := md.PrimitiveDecode(hostConfig.CACert, &caCert); err != nil {
+					return nil, errors.Wrap(err, "failed to decode \"ca\"")
+				}
+				hosts[i].caCerts = []string{makeAbsPath(caCert, baseDir)}
+			case "Array":
+				var caCerts []string
+				if err := md.PrimitiveDecode(hostConfig.CACert, &caCerts); err != nil {
+					return nil, errors.Wrap(err, "failed to decode \"ca\"")
+				}
+				for i, p := range caCerts {
+					caCerts[i] = makeAbsPath(p, baseDir)
+				}
+
+				hosts[i].caCerts = caCerts
+			default:
+				return nil, errors.Errorf("invalid type %v for \"ca\"", t)
+			}
+		}
+
+		clientKey := append(baseKey, "client")
+		if md.IsDefined(clientKey...) {
+			switch t := md.Type(clientKey...); t {
+			case "String":
+				var clientCert string
+				if err := md.PrimitiveDecode(hostConfig.Client, &clientCert); err != nil {
+					return nil, errors.Wrap(err, "failed to decode \"ca\"")
+				}
+				hosts[i].clientPairs = [][2]string{{makeAbsPath(clientCert, baseDir), ""}}
+			case "Array":
+				var clientCerts []interface{}
+				if err := md.PrimitiveDecode(hostConfig.Client, &clientCerts); err != nil {
+					return nil, errors.Wrap(err, "failed to decode \"ca\"")
+				}
+				for _, pairs := range clientCerts {
+					switch p := pairs.(type) {
+					case string:
+						hosts[i].clientPairs = append(hosts[i].clientPairs, [2]string{makeAbsPath(p, baseDir), ""})
+					case []interface{}:
+						var pair [2]string
+						if len(p) > 2 {
+							return nil, errors.Errorf("invalid pair %v for \"client\"", p)
+						}
+						for pi, cp := range p {
+							s, ok := cp.(string)
+							if !ok {
+								return nil, errors.Errorf("invalid type %T for \"client\"", cp)
+							}
+							pair[pi] = makeAbsPath(s, baseDir)
+						}
+						hosts[i].clientPairs = append(hosts[i].clientPairs, pair)
+					default:
+						return nil, errors.Errorf("invalid type %T for \"client\"", p)
+					}
+				}
+			default:
+				return nil, errors.Errorf("invalid type %v for \"client\"", t)
+			}
+		}
+
+		headerKey := append(baseKey, "header")
+		if md.IsDefined(headerKey...) {
+			header := http.Header{}
+			for key, prim := range hostConfig.Header {
+				switch t := md.Type(append(headerKey, key)...); t {
+				case "String":
+					var value string
+					if err := md.PrimitiveDecode(prim, &value); err != nil {
+						return nil, errors.Wrapf(err, "failed to decode header %q", key)
+					}
+					header[key] = []string{value}
+				case "Array":
+					var value []string
+					if err := md.PrimitiveDecode(prim, &value); err != nil {
+						return nil, errors.Wrapf(err, "failed to decode header %q", key)
+					}
+
+					header[key] = value
+				default:
+					return nil, errors.Errorf("invalid type %v for header %q", t, key)
+				}
+			}
+			hosts[i].header = header
+		}
+	}
+
+	return hosts, nil
+}
+
+func makeAbsPath(p string, base string) string {
+	if filepath.IsAbs(p) {
+		return p
+	}
+	return filepath.Join(base, p)
+}
+
+// loadCertsDir loads certs from certsDir like "/etc/docker/certs.d" .
+// Compatible with Docker file layout
+// - files ending with ".crt" are treated as CA certificate files
+// - files ending with ".cert" are treated as client certificates, and
+//   files with the same name but ending with ".key" are treated as the
+//   corresponding private key.
+//   NOTE: If a ".key" file is missing, this function will just return
+//   the ".cert", which may contain the private key. If the ".cert" file
+//   does not contain the private key, the caller should detect and error.
+func loadCertFiles(ctx context.Context, certsDir string) ([]hostConfig, error) {
+	fs, err := ioutil.ReadDir(certsDir)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	hosts := make([]hostConfig, 1)
+	for _, f := range fs {
+		if !f.IsDir() {
+			continue
+		}
+		if strings.HasSuffix(f.Name(), ".crt") {
+			hosts[0].caCerts = append(hosts[0].caCerts, filepath.Join(certsDir, f.Name()))
+		}
+		if strings.HasSuffix(f.Name(), ".cert") {
+			var pair [2]string
+			certFile := f.Name()
+			pair[0] = filepath.Join(certsDir, certFile)
+			// Check if key also exists
+			keyFile := certFile[:len(certFile)-5] + ".key"
+			if _, err := os.Stat(keyFile); err == nil {
+				pair[1] = filepath.Join(certsDir, keyFile)
+			} else if !os.IsNotExist(err) {
+				return nil, err
+			}
+			hosts[0].clientPairs = append(hosts[0].clientPairs, pair)
+		}
+	}
+	return hosts, nil
+}


### PR DESCRIPTION
Add support for the registry configuration directory. This also adds compatibility for the Docker configuration directory at `/etc/docker/conf.d` through this option.

Please closely review the associated deprecations. It may be possible to avoid returning error when both provided by converting the existing TLS and mirrors configs, but I'm not convinced it is needed.

Marking as draft while finishing up the unit tests.