### PR TITLE
[release/1.4] update Go 1.15.5 (to match containerd)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ environment:
   CGO_ENABLED: 1
   GO111MODULE: off
   matrix:
-    - GO_VERSION: 1.13.15
+    - GO_VERSION: 1.15.5
 
 install:
   # Install Mingw

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.15'
+          go-version: '1.15.5'
 
       - name: Set env
         shell: bash
@@ -82,7 +82,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.13.15'
+          go-version: '1.15.5'
 
       - name: Set env
         shell: bash
@@ -147,10 +147,10 @@ jobs:
     name: Build and CRI Test (Windows amd64)
     runs-on: windows-2016
     steps:
-      - name: Set up Go 1.13.15
+      - name: Set up Go 1.15.5
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13.15
+          go-version: 1.15.5
 
       - name: Checkout cri repo
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ specifications as appropriate.
 backport version of `libseccomp-dev` is required. See [travis.yml](.travis.yml) for an example on trusty.
 * **btrfs development library.** Required by containerd btrfs support. `btrfs-tools`(Ubuntu, Debian) / `btrfs-progs-devel`(Fedora, CentOS, RHEL)
 2. Install **`pkg-config`** (required for linking with `libseccomp`).
-3. Install and setup a Go 1.13.15 development environment.
+3. Install and setup a Go 1.15.5 development environment.
 4. Make a local clone of this repository.
 5. Install binary dependencies by running the following command from your cloned `cri/` project directory:
 ```bash

--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -18,7 +18,7 @@ ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
 
 # Not from vendor.conf.
 KUBERNETES_VERSION="v1.19.0-beta.2"
-CRITOOL_VERSION=${CRITOOL_VERSION:-baca4a152dfe671fc17911a7af74bcb61680ee39}
+CRITOOL_VERSION=${CRITOOL_VERSION:-0f5f734a7e1da0979915c6e7d5b6641bd9dc2627}
 CRITOOL_PKG=github.com/kubernetes-sigs/cri-tools
 CRITOOL_REPO=github.com/kubernetes-sigs/cri-tools
 


### PR DESCRIPTION
Follow-up to https://github.com/containerd/cri/pull/1607

Changes: https://golang.org/doc/devel/release.html#go1.15