### PR TITLE
[release/1.4 backport] Set masked and readonly paths based on default Unix spec

### DIFF
--- a/pkg/server/container_create_unix.go
+++ b/pkg/server/container_create_unix.go
@@ -182,11 +182,15 @@ func (c *criService) containerSpec(id string, sandboxID string, sandboxPid uint3
 	if !c.config.DisableProcMount {
 		// Apply masked paths if specified.
 		// If the container is privileged, this will be cleared later on.
-		specOpts = append(specOpts, oci.WithMaskedPaths(securityContext.GetMaskedPaths()))
+		if maskedPaths := securityContext.GetMaskedPaths(); maskedPaths != nil {
+			specOpts = append(specOpts, oci.WithMaskedPaths(maskedPaths))
+		}
 
 		// Apply readonly paths if specified.
 		// If the container is privileged, this will be cleared later on.
-		specOpts = append(specOpts, oci.WithReadonlyPaths(securityContext.GetReadonlyPaths()))
+		if readonlyPaths := securityContext.GetReadonlyPaths(); readonlyPaths != nil {
+			specOpts = append(specOpts, oci.WithReadonlyPaths(readonlyPaths))
+		}
 	}
 
 	if securityContext.GetPrivileged() {

--- a/pkg/server/container_create_unix_test.go
+++ b/pkg/server/container_create_unix_test.go
@@ -959,12 +959,12 @@ func TestMaskedAndReadonlyPaths(t *testing.T) {
 			expectedReadonly: defaultSpec.Linux.ReadonlyPaths,
 			privileged:       false,
 		},
-		"should always apply CRI specified paths when disable_proc_mount = false": {
+		"should apply default if not specified when disable_proc_mount = false": {
 			disableProcMount: false,
 			masked:           nil,
 			readonly:         nil,
-			expectedMasked:   nil,
-			expectedReadonly: nil,
+			expectedMasked:   defaultSpec.Linux.MaskedPaths,
+			expectedReadonly: defaultSpec.Linux.ReadonlyPaths,
 			privileged:       false,
 		},
 		"should be able to specify empty paths": {


### PR DESCRIPTION
backport of https://github.com/containerd/cri/pull/1570

The default values of masked and readonly paths are defined
in populateDefaultUnixSpec, and are used when a sandbox is
created.  It is not, however, used for new containers.  If
a container definition does not contain a security context
specifying masked/readonly paths, a container created from
it does not have masked and readonly paths.

This patch applies the default values to masked and
readonly paths of a new container, when any specific values
are not specified.

Fixes #1569

Signed-off-by: Yohei Ueda <yohei@jp.ibm.com>
(cherry picked from commit b582da44384edbf6b8c3fbf635979ec554f5bd6b)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>