### PR TITLE
[release/1.3] Fix golangci-lint installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,10 +170,10 @@ install.tools: .install.gitvalidation .install.golangci-lint .install.vndr ## in
 
 .install.golangci-lint:
 	@echo "$(WHALE) $@"
-	$(GO) get -d github.com/golangci/golangci-lint/cmd/golangci-lint
+	git clone https://github.com/golangci/golangci-lint.git $(GOPATH)/src/github.com/golangci/golangci-lint
 	@cd $(GOPATH)/src/github.com/golangci/golangci-lint/cmd/golangci-lint; \
 		git checkout v1.18.0; \
-		go install
+		GO111MODULE=off go install
 
 .install.vndr:
 	@echo "$(WHALE) $@"


### PR DESCRIPTION
relates to https://github.com/containerd/cri/compare/release/1.4...thaJeztah:1.3_fix_golangci_install?expand=1

The makefile was using "go get" as a replacement for "git clone", whith
would try to fetch some dependencies that are not in the version we're
installing,

    go get -d github.com/golangci/golangci-lint/cmd/golangci-lint

Causing the build to fail;

    package 4d63.com/gochecknoglobals/checknoglobals: unrecognized import path "4d63.com/gochecknoglobals/checknoglobals": reading https://4d63.com/gochecknoglobals/checknoglobals?go-get=1: 404 Not Found

Switching to use git clone to prevent golang attempting to download
dependencies, as the version we're currently installing uses vendoring, and
disabling go modules when building (otherwise go 1.13 would still fetch go modules)

This could be changed to using go modules, and use `go get golangci-lint@VERSION`,
but this needs to be done in a directory outside of GOPATH, so keeping that
for a follow-up.
