### PR TITLE
[release/1.3] cri: append envs from image config to empty slice to avoid env lost

### DIFF
--- a/pkg/server/container_create.go
+++ b/pkg/server/container_create.go
@@ -359,7 +359,7 @@ func (c *criService) generateContainerSpec(id string, sandboxID string, sandboxP
 
 	// Apply envs from image config first, so that envs from container config
 	// can override them.
-	env := imageConfig.Env
+	env := append([]string{}, imageConfig.Env...)
 	for _, e := range config.GetEnvs() {
 		env = append(env, e.GetKey()+"="+e.GetValue())
 	}


### PR DESCRIPTION
(cherry picked from commit containerd/containerd@08318b1)

Signed-off-by: Yadong Zhang <yadzhang@gmail.com>
Signed-off-by: Wei Fu <fuweid89@gmail.com>