### PR TITLE
Bump Golang 1.13.14

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ environment:
   CGO_ENABLED: 1
   GO111MODULE: off
   matrix:
-    - GO_VERSION: 1.13.12
+    - GO_VERSION: 1.13.14
 
 install:
   # Install Mingw

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.12'
+          go-version: '1.13.14'
 
       - name: Set env
         shell: bash
@@ -82,7 +82,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.12'
+          go-version: '1.13.14'
 
       - name: Set env
         shell: bash
@@ -147,10 +147,10 @@ jobs:
     name: Build and CRI Test (Windows amd64)
     runs-on: windows-2016
     steps:
-      - name: Set up Go 1.13.12
+      - name: Set up Go 1.13.14
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13.12
+          go-version: 1.13.14
 
       - name: Checkout cri repo
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ specifications as appropriate.
 backport version of `libseccomp-dev` is required. See [travis.yml](.travis.yml) for an example on trusty.
 * **btrfs development library.** Required by containerd btrfs support. `btrfs-tools`(Ubuntu, Debian) / `btrfs-progs-devel`(Fedora, CentOS, RHEL)
 2. Install **`pkg-config`** (required for linking with `libseccomp`).
-3. Install and setup a Go 1.13.12 development environment.
+3. Install and setup a Go 1.13.14 development environment.
 4. Make a local clone of this repository.
 5. Install binary dependencies by running the following command from your cloned `cri/` project directory:
 ```bash


### PR DESCRIPTION
full diff: https://github.com/golang/go/compare/go1.13.12...go1.13.14

- go1.13.14 (released 2020/07/16) includes fixes to the compiler, vet, and the
  database/sql, net/http, and reflect packages. See the Go 1.13.14 milestone on
  the issue tracker for details:
  https://github.com/golang/go/issues?q=milestone%3AGo1.13.14+label%3ACherryPickApproved
- go1.13.13 (released 2020/07/14) includes security fixes to the crypto/x509 and
  net/http packages. See the Go 1.13.13 milestone on our issue tracker for details:
  https://github.com/golang/go/issues?q=milestone%3AGo1.13.13+label%3ACherryPickApproved
