### PR TITLE
fix no-pivot not working in io.containerd.runtime.v1.linux

### DIFF
--- a/pkg/server/sandbox_run_linux.go
+++ b/pkg/server/sandbox_run_linux.go
@@ -301,8 +301,14 @@ func (c *criService) cleanupSandboxFiles(id string, config *runtime.PodSandboxCo
 func (c *criService) taskOpts(runtimeType string) []containerd.NewTaskOpts {
 	// TODO(random-liu): Remove this after shim v1 is deprecated.
 	var taskOpts []containerd.NewTaskOpts
-	if c.config.NoPivot && (runtimeType == plugin.RuntimeRuncV1 || runtimeType == plugin.RuntimeRuncV2) {
+
+	// c.config.NoPivot is only supported for RuntimeLinuxV1 = "io.containerd.runtime.v1.linux" legacy linux runtime
+	// and is not supported for RuntimeRuncV1 = "io.containerd.runc.v1" or  RuntimeRuncV2 = "io.containerd.runc.v2"
+	// for RuncV1/2 no pivot is set under the containerd.runtimes.runc.options config see
+	// https://github.com/containerd/containerd/blob/v1.3.2/runtime/v2/runc/options/oci.pb.go#L26
+	if c.config.NoPivot && runtimeType == plugin.RuntimeLinuxV1 {
 		taskOpts = append(taskOpts, containerd.WithNoPivotRoot)
 	}
+
 	return taskOpts
 }


### PR DESCRIPTION
no_pivot not working in io.containerd.runtime.v1.linux

relates to [1220](https://github.com/containerd/cri/pull/1220)

Signed-off-by: zhangjianming <zhang.jianming7@zte.com.cn>