### PR TITLE
Add reference to daemon-reload before starting containerd service

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -87,6 +87,7 @@ curl https://storage.googleapis.com/cri-containerd-release/cri-containerd-${VERS
 If you are using systemd, just simply unpack the tarball to the root directory:
 ```bash
 sudo tar --no-overwrite-dir -C / -xzf cri-containerd-${VERSION}.linux-amd64.tar.gz
+sudo systemctl daemon-reload
 sudo systemctl start containerd
 ```
 If you are not using systemd, please unpack all binaries into a directory in your `PATH`, and start `containerd` as monitored long running services with the service manager you are using e.g. `supervisord`, `upstart` etc.


### PR DESCRIPTION
I was running through these docs today on an unbuntu 20.04 system and I noticed that, in step 2, it was necessary to do a `daemon-reload` to get systemd to pick up the existence of the new containerd service.

Modification adds that line to the docs before starting the containerd service.