### PR TITLE
Disable experimental feature in default config

### DIFF
--- a/pkg/config/config_unix.go
+++ b/pkg/config/config_unix.go
@@ -43,6 +43,7 @@ func DefaultConfig() PluginConfig {
 					Options: new(toml.Primitive),
 				},
 			},
+			DisableSnapshotAnnotations: true,
 		},
 		DisableTCPService:    true,
 		StreamServerAddress:  "127.0.0.1",


### PR DESCRIPTION
This is a cross-project "cherry-pick" since it sits between containerd future/1.5 (where CRI is already merged in) and containerd `release/1.4` where CRI is still vendored from this project.

"Upstream" change: containerd/containerd#4665

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>