### PR TITLE
[release/1.4] Add manifest digest annotation for snapshotters

### DIFF
--- a/pkg/server/image_pull.go
+++ b/pkg/server/image_pull.go
@@ -456,9 +456,12 @@ const (
 	// targetRefLabel is a label which contains image reference and will be passed
 	// to snapshotters.
 	targetRefLabel = "containerd.io/snapshot/cri.image-ref"
-	// targetDigestLabel is a label which contains layer digest and will be passed
+	// targetManifestDigestLabel is a label which contains manifest digest and will be passed
 	// to snapshotters.
-	targetDigestLabel = "containerd.io/snapshot/cri.layer-digest"
+	targetManifestDigestLabel = "containerd.io/snapshot/cri.manifest-digest"
+	// targetLayerDigestLabel is a label which contains layer digest and will be passed
+	// to snapshotters.
+	targetLayerDigestLabel = "containerd.io/snapshot/cri.layer-digest"
 	// targetImageLayersLabel is a label which contains layer digests contained in
 	// the target image and will be passed to snapshotters for preparing layers in
 	// parallel. Skipping some layers is allowed and only affects performance.
@@ -466,8 +469,8 @@ const (
 )
 
 // appendInfoHandlerWrapper makes a handler which appends some basic information
-// of images to each layer descriptor as annotations during unpack. These
-// annotations will be passed to snapshotters as labels. These labels will be
+// of images like digests for manifest and their child layers as annotations during unpack.
+// These annotations will be passed to snapshotters as labels. These labels will be
 // used mainly by stargz-based snapshotters for querying image contents from the
 // registry.
 func appendInfoHandlerWrapper(ref string) func(f containerdimages.Handler) containerdimages.Handler {
@@ -486,8 +489,9 @@ func appendInfoHandlerWrapper(ref string) func(f containerdimages.Handler) conta
 							c.Annotations = make(map[string]string)
 						}
 						c.Annotations[targetRefLabel] = ref
-						c.Annotations[targetDigestLabel] = c.Digest.String()
+						c.Annotations[targetLayerDigestLabel] = c.Digest.String()
 						c.Annotations[targetImageLayersLabel] = getLayers(ctx, targetImageLayersLabel, children[i:], labels.Validate)
+						c.Annotations[targetManifestDigestLabel] = desc.Digest.String()
 					}
 				}
 			}

--- a/pkg/server/image_pull_test.go
+++ b/pkg/server/image_pull_test.go
@@ -17,9 +17,14 @@
 package server
 
 import (
+	"context"
 	"encoding/base64"
+	"fmt"
+	"strings"
 	"testing"
 
+	digest "github.com/opencontainers/go-digest"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	runtime "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 
@@ -325,5 +330,50 @@ func TestEncryptedImagePullOpts(t *testing.T) {
 		c.config.ImageDecryption.KeyModel = test.keyModel
 		got := len(c.encryptedImagesPullOpts())
 		assert.Equal(t, test.expectedOpts, got)
+	}
+}
+
+func TestImageLayersLabel(t *testing.T) {
+	sampleKey := "sampleKey"
+	sampleDigest, err := digest.Parse("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	assert.NoError(t, err)
+	sampleMaxSize := 300
+	sampleValidate := func(k, v string) error {
+		if (len(k) + len(v)) > sampleMaxSize {
+			return fmt.Errorf("invalid: %q: %q", k, v)
+		}
+		return nil
+	}
+
+	tests := []struct {
+		name      string
+		layersNum int
+		wantNum   int
+	}{
+		{
+			name:      "valid number of layers",
+			layersNum: 2,
+			wantNum:   2,
+		},
+		{
+			name:      "many layers",
+			layersNum: 5, // hits sampleMaxSize (300 chars).
+			wantNum:   4, // layers should be ommitted for avoiding invalid label.
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sampleLayers []imagespec.Descriptor
+			for i := 0; i < tt.layersNum; i++ {
+				sampleLayers = append(sampleLayers, imagespec.Descriptor{
+					MediaType: imagespec.MediaTypeImageLayerGzip,
+					Digest:    sampleDigest,
+				})
+			}
+			gotS := getLayers(context.Background(), sampleKey, sampleLayers, sampleValidate)
+			got := len(strings.Split(gotS, ","))
+			assert.Equal(t, tt.wantNum, got)
+		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: Samarth Shah <samarthmshah@gmail.com>

We leverage stargz-based snapshotter and have implemented our own Filesystem interface. We need the image digest to get some metadata for the image itself.

