### PR TITLE
Add missing sandbox labels when invoking nri

### DIFF
--- a/pkg/server/container_start.go
+++ b/pkg/server/container_start.go
@@ -126,7 +126,8 @@ func (c *criService) StartContainer(ctx context.Context, r *runtime.StartContain
 	}
 	if nric != nil {
 		nriSB := &nri.Sandbox{
-			ID: sandboxID,
+			ID:     sandboxID,
+			Labels: sandbox.Config.Labels,
 		}
 		if _, err := nric.InvokeWithSandbox(ctx, task, v1.Create, nriSB); err != nil {
 			return nil, errors.Wrap(err, "nri invoke")


### PR DESCRIPTION
The sandbox labels are missing when the create event is invoked, as far as i can tell this is a bug.
This is a important thing to have in order to be able to differenciate the containers using their pod name, namespace or uid. 

When creating the pod `sandbox` the labels are passed correctly:
https://github.com/containerd/cri/blob/d620c30d7ecbc756f8d818237f9bccbbb7353e9e/pkg/server/sandbox_run.go#L291-L300 