### PR TITLE
client: add synchronize between userCloseFunc and rpc call

### DIFF
--- a/vendor/github.com/containerd/ttrpc/client.go
+++ b/vendor/github.com/containerd/ttrpc/client.go
@@ -170,6 +170,7 @@ func (c *Client) dispatch(ctx context.Context, req *Request, resp *Response) err
 
 func (c *Client) Close() error {
 	c.closeOnce.Do(func() {
+		c.userCloseFunc()
 		c.closed()
 	})
 	return nil
@@ -250,7 +251,6 @@ func (c *Client) run() {
 
 	defer func() {
 		c.conn.Close()
-		c.userCloseFunc()
 	}()
 
 	for {


### PR DESCRIPTION
when containerd runtime plugin exites abnormally, ttrpc connection will closed
and userCloseFunc will be called to handle cleanup the resources created by
containerd shim. current rpc call will also return err. But these two step are
asynchronous.

after rpc call return err, upper application such as k8s may restart container.
but start may fail due to cleanup not finish, some resources not be released.
and this leaked resources leads to failed inplace-update the pod again.

Signed-off-by: Qingyuan Hou <qingyuan.hou@linux.alibaba.com>