### PR TITLE
[release/1.3] enable test-integration target to specify runtime

### DIFF
--- a/hack/test-utils.sh
+++ b/hack/test-utils.sh
@@ -23,6 +23,19 @@ CONTAINERD_FLAGS="--log-level=debug "
 
 # Use a configuration file for containerd.
 CONTAINERD_CONFIG_FILE=${CONTAINERD_CONFIG_FILE:-""}
+# The runtime to use (ignored when CONTAINERD_CONFIG_FILE is set)
+CONTAINERD_RUNTIME=${CONTAINERD_RUNTIME:-""}
+if [ -z "${CONTAINERD_CONFIG_FILE}" ]; then
+  config_file="/tmp/containerd-config-cri.toml"
+  if [ -n "${CONTAINERD_RUNTIME}" ]; then
+    cat >${config_file} <<EOF
+[plugins.cri.containerd.default_runtime]
+  runtime_type="${CONTAINERD_RUNTIME}"
+EOF
+  fi
+  CONTAINERD_CONFIG_FILE="${config_file}"
+fi
+
 # CONTAINERD_TEST_SUFFIX is the suffix appended to the root/state directory used
 # by test containerd.
 CONTAINERD_TEST_SUFFIX=${CONTAINERD_TEST_SUFFIX:-"-test"}


### PR DESCRIPTION
Partial backport of https://github.com/containerd/cri/pull/1603, omitting the GitHub Actions changes, since Actions isn't set up for this branch.

/cc @mikebrow 