### PR TITLE
Add image digest annotation for snapshotters

### DIFF
--- a/pkg/server/image_pull.go
+++ b/pkg/server/image_pull.go
@@ -456,9 +456,12 @@ const (
 	// targetRefLabel is a label which contains image reference and will be passed
 	// to snapshotters.
 	targetRefLabel = "containerd.io/snapshot/cri.image-ref"
-	// targetDigestLabel is a label which contains layer digest and will be passed
+	// targetImageDigestLabel is a label which contains image digest and will be passed
 	// to snapshotters.
-	targetDigestLabel = "containerd.io/snapshot/cri.layer-digest"
+	targetImageDigestLabel = "containerd.io/snapshot/cri.image-digest"
+	// targetLayerDigestLabel is a label which contains layer digest and will be passed
+	// to snapshotters.
+	targetLayerDigestLabel = "containerd.io/snapshot/cri.layer-digest"
 	// targetImageLayersLabel is a label which contains layer digests contained in
 	// the target image and will be passed to snapshotters for preparing layers in
 	// parallel. Skipping some layers is allowed and only affects performance.
@@ -466,8 +469,8 @@ const (
 )
 
 // appendInfoHandlerWrapper makes a handler which appends some basic information
-// of images to each layer descriptor as annotations during unpack. These
-// annotations will be passed to snapshotters as labels. These labels will be
+// of images like digests for manifest and their child layers as annotations during unpack.
+// These annotations will be passed to snapshotters as labels. These labels will be
 // used mainly by stargz-based snapshotters for querying image contents from the
 // registry.
 func appendInfoHandlerWrapper(ref string) func(f containerdimages.Handler) containerdimages.Handler {
@@ -486,8 +489,9 @@ func appendInfoHandlerWrapper(ref string) func(f containerdimages.Handler) conta
 							c.Annotations = make(map[string]string)
 						}
 						c.Annotations[targetRefLabel] = ref
-						c.Annotations[targetDigestLabel] = c.Digest.String()
+						c.Annotations[targetLayerDigestLabel] = c.Digest.String()
 						c.Annotations[targetImageLayersLabel] = getLayers(ctx, targetImageLayersLabel, children[i:], labels.Validate)
+						c.Annotations[targetImageDigestLabel] = desc.Digest.String()
 					}
 				}
 			}


### PR DESCRIPTION
Adds image digest to the label for Snapshotters to consume when it Prepares filesystem.