### PR TITLE
vendor: github.com/willf/bitset v1.1.11

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -2,7 +2,7 @@
 github.com/docker/docker                            4634ce647cf2ce2c6031129ccd109e557244986f
 github.com/opencontainers/selinux                   v1.6.0
 github.com/tchap/go-patricia                        v2.2.6
-github.com/willf/bitset                             d5bec3311243426a3c6d1b7a795f24b17c686dbb # 1.1.10+ used by selinux pkg
+github.com/willf/bitset                             v1.1.11
 
 # containerd dependencies
 github.com/beorn7/perks                             v1.0.1

--- a/vendor/github.com/willf/bitset/README.md
+++ b/vendor/github.com/willf/bitset/README.md
@@ -2,10 +2,10 @@
 
 *Go language library to map between non-negative integers and boolean values*
 
-[![Master Build Status](https://secure.travis-ci.org/willf/bitset.png?branch=master)](https://travis-ci.org/willf/bitset?branch=master)
+[![Test](https://github.com/willf/bitset/workflows/Test/badge.svg)](https://github.com/willf/bitset/actions?query=workflow%3ATest)
 [![Master Coverage Status](https://coveralls.io/repos/willf/bitset/badge.svg?branch=master&service=github)](https://coveralls.io/github/willf/bitset?branch=master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/willf/bitset)](https://goreportcard.com/report/github.com/willf/bitset)
-[![GoDoc](https://godoc.org/github.com/willf/bitset?status.svg)](http://godoc.org/github.com/willf/bitset)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/willf/bitset?tab=doc)](https://pkg.go.dev/github.com/willf/bitset?tab=doc)
 
 
 ## Description
@@ -63,8 +63,11 @@ func main() {
 
 As an alternative to BitSets, one should check out the 'big' package, which provides a (less set-theoretical) view of bitsets.
 
-Godoc documentation is at: https://godoc.org/github.com/willf/bitset
+Package documentation is at: https://pkg.go.dev/github.com/willf/bitset?tab=doc
 
+## Memory Usage
+
+The memory usage of a bitset using N bits is at least N/8 bytes. The number of bits in a bitset is at least as large as one plus the greatest bit index you have accessed. Thus it is possible to run out of memory while using a bitset. If you have lots of bits, you might prefer compressed bitsets, like the [Roaring bitmaps](http://roaringbitmap.org) and its [Go implementation](https://github.com/RoaringBitmap/roaring).
 
 ## Implementation Note
 
@@ -82,15 +85,10 @@ go get github.com/willf/bitset
 
 If you wish to contribute to this project, please branch and issue a pull request against master ("[GitHub Flow](https://guides.github.com/introduction/flow/)")
 
-This project include a Makefile that allows you to test and build the project with simple commands.
-To see all available options:
-```bash
-make help
-```
-
 ## Running all tests
 
-Before committing the code, please check if it passes all tests using (note: this will install some dependencies):
+Before committing the code, please check if it passes tests, has adequate coverage, etc.
 ```bash
-make qa
+go test
+go test -cover
 ```

--- a/vendor/github.com/willf/bitset/go.mod
+++ b/vendor/github.com/willf/bitset/go.mod
@@ -1,0 +1,3 @@
+module github.com/willf/bitset
+
+go 1.14


### PR DESCRIPTION
The changes needed by opencontainers/selinux are now in a tagged
release. This will make our dependency slightly ahead of what's
used by opencontainers/selinux until a v1.6.1 is tagged.

full diff: https://github.com/willf/bitset/compare/d5bec3311243...v1.1.11
