### PR TITLE
[release/1.4] gha: replace uses of deprecated "set-env", "add-path"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Set env
         shell: bash
         run: |
-          echo "::set-env name=GOPATH::${{ github.workspace }}"
-          echo "::add-path::${{ github.workspace }}/bin"
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
       - name: Checkout cri repo
         uses: actions/checkout@v2
@@ -87,8 +87,8 @@ jobs:
       - name: Set env
         shell: bash
         run: |
-          echo "::set-env name=GOPATH::${{ github.workspace }}"
-          echo "::add-path::${{ github.workspace }}/bin"
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
       - name: Checkout cri repo
         uses: actions/checkout@v2
@@ -158,16 +158,20 @@ jobs:
           path: ${{github.workspace}}\\src\\github.com\\containerd\\cri
 
       - name: Clone containerd repo
+        shell: bash
         run: |
-          bash.exe -c "GO111MODULE=off go get github.com/containerd/containerd"
+          GO111MODULE=off go get github.com/containerd/containerd
 
       - name: Configure Windows environment variables
+        shell: bash
         run: |
-          echo "::set-env name=GOPATH::$env:GITHUB_WORKSPACE"
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
       - name: Build
+        shell: bash
         run: |
-          bash.exe -c "pwd && ./test/windows/test.sh"
+          pwd && ./test/windows/test.sh
         working-directory: ${{github.workspace}}\\src\\github.com\\containerd\\cri
 
       - name: Upload containerd log file


### PR DESCRIPTION
These have been deprecated (related to CVE-2020-15228):
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

This fixes CI failing;

    Error: Unable to process command '::set-env name=GOPATH::/home/runner/work/cri/cri' successfully.
    Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into
    unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable
    to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
