### PR TITLE
add oci.WithAllDevicesAllowed regardless of ociRuntime.PrivilegedWithoutHostDevices

### DIFF
--- a/pkg/server/container_create_unix.go
+++ b/pkg/server/container_create_unix.go
@@ -193,9 +193,9 @@ func (c *criService) containerSpec(id string, sandboxID string, sandboxPid uint3
 		if !sandboxConfig.GetLinux().GetSecurityContext().GetPrivileged() {
 			return nil, errors.New("no privileged container allowed in sandbox")
 		}
-		specOpts = append(specOpts, oci.WithPrivileged)
+		specOpts = append(specOpts, oci.WithPrivileged, oci.WithAllDevicesAllowed)
 		if !ociRuntime.PrivilegedWithoutHostDevices {
-			specOpts = append(specOpts, oci.WithHostDevices, oci.WithAllDevicesAllowed)
+			specOpts = append(specOpts, oci.WithHostDevices)
 		} else {
 			// add requested devices by the config as host devices are not automatically added
 			specOpts = append(specOpts, customopts.WithDevices(c.os, config), customopts.WithCapabilities(securityContext))

--- a/pkg/server/container_create_unix_test.go
+++ b/pkg/server/container_create_unix_test.go
@@ -1161,26 +1161,31 @@ func TestPrivilegedDevices(t *testing.T) {
 		privileged                   bool
 		privilegedWithoutHostDevices bool
 		expectHostDevices            bool
+		expectAllDevicesAllowed      bool
 	}{
 		"expect no host devices when privileged is false": {
 			privileged:                   false,
 			privilegedWithoutHostDevices: false,
 			expectHostDevices:            false,
+			expectAllDevicesAllowed:      false,
 		},
 		"expect no host devices when privileged is false and privilegedWithoutHostDevices is true": {
 			privileged:                   false,
 			privilegedWithoutHostDevices: true,
 			expectHostDevices:            false,
+			expectAllDevicesAllowed:      false,
 		},
 		"expect host devices when privileged is true": {
 			privileged:                   true,
 			privilegedWithoutHostDevices: false,
 			expectHostDevices:            true,
+			expectAllDevicesAllowed:      true,
 		},
 		"expect no host devices when privileged is true and privilegedWithoutHostDevices is true": {
 			privileged:                   true,
 			privilegedWithoutHostDevices: true,
 			expectHostDevices:            false,
+			expectAllDevicesAllowed:      true,
 		},
 	} {
 		t.Logf("TestCase %q", desc)
@@ -1209,6 +1214,10 @@ func TestPrivilegedDevices(t *testing.T) {
 		} else {
 			assert.Empty(t, spec.Linux.Devices)
 		}
+
+		assert.Len(t, spec.Linux.Resources.Devices, 1)
+		assert.Equal(t, spec.Linux.Resources.Devices[0].Allow, test.expectAllDevicesAllowed)
+		assert.Equal(t, spec.Linux.Resources.Devices[0].Access, "rwm")
 	}
 }
 


### PR DESCRIPTION
fixes containerd/containerd#6643

Signed-off-by: Alex Price <aprice@atlassian.com>