### PR TITLE
Handle KVM based runtimes with selinux

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -161,6 +161,12 @@ func (c *criService) CreateContainer(ctx context.Context, r *runtime.CreateConta
 	}
 
 	meta.ProcessLabel = spec.Process.SelinuxLabel
+
+	// handle any KVM based runtime
+	if err := modifyProcessLabel(ociRuntime.Type, spec); err != nil {
+		return nil, err
+	}
+
 	if config.GetLinux().GetSecurityContext().GetPrivileged() {
 		// If privileged don't set the SELinux label but still record it on the container so
 		// the unused MCS label can be release later

--- a/pkg/server/helpers_windows.go
+++ b/pkg/server/helpers_windows.go
@@ -24,6 +24,8 @@ import (
 	"path/filepath"
 	"syscall"
 	"time"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // openLogFile opens/creates a container log file.
@@ -216,4 +218,8 @@ func ensureRemoveAll(_ context.Context, dir string) error {
 		exitOnErr[pe.Path]++
 		time.Sleep(100 * time.Millisecond)
 	}
+}
+
+func modifyProcessLabel(runtimeType string, spec *specs.Spec) error {
+	return nil
 }

--- a/pkg/server/sandbox_run.go
+++ b/pkg/server/sandbox_run.go
@@ -167,6 +167,11 @@ func (c *criService) RunPodSandbox(ctx context.Context, r *runtime.RunPodSandbox
 		}
 	}()
 
+	// handle any KVM based runtime
+	if err := modifyProcessLabel(ociRuntime.Type, spec); err != nil {
+		return nil, err
+	}
+
 	if config.GetLinux().GetSecurityContext().GetPrivileged() {
 		// If privileged don't set selinux label, but we still record the MCS label so that
 		// the unused label can be freed later.

--- a/pkg/seutil/seutil.go
+++ b/pkg/seutil/seutil.go
@@ -1,0 +1,71 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package seutil
+
+import (
+	"bufio"
+	"os"
+
+	"github.com/opencontainers/selinux/go-selinux"
+)
+
+var seTypes map[string]struct{}
+
+const typePath = "/etc/selinux/targeted/contexts/customizable_types"
+
+func init() {
+	seTypes = make(map[string]struct{})
+	if !selinux.GetEnabled() {
+		return
+	}
+	f, err := os.Open(typePath)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		seTypes[s.Text()] = struct{}{}
+	}
+}
+
+// HasType returns true if the underlying system has the
+// provided selinux type enabled.
+func HasType(name string) bool {
+	_, ok := seTypes[name]
+	return ok
+}
+
+// ChangeToKVM process label
+func ChangeToKVM(l string) (string, error) {
+	if l == "" || !selinux.GetEnabled() {
+		return "", nil
+	}
+	proc, _ := selinux.KVMContainerLabels()
+	selinux.ReleaseLabel(proc)
+
+	current, err := selinux.NewContext(l)
+	if err != nil {
+		return "", err
+	}
+	next, err := selinux.NewContext(proc)
+	if err != nil {
+		return "", err
+	}
+	current["type"] = next["type"]
+	return current.Get(), nil
+}


### PR DESCRIPTION
This handles kvm based runtimes for new and old versions of the selinux packages.  If the `container_kvm_t` label exists, then we use them, if not, we clear the process label. 

Signed-off-by: Michael Crosby <michael@thepasture.io>