### PR TITLE
switching to windows-2016.. latest is breaking due to wsl conflict with bash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
 
   test-windows:
     name: Build and CRI Test (Windows amd64)
-    runs-on: windows-latest
+    runs-on: windows-2016
     steps:
       - name: Set up Go 1.13.12
         uses: actions/setup-go@v1


### PR DESCRIPTION
temporary workaround for issue #1538

Signed-off-by: Mike Brown <brownwm@us.ibm.com>