### PR TITLE
[release/1.4 backport] Make script work for both python2.7 and 3.6

### DIFF
--- a/cluster/gce/configure.sh
+++ b/cluster/gce/configure.sh
@@ -19,6 +19,22 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if [[ "$(python -V 2>&1)" =~ "Python 2" ]]; then
+  # found python2, just use that
+  PYTHON="python"
+elif [[ -f "/usr/bin/python2.7" ]]; then
+  # System python not defaulted to python 2 but using 2.7 during migration
+  PYTHON="/usr/bin/python2.7"
+else
+  # No python2 either by default, let's see if we can find python3
+  PYTHON="python3"
+  if ! command -v ${PYTHON} >/dev/null 2>&1; then
+    echo "ERROR Python not found. Aborting."
+    exit 2
+  fi
+fi
+echo "Version : " $(${PYTHON} -V 2>&1)
+
 # CONTAINERD_HOME is the directory for containerd.
 CONTAINERD_HOME="/home/containerd"
 cd "${CONTAINERD_HOME}"
@@ -53,9 +69,13 @@ fetch_env() {
     fi
     echo "${tmp_env_content}" > "${tmp_env_file}"
     # Convert the yaml format file into a shell-style file.
-    eval $(python -c '''
+    eval $(${PYTHON} -c '''
 import pipes,sys,yaml
-for k,v in yaml.load(sys.stdin).iteritems():
+if sys.version_info[0] < 3:
+    items = yaml.load(sys.stdin).iteritems()
+else:
+    items = yaml.load(sys.stdin, Loader=yaml.BaseLoader).items()
+for k,v in items:
   print("readonly {var}={value}".format(var = k, value = pipes.quote(str(v))))
 ''' < "${tmp_env_file}" > "${CONTAINERD_HOME}/${env_file_name}")
     rm -f "${tmp_env_file}"
@@ -163,10 +183,8 @@ version = 2
 required_plugins = ["io.containerd.grpc.v1.cri"]
 # Kubernetes doesn't use containerd restart manager.
 disabled_plugins = ["io.containerd.internal.v1.restart"]
-
 [debug]
   level = "${log_level}"
-
 [plugins."io.containerd.grpc.v1.cri"]
   stream_server_address = "127.0.0.1"
   stream_server_port = "0"
@@ -192,7 +210,6 @@ if [[ -n "${containerd_extra_runtime_handler}" ]]; then
   cat >> ${config_path} <<EOF
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.${containerd_extra_runtime_handler}]
   runtime_type = "${CONTAINERD_EXTRA_RUNTIME_TYPE:-io.containerd.runc.v1}"
-
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.${containerd_extra_runtime_handler}.options]
 ${CONTAINERD_EXTRA_RUNTIME_OPTIONS:-}
 EOF


### PR DESCRIPTION
backport of https://github.com/containerd/cri/pull/1577

I wasn't 100% if this was needed, but noticed https://github.com/containerd/cri/pull/1577#issuecomment-692494275

> The change is used to fix Kubernetes upstream containerd test.
>
> The script change is GCE only and has been tested. I think it looks good to me.

@Random-Liu @vteratipally @mikebrow PTAL