### PR TITLE
Fix unix lint

### DIFF
--- a/cmd/containerd/builtins_linux.go
+++ b/cmd/containerd/builtins_linux.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 /*
    Copyright The containerd Authors.
 
@@ -16,16 +14,10 @@
    limitations under the License.
 */
 
-package os
+package main
 
 import (
-	"github.com/containerd/containerd/mount"
+	_ "github.com/containerd/containerd/metrics/cgroups"
+	_ "github.com/containerd/containerd/runtime/v1/linux"
+	_ "github.com/containerd/containerd/snapshots/overlay"
 )
-
-// UNIX collects unix system level operations that need to be
-// mocked out during tests.
-type UNIX interface {
-	Mount(source string, target string, fstype string, flags uintptr, data string) error
-	Unmount(target string) error
-	LookupMount(path string) (mount.Info, error)
-}

--- a/integration/addition_gids_test.go
+++ b/integration/addition_gids_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/integration/container_log_test.go
+++ b/integration/container_log_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/integration/container_restart_test.go
+++ b/integration/container_restart_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/integration/container_stats_test.go
+++ b/integration/container_stats_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/integration/container_stop_test.go
+++ b/integration/container_stop_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/integration/container_update_resources_test.go
+++ b/integration/container_update_resources_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/integration/container_without_image_ref_test.go
+++ b/integration/container_without_image_ref_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/integration/containerd_image_test.go
+++ b/integration/containerd_image_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/integration/duplicate_name_test.go
+++ b/integration/duplicate_name_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/integration/image_load_test.go
+++ b/integration/image_load_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/integration/imagefs_info_test.go
+++ b/integration/imagefs_info_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/integration/no_metadata_test.go
+++ b/integration/no_metadata_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/integration/pod_dualstack_test.go
+++ b/integration/pod_dualstack_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/integration/pod_hostname_test.go
+++ b/integration/pod_hostname_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/integration/restart_test.go
+++ b/integration/restart_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/integration/runtime_handler_test.go
+++ b/integration/runtime_handler_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/integration/sandbox_clean_remove_test.go
+++ b/integration/sandbox_clean_remove_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/integration/truncindex_test.go
+++ b/integration/truncindex_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/integration/volume_copy_up_test.go
+++ b/integration/volume_copy_up_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build linux
 
 /*
    Copyright The containerd Authors.

--- a/pkg/containerd/opts/spec_linux.go
+++ b/pkg/containerd/opts/spec_linux.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/containerd/opts/spec_linux_test.go
+++ b/pkg/containerd/opts/spec_linux_test.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/netns/netns_linux.go
+++ b/pkg/netns/netns_linux.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 /*
    Copyright The containerd Authors.
 
@@ -25,6 +23,7 @@
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
+
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
@@ -40,12 +39,11 @@ import (
 	"runtime"
 	"sync"
 
+	"github.com/containerd/containerd/mount"
 	cnins "github.com/containernetworking/plugins/pkg/ns"
 	"github.com/docker/docker/pkg/symlink"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
-
-	osinterface "github.com/containerd/cri/pkg/os"
 )
 
 const nsRunDir = "/var/run/netns"
@@ -141,7 +139,7 @@ func unmountNS(path string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to follow symlink")
 	}
-	if err := osinterface.Unmount(path); err != nil && !os.IsNotExist(err) {
+	if err := mount.Unmount(path, unix.MNT_DETACH); err != nil && !os.IsNotExist(err) {
 		return errors.Wrap(err, "failed to umount netns")
 	}
 	if err := os.RemoveAll(path); err != nil {

--- a/pkg/netns/netns_other.go
+++ b/pkg/netns/netns_other.go
@@ -1,0 +1,58 @@
+// +build !windows,!linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package netns
+
+import (
+	"github.com/pkg/errors"
+)
+
+var errNotImplementedOnUnix = errors.New("not implemented on unix")
+
+// NetNS holds network namespace.
+type NetNS struct {
+	path string
+}
+
+// NewNetNS creates a network namespace.
+func NewNetNS() (*NetNS, error) {
+	return nil, errNotImplementedOnUnix
+}
+
+// LoadNetNS loads existing network namespace.
+func LoadNetNS(path string) *NetNS {
+	return &NetNS{path: path}
+}
+
+// Remove removes network namepace. Remove is idempotent, meaning it might
+// be invoked multiple times and provides consistent result.
+func (n *NetNS) Remove() error {
+	return errNotImplementedOnUnix
+}
+
+// Closed checks whether the network namespace has been closed.
+func (n *NetNS) Closed() (bool, error) {
+	return false, errNotImplementedOnUnix
+}
+
+// GetPath returns network namespace path for sandbox container
+func (n *NetNS) GetPath() string {
+	return n.path
+}
+
+// NOTE: Do function is not supported.

--- a/pkg/os/mount_linux.go
+++ b/pkg/os/mount_linux.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 /*
    Copyright The containerd Authors.
 
@@ -16,10 +14,24 @@
    limitations under the License.
 */
 
-package main
+package os
 
 import (
-	_ "github.com/containerd/containerd/metrics/cgroups"
-	_ "github.com/containerd/containerd/runtime/v1/linux"
-	_ "github.com/containerd/containerd/snapshots/overlay"
+	"github.com/containerd/containerd/mount"
+	"golang.org/x/sys/unix"
 )
+
+// Mount will call unix.Mount to mount the file.
+func (RealOS) Mount(source string, target string, fstype string, flags uintptr, data string) error {
+	return unix.Mount(source, target, fstype, flags, data)
+}
+
+// Unmount will call Unmount to unmount the file.
+func (RealOS) Unmount(target string) error {
+	return mount.Unmount(target, unix.MNT_DETACH)
+}
+
+// LookupMount gets mount info of a given path.
+func (RealOS) LookupMount(path string) (mount.Info, error) {
+	return mount.Lookup(path)
+}

--- a/pkg/os/mount_other.go
+++ b/pkg/os/mount_other.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,!linux
 
 /*
    Copyright The containerd Authors.
@@ -18,14 +18,9 @@
 
 package os
 
-import (
-	"github.com/containerd/containerd/mount"
-)
+import "github.com/containerd/containerd/mount"
 
-// UNIX collects unix system level operations that need to be
-// mocked out during tests.
-type UNIX interface {
-	Mount(source string, target string, fstype string, flags uintptr, data string) error
-	Unmount(target string) error
-	LookupMount(path string) (mount.Info, error)
+// LookupMount gets mount info of a given path.
+func (RealOS) LookupMount(path string) (mount.Info, error) {
+	return mount.Lookup(path)
 }

--- a/pkg/os/mount_unix.go
+++ b/pkg/os/mount_unix.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,!linux
 
 /*
    Copyright The containerd Authors.
@@ -22,10 +22,12 @@ import (
 	"github.com/containerd/containerd/mount"
 )
 
-// UNIX collects unix system level operations that need to be
-// mocked out during tests.
-type UNIX interface {
-	Mount(source string, target string, fstype string, flags uintptr, data string) error
-	Unmount(target string) error
-	LookupMount(path string) (mount.Info, error)
+// Mount will call unix.Mount to mount the file.
+func (RealOS) Mount(source string, target string, fstype string, flags uintptr, data string) error {
+	return mount.ErrNotImplementOnUnix
+}
+
+// Unmount will call Unmount to unmount the file.
+func (RealOS) Unmount(target string) error {
+	return mount.Unmount(target, 0)
 }

--- a/pkg/server/container_create_linux.go
+++ b/pkg/server/container_create_linux.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/server/container_create_linux_test.go
+++ b/pkg/server/container_create_linux_test.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/server/container_create_other.go
+++ b/pkg/server/container_create_other.go
@@ -1,0 +1,44 @@
+// +build !windows,!linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"github.com/containerd/containerd/oci"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
+	"github.com/containerd/cri/pkg/config"
+)
+
+// containerMounts sets up necessary container system file mounts
+// including /dev/shm, /etc/hosts and /etc/resolv.conf.
+func (c *criService) containerMounts(sandboxID string, config *runtime.ContainerConfig) []*runtime.Mount {
+	return []*runtime.Mount{}
+}
+
+func (c *criService) containerSpec(id string, sandboxID string, sandboxPid uint32, netNSPath string, containerName string,
+	config *runtime.ContainerConfig, sandboxConfig *runtime.PodSandboxConfig, imageConfig *imagespec.ImageConfig,
+	extraMounts []*runtime.Mount, ociRuntime config.Runtime) (_ *runtimespec.Spec, retErr error) {
+	return c.runtimeSpec(id, ociRuntime.BaseRuntimeSpec)
+}
+
+func (c *criService) containerSpecOpts(config *runtime.ContainerConfig, imageConfig *imagespec.ImageConfig) ([]oci.SpecOpts, error) {
+	return []oci.SpecOpts{}, nil
+}

--- a/pkg/server/container_create_other_test.go
+++ b/pkg/server/container_create_other_test.go
@@ -1,0 +1,40 @@
+// +build !windows,!linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"testing"
+
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+// checkMount is defined by all tests but not used here
+var _ = checkMount
+
+func getCreateContainerTestData() (*runtime.ContainerConfig, *runtime.PodSandboxConfig,
+	*imagespec.ImageConfig, func(*testing.T, string, string, uint32, *runtimespec.Spec)) {
+	config := &runtime.ContainerConfig{}
+	sandboxConfig := &runtime.PodSandboxConfig{}
+	imageConfig := &imagespec.ImageConfig{}
+	specCheck := func(t *testing.T, id string, sandboxID string, sandboxPid uint32, spec *runtimespec.Spec) {
+	}
+	return config, sandboxConfig, imageConfig, specCheck
+}

--- a/pkg/server/container_stats_list_linux.go
+++ b/pkg/server/container_stats_list_linux.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/server/container_stats_list_linux_test.go
+++ b/pkg/server/container_stats_list_linux_test.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/server/container_stats_list_other.go
+++ b/pkg/server/container_stats_list_other.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,!linux
 
 /*
    Copyright The containerd Authors.
@@ -16,16 +16,21 @@
    limitations under the License.
 */
 
-package os
+package server
 
 import (
-	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/pkg/errors"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
+	containerstore "github.com/containerd/cri/pkg/store/container"
 )
 
-// UNIX collects unix system level operations that need to be
-// mocked out during tests.
-type UNIX interface {
-	Mount(source string, target string, fstype string, flags uintptr, data string) error
-	Unmount(target string) error
-	LookupMount(path string) (mount.Info, error)
+func (c *criService) containerMetrics(
+	meta containerstore.Metadata,
+	stats *types.Metric,
+) (*runtime.ContainerStats, error) {
+	var cs runtime.ContainerStats
+	return &cs, errors.Wrap(errdefs.ErrNotImplemented, "container metrics")
 }

--- a/pkg/server/container_update_resources_linux.go
+++ b/pkg/server/container_update_resources_linux.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/server/container_update_resources_linux_test.go
+++ b/pkg/server/container_update_resources_linux_test.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/server/container_update_resources_other.go
+++ b/pkg/server/container_update_resources_other.go
@@ -1,0 +1,44 @@
+// +build !windows,!linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
+	containerstore "github.com/containerd/cri/pkg/store/container"
+)
+
+// UpdateContainerResources updates ContainerConfig of the container.
+func (c *criService) UpdateContainerResources(ctx context.Context, r *runtime.UpdateContainerResourcesRequest) (retRes *runtime.UpdateContainerResourcesResponse, retErr error) {
+	container, err := c.containerStore.Get(r.GetContainerId())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to find container")
+	}
+	// Update resources in status update transaction, so that:
+	// 1) There won't be race condition with container start.
+	// 2) There won't be concurrent resource update to the same container.
+	if err := container.Status.Update(func(status containerstore.Status) (containerstore.Status, error) {
+		return status, nil
+	}); err != nil {
+		return nil, errors.Wrap(err, "failed to update resources")
+	}
+	return &runtime.UpdateContainerResourcesResponse{}, nil
+}

--- a/pkg/server/helpers_linux.go
+++ b/pkg/server/helpers_linux.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/server/helpers_linux_test.go
+++ b/pkg/server/helpers_linux_test.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/server/helpers_other.go
+++ b/pkg/server/helpers_other.go
@@ -1,0 +1,43 @@
+// +build !windows,!linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"os"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// openLogFile opens/creates a container log file.
+func openLogFile(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0640)
+}
+
+// ensureRemoveAll wraps `os.RemoveAll` to check for specific errors that can
+// often be remedied.
+// Only use `ensureRemoveAll` if you really want to make every effort to remove
+// a directory.
+func ensureRemoveAll(ctx context.Context, dir string) error {
+	return os.RemoveAll(dir)
+}
+
+func modifyProcessLabel(runtimeType string, spec *specs.Spec) error {
+	return nil
+}

--- a/pkg/server/sandbox_portforward_linux.go
+++ b/pkg/server/sandbox_portforward_linux.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/server/sandbox_portforward_other.go
+++ b/pkg/server/sandbox_portforward_other.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,!linux
 
 /*
    Copyright The containerd Authors.
@@ -16,16 +16,18 @@
    limitations under the License.
 */
 
-package os
+package server
 
 import (
-	"github.com/containerd/containerd/mount"
+	"io"
+
+	"github.com/containerd/containerd/errdefs"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 )
 
-// UNIX collects unix system level operations that need to be
-// mocked out during tests.
-type UNIX interface {
-	Mount(source string, target string, fstype string, flags uintptr, data string) error
-	Unmount(target string) error
-	LookupMount(path string) (mount.Info, error)
+// portForward uses netns to enter the sandbox namespace, and forwards a stream inside the
+// the namespace to a specific port. It keeps forwarding until it exits or client disconnect.
+func (c *criService) portForward(ctx context.Context, id string, port int32, stream io.ReadWriteCloser) error {
+	return errors.Wrap(errdefs.ErrNotImplemented, "port forward")
 }

--- a/pkg/server/sandbox_run_linux.go
+++ b/pkg/server/sandbox_run_linux.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/server/sandbox_run_linux_test.go
+++ b/pkg/server/sandbox_run_linux_test.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/server/sandbox_run_other.go
+++ b/pkg/server/sandbox_run_other.go
@@ -1,0 +1,55 @@
+// +build !windows,!linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package server
+
+import (
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/oci"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+)
+
+func (c *criService) sandboxContainerSpec(id string, config *runtime.PodSandboxConfig,
+	imageConfig *imagespec.ImageConfig, nsPath string, runtimePodAnnotations []string) (_ *runtimespec.Spec, retErr error) {
+	return c.runtimeSpec(id, "")
+}
+
+// sandboxContainerSpecOpts generates OCI spec options for
+// the sandbox container.
+func (c *criService) sandboxContainerSpecOpts(config *runtime.PodSandboxConfig, imageConfig *imagespec.ImageConfig) ([]oci.SpecOpts, error) {
+	return []oci.SpecOpts{}, nil
+}
+
+// setupSandboxFiles sets up necessary sandbox files including /dev/shm, /etc/hosts,
+// /etc/resolv.conf and /etc/hostname.
+func (c *criService) setupSandboxFiles(id string, config *runtime.PodSandboxConfig) error {
+	return nil
+}
+
+// cleanupSandboxFiles unmount some sandbox files, we rely on the removal of sandbox root directory to
+// remove these files. Unmount should *NOT* return error if the mount point is already unmounted.
+func (c *criService) cleanupSandboxFiles(id string, config *runtime.PodSandboxConfig) error {
+	return nil
+}
+
+// taskOpts generates task options for a (sandbox) container.
+func (c *criService) taskOpts(runtimeType string) []containerd.NewTaskOpts {
+	return []containerd.NewTaskOpts{}
+}

--- a/pkg/server/sandbox_run_other_test.go
+++ b/pkg/server/sandbox_run_other_test.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,!linux
 
 /*
    Copyright The containerd Authors.
@@ -16,16 +16,20 @@
    limitations under the License.
 */
 
-package os
+package server
 
 import (
-	"github.com/containerd/containerd/mount"
+	"testing"
+
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
+	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
+	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
-// UNIX collects unix system level operations that need to be
-// mocked out during tests.
-type UNIX interface {
-	Mount(source string, target string, fstype string, flags uintptr, data string) error
-	Unmount(target string) error
-	LookupMount(path string) (mount.Info, error)
+func getRunPodSandboxTestData() (*runtime.PodSandboxConfig, *imagespec.ImageConfig, func(*testing.T, string, *runtimespec.Spec)) {
+	config := &runtime.PodSandboxConfig{}
+	imageConfig := &imagespec.ImageConfig{}
+	specCheck := func(t *testing.T, id string, spec *runtimespec.Spec) {
+	}
+	return config, imageConfig, specCheck
 }

--- a/pkg/server/service_linux.go
+++ b/pkg/server/service_linux.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 /*
    Copyright The containerd Authors.
 

--- a/pkg/server/service_other.go
+++ b/pkg/server/service_other.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,!linux
 
 /*
    Copyright The containerd Authors.
@@ -16,16 +16,18 @@
    limitations under the License.
 */
 
-package os
+package server
 
 import (
-	"github.com/containerd/containerd/mount"
+	cni "github.com/containerd/go-cni"
 )
 
-// UNIX collects unix system level operations that need to be
-// mocked out during tests.
-type UNIX interface {
-	Mount(source string, target string, fstype string, flags uintptr, data string) error
-	Unmount(target string) error
-	LookupMount(path string) (mount.Info, error)
+// initPlatform handles linux specific initialization for the CRI service.
+func (c *criService) initPlatform() error {
+	return nil
+}
+
+// cniLoadOptions returns cni load options for the linux.
+func (c *criService) cniLoadOptions() []cni.CNIOpt {
+	return []cni.CNIOpt{}
 }

--- a/test/verify.sh
+++ b/test/verify.sh
@@ -26,4 +26,5 @@ cd "${ROOT}"
 
 make install.tools
 make verify
+GOOS=macos make verify
 GOOS=windows make verify


### PR DESCRIPTION
Aligns linting targets with containerd

Note: there were many files marked as `_unix.go` which were actually targeting Linux only and not compilable on Linux due to Linux-only dependencies or use of Linux specific syscalls. 